### PR TITLE
feat: Implement dp-crypto crate with ECIES decryption and SHA-256 com…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,6 @@ serde_repr = "0.1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 parking_lot = "0.12"
+sha2 = "0.10"
+hex = "0.4"
+ecies = { version = "0.2", default-features = false, features = ["pure"] }

--- a/crates/dp-crypto/Cargo.toml
+++ b/crates/dp-crypto/Cargo.toml
@@ -2,3 +2,20 @@
 name = "dp-crypto"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+dp-types     = { path = "../dp-types" }
+rust_decimal = { workspace = true }
+serde        = { workspace = true }
+serde_json   = { workspace = true }
+thiserror    = { workspace = true }
+sha2         = { workspace = true }
+hex          = { workspace = true }
+ecies        = { workspace = true }
+zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
+
+[dev-dependencies]
+tokio    = { workspace = true }
+k256     = "0.13"
+rand     = "0.8"
+tempfile = "3"

--- a/crates/dp-crypto/src/decrypted_order.rs
+++ b/crates/dp-crypto/src/decrypted_order.rs
@@ -1,0 +1,85 @@
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use dp_types::Side;
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DecryptedOrder {
+    pub pair: String,
+    pub side: Side,
+    pub price: Decimal,
+    pub size: Decimal,
+    pub commitment_key: String,
+    pub ttl: i64,
+}
+
+pub fn canonical_bytes(o: &DecryptedOrder) -> Vec<u8> {
+    format!(
+        "pair={}|side={}|price={}|size={}|key={}|ttl={}",
+        o.pair, o.side, o.price, o.size, o.commitment_key, o.ttl,
+    )
+    .into_bytes()
+}
+
+pub fn compute_commitment(o: &DecryptedOrder) -> Vec<u8> {
+    let mut hasher = Sha256::new();
+    hasher.update(canonical_bytes(o));
+    hasher.finalize().to_vec()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_order() -> DecryptedOrder {
+        DecryptedOrder {
+            pair: "ETH-USD".into(),
+            side: Side::Buy,
+            price: Decimal::new(250000, 2),
+            size: Decimal::new(10, 1),
+            commitment_key: "abc123".into(),
+            ttl: 5_000_000_000,
+        }
+    }
+
+    #[test]
+    fn canonical_bytes_format() {
+        let o = sample_order();
+        let s = String::from_utf8(canonical_bytes(&o)).unwrap();
+        assert_eq!(s, "pair=ETH-USD|side=BUY|price=2500.00|size=1.0|key=abc123|ttl=5000000000");
+    }
+
+    #[test]
+    fn canonical_bytes_sell_side() {
+        let mut o = sample_order();
+        o.side = Side::Sell;
+        let s = String::from_utf8(canonical_bytes(&o)).unwrap();
+        assert!(s.contains("side=SELL"));
+    }
+
+    #[test]
+    fn commitment_determinism() {
+        let o = sample_order();
+        let c1 = compute_commitment(&o);
+        let c2 = compute_commitment(&o);
+        assert_eq!(c1.len(), 32);
+        assert_eq!(c1, c2);
+    }
+
+    #[test]
+    fn commitment_changes_with_input() {
+        let o1 = sample_order();
+        let mut o2 = sample_order();
+        o2.price = Decimal::new(300000, 2);
+        assert_ne!(compute_commitment(&o1), compute_commitment(&o2));
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let o = sample_order();
+        let json = serde_json::to_string(&o).unwrap();
+        let back: DecryptedOrder = serde_json::from_str(&json).unwrap();
+        assert_eq!(o, back);
+    }
+}

--- a/crates/dp-crypto/src/decrypter.rs
+++ b/crates/dp-crypto/src/decrypter.rs
@@ -1,0 +1,55 @@
+use std::future::Future;
+use std::pin::Pin;
+
+use crate::decrypted_order::DecryptedOrder;
+use crate::CryptoError;
+
+pub trait Decrypter: Send + Sync {
+    fn decrypt<'a>(
+        &'a self,
+        ciphertext: &'a [u8],
+    ) -> Pin<Box<dyn Future<Output = Result<DecryptedOrder, CryptoError>> + Send + 'a>>;
+}
+
+pub struct NoopDecrypter;
+
+impl Decrypter for NoopDecrypter {
+    fn decrypt<'a>(
+        &'a self,
+        ciphertext: &'a [u8],
+    ) -> Pin<Box<dyn Future<Output = Result<DecryptedOrder, CryptoError>> + Send + 'a>> {
+        Box::pin(async move {
+            let order: DecryptedOrder = serde_json::from_slice(ciphertext)?;
+            Ok(order)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rust_decimal::Decimal;
+
+    #[tokio::test]
+    async fn noop_json_roundtrip() {
+        let order = DecryptedOrder {
+            pair: "BTC-USD".into(),
+            side: dp_types::Side::Buy,
+            price: Decimal::new(5000000, 2),
+            size: Decimal::new(1, 0),
+            commitment_key: "key1".into(),
+            ttl: 10_000_000_000,
+        };
+        let json = serde_json::to_vec(&order).unwrap();
+        let dec = NoopDecrypter;
+        let result = dec.decrypt(&json).await.unwrap();
+        assert_eq!(result, order);
+    }
+
+    #[tokio::test]
+    async fn noop_invalid_json() {
+        let dec = NoopDecrypter;
+        let result = dec.decrypt(b"not json").await;
+        assert!(result.is_err());
+    }
+}

--- a/crates/dp-crypto/src/ecies_decrypter.rs
+++ b/crates/dp-crypto/src/ecies_decrypter.rs
@@ -1,0 +1,154 @@
+use std::future::Future;
+use std::path::Path;
+use std::pin::Pin;
+
+use zeroize::Zeroize;
+
+use crate::decrypted_order::DecryptedOrder;
+use crate::{CryptoError, Decrypter};
+
+pub struct EciesDecrypter {
+    secret_key: Vec<u8>,
+}
+
+impl Drop for EciesDecrypter {
+    fn drop(&mut self) {
+        self.secret_key.zeroize();
+    }
+}
+
+impl EciesDecrypter {
+    pub fn from_file(path: impl AsRef<Path>) -> Result<Self, CryptoError> {
+        let sk = load_operator_key_file(path)?;
+        Ok(Self { secret_key: sk })
+    }
+}
+
+impl Decrypter for EciesDecrypter {
+    fn decrypt<'a>(
+        &'a self,
+        ciphertext: &'a [u8],
+    ) -> Pin<Box<dyn Future<Output = Result<DecryptedOrder, CryptoError>> + Send + 'a>> {
+        Box::pin(async move {
+            let plaintext = ecies::decrypt(&self.secret_key, ciphertext)
+                .map_err(|e| CryptoError::DecryptionFailed(e.to_string()))?;
+            let order: DecryptedOrder = serde_json::from_slice(&plaintext)?;
+            Ok(order)
+        })
+    }
+}
+
+pub fn load_operator_key_file(path: impl AsRef<Path>) -> Result<Vec<u8>, CryptoError> {
+    let raw = std::fs::read_to_string(path)?;
+    let trimmed = raw.trim().trim_start_matches("0x");
+    let key_bytes = hex::decode(trimmed)?;
+    if key_bytes.len() != 32 {
+        return Err(CryptoError::InvalidKeyFile(format!(
+            "expected 32 bytes, got {}",
+            key_bytes.len()
+        )));
+    }
+    Ok(key_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k256::ecdsa::SigningKey;
+    use rust_decimal::Decimal;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn test_order() -> DecryptedOrder {
+        DecryptedOrder {
+            pair: "ETH-USD".into(),
+            side: dp_types::Side::Sell,
+            price: Decimal::new(180000, 2),
+            size: Decimal::new(5, 0),
+            commitment_key: "testkey".into(),
+            ttl: 3_000_000_000,
+        }
+    }
+
+    fn write_key_file(content: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f.flush().unwrap();
+        f
+    }
+
+    #[tokio::test]
+    async fn ecies_roundtrip() {
+        let sk = SigningKey::random(&mut rand::thread_rng());
+        let sk_bytes = sk.to_bytes();
+        let pk = sk.verifying_key();
+        let pk_bytes = pk.to_sec1_bytes();
+
+        let order = test_order();
+        let plaintext = serde_json::to_vec(&order).unwrap();
+        let ciphertext = ecies::encrypt(&pk_bytes, &plaintext).unwrap();
+
+        let dec = EciesDecrypter {
+            secret_key: sk_bytes.to_vec(),
+        };
+        let result = dec.decrypt(&ciphertext).await.unwrap();
+        assert_eq!(result, order);
+    }
+
+    #[tokio::test]
+    async fn tampered_ciphertext_rejected() {
+        let sk = SigningKey::random(&mut rand::thread_rng());
+        let sk_bytes = sk.to_bytes();
+        let pk = sk.verifying_key();
+        let pk_bytes = pk.to_sec1_bytes();
+
+        let order = test_order();
+        let plaintext = serde_json::to_vec(&order).unwrap();
+        let mut ciphertext = ecies::encrypt(&pk_bytes, &plaintext).unwrap();
+
+        let mid = ciphertext.len() / 2;
+        ciphertext[mid] ^= 0xff;
+
+        let dec = EciesDecrypter {
+            secret_key: sk_bytes.to_vec(),
+        };
+        let result = dec.decrypt(&ciphertext).await;
+        assert!(matches!(result, Err(CryptoError::DecryptionFailed(_))));
+    }
+
+    #[test]
+    fn bad_key_not_hex() {
+        let f = write_key_file("not-valid-hex!");
+        let result = load_operator_key_file(f.path());
+        assert!(matches!(result, Err(CryptoError::HexDecode(_))));
+    }
+
+    #[test]
+    fn bad_key_wrong_length() {
+        let f = write_key_file(&hex::encode([0u8; 16]));
+        let result = load_operator_key_file(f.path());
+        assert!(matches!(result, Err(CryptoError::InvalidKeyFile(_))));
+    }
+
+    #[test]
+    fn bad_key_missing_file() {
+        let result = load_operator_key_file("/tmp/nonexistent_key_dp_crypto_test");
+        assert!(matches!(result, Err(CryptoError::Io(_))));
+    }
+
+    #[test]
+    fn load_key_0x_prefix() {
+        let key = [0xab_u8; 32];
+        let f = write_key_file(&format!("0x{}", hex::encode(key)));
+        let loaded = load_operator_key_file(f.path()).unwrap();
+        assert_eq!(loaded, key);
+    }
+
+    #[test]
+    fn load_key_whitespace() {
+        let key = [0xcd_u8; 32];
+        let f = write_key_file(&format!("  {}  \n", hex::encode(key)));
+        let loaded = load_operator_key_file(f.path()).unwrap();
+        assert_eq!(loaded, key);
+    }
+}

--- a/crates/dp-crypto/src/lib.rs
+++ b/crates/dp-crypto/src/lib.rs
@@ -1,0 +1,25 @@
+mod decrypted_order;
+mod decrypter;
+mod ecies_decrypter;
+
+pub use decrypted_order::{canonical_bytes, compute_commitment, DecryptedOrder};
+pub use decrypter::{Decrypter, NoopDecrypter};
+pub use ecies_decrypter::{load_operator_key_file, EciesDecrypter};
+
+#[derive(Debug, thiserror::Error)]
+pub enum CryptoError {
+    #[error("decryption failed: {0}")]
+    DecryptionFailed(String),
+
+    #[error("invalid key file: {0}")]
+    InvalidKeyFile(String),
+
+    #[error("deserialization failed: {0}")]
+    DeserializationFailed(#[from] serde_json::Error),
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("hex decode error: {0}")]
+    HexDecode(#[from] hex::FromHexError),
+}


### PR DESCRIPTION
…mitments

Port decryption + commitment layer from server/engine/decrypt/ (Go) into Rust. Adds DecryptedOrder, canonical_bytes, compute_commitment, async Decrypter trait, NoopDecrypter, EciesDecrypter with key file loading, and CryptoError. Secret keys zeroized on drop.

Closes #40