### PR TITLE
feat: Implement dp-event crate with event store layer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ parking_lot = "0.12"
 sha2 = "0.10"
 hex = "0.4"
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
+bincode = "1"

--- a/crates/dp-event/Cargo.toml
+++ b/crates/dp-event/Cargo.toml
@@ -2,3 +2,17 @@
 name = "dp-event"
 version = "0.1.0"
 edition = "2021"
+
+[dependencies]
+dp-types = { path = "../dp-types" }
+uuid = { workspace = true }
+rust_decimal = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true }
+thiserror = { workspace = true }
+parking_lot = { workspace = true }
+bincode = { workspace = true }
+
+[dev-dependencies]
+serde_json = { workspace = true }
+tempfile = "3"

--- a/crates/dp-event/src/event.rs
+++ b/crates/dp-event/src/event.rs
@@ -1,0 +1,76 @@
+use chrono::{DateTime, Utc};
+use dp_types::{EventType, Fill};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Event {
+    pub seq: u64,
+    pub event_type: EventType,
+    pub timestamp: DateTime<Utc>,
+    pub data: EventData,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum EventData {
+    OrderPlaced {
+        order_id: Uuid,
+        commitment: Vec<u8>,
+        proof: Vec<u8>,
+        ciphertext: Vec<u8>,
+    },
+    OrderCancelled {
+        order_id: Uuid,
+        reason: String,
+    },
+    OrderExpired {
+        order_id: Uuid,
+    },
+    AuctionExecuted {
+        auction_id: Uuid,
+        pair: String,
+        clearing_price: Decimal,
+        matched_volume: Decimal,
+        match_count: u32,
+        timestamp: DateTime<Utc>,
+    },
+    OrderMatched {
+        auction_id: Uuid,
+        bid: Fill,
+        ask: Fill,
+        price: Decimal,
+        size: Decimal,
+    },
+    BatchSubmitted {
+        batch_id: Uuid,
+        auction_id: Uuid,
+        tx_hash: String,
+        match_count: u32,
+        proof: Vec<u8>,
+    },
+    BatchConfirmed {
+        batch_id: Uuid,
+        tx_hash: String,
+    },
+    BatchSettled {
+        batch_id: Uuid,
+        block_number: u64,
+        tx_hash: String,
+    },
+}
+
+impl EventData {
+    pub fn event_type(&self) -> EventType {
+        match self {
+            Self::OrderPlaced { .. } => EventType::OrderPlaced,
+            Self::OrderCancelled { .. } => EventType::OrderCancelled,
+            Self::OrderExpired { .. } => EventType::OrderExpired,
+            Self::AuctionExecuted { .. } => EventType::AuctionExecuted,
+            Self::OrderMatched { .. } => EventType::OrderMatched,
+            Self::BatchSubmitted { .. } => EventType::BatchSubmitted,
+            Self::BatchConfirmed { .. } => EventType::BatchConfirmed,
+            Self::BatchSettled { .. } => EventType::BatchSettled,
+        }
+    }
+}

--- a/crates/dp-event/src/file_store.rs
+++ b/crates/dp-event/src/file_store.rs
@@ -1,0 +1,262 @@
+use std::fs::{File, OpenOptions};
+use std::io::{self, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::path::Path;
+
+use parking_lot::RwLock;
+
+use crate::{assign_seq_and_timestamp, index_after, Event, EventError, Store};
+
+const MAX_RECORD_BYTES: u32 = 16 * 1024 * 1024;
+
+struct FileInner {
+    file: File,
+    writer: BufWriter<File>,
+    events: Vec<Event>,
+    seq: u64,
+}
+
+pub struct FileStore {
+    inner: RwLock<FileInner>,
+}
+
+impl FileStore {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self, EventError> {
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(path.as_ref())?;
+
+        let (events, seq, good_end) = load_and_truncate(&mut file)?;
+
+        file.set_len(good_end)?;
+        file.seek(SeekFrom::Start(good_end))?;
+
+        let writer = BufWriter::new(file.try_clone()?);
+
+        Ok(Self {
+            inner: RwLock::new(FileInner {
+                file,
+                writer,
+                events,
+                seq,
+            }),
+        })
+    }
+
+    pub fn close(self) -> Result<(), EventError> {
+        let mut inner = self.inner.into_inner();
+        inner.writer.flush()?;
+        inner.file.sync_all()?;
+        Ok(())
+    }
+}
+
+fn load_and_truncate(file: &mut File) -> Result<(Vec<Event>, u64, u64), EventError> {
+    file.seek(SeekFrom::Start(0))?;
+    let mut reader = BufReader::new(file);
+    let mut events = Vec::new();
+    let mut seq: u64 = 0;
+    let mut good_end: u64 = 0;
+
+    loop {
+        let mut len_buf = [0u8; 4];
+        match reader.read_exact(&mut len_buf) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e.into()),
+        }
+        let length = u32::from_be_bytes(len_buf);
+
+        if length == 0 || length > MAX_RECORD_BYTES {
+            break;
+        }
+
+        let mut payload = vec![0u8; length as usize];
+        match reader.read_exact(&mut payload) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => break,
+            Err(e) => return Err(e.into()),
+        }
+
+        let evt: Event = bincode::deserialize(&payload).map_err(|source| {
+            EventError::CorruptEvent {
+                offset: good_end,
+                source,
+            }
+        })?;
+
+        if evt.seq > seq {
+            seq = evt.seq;
+        }
+        events.push(evt);
+        good_end += 4 + length as u64;
+    }
+
+    Ok((events, seq, good_end))
+}
+
+impl Store for FileStore {
+    fn append(&self, events: &mut [Event]) -> Result<(), EventError> {
+        let mut inner = self.inner.write();
+
+        for e in events.iter_mut() {
+            assign_seq_and_timestamp(e, &mut inner.seq);
+        }
+
+        for e in events.iter() {
+            let payload = bincode::serialize(e)?;
+            let length = payload.len() as u32;
+            inner.writer.write_all(&length.to_be_bytes())?;
+            inner.writer.write_all(&payload)?;
+        }
+
+        inner.writer.flush()?;
+        inner.file.sync_all()?;
+
+        for e in events.iter() {
+            inner.events.push(e.clone());
+        }
+        Ok(())
+    }
+
+    fn read_from(&self, after_seq: u64, limit: usize) -> Result<Vec<Event>, EventError> {
+        if limit == 0 {
+            return Err(EventError::LimitMustBePositive);
+        }
+        let inner = self.inner.read();
+        let start = index_after(&inner.events, after_seq);
+        if start >= inner.events.len() {
+            return Ok(Vec::new());
+        }
+        let end = (start + limit).min(inner.events.len());
+        Ok(inner.events[start..end].to_vec())
+    }
+
+    fn last_seq(&self) -> u64 {
+        self.inner.read().seq
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::DateTime;
+    use crate::EventData;
+    use dp_types::EventType;
+    use uuid::Uuid;
+
+    fn placed_event() -> Event {
+        Event {
+            seq: 0,
+            event_type: EventType::OrderPlaced,
+            timestamp: DateTime::default(),
+            data: EventData::OrderPlaced {
+                order_id: Uuid::new_v4(),
+                commitment: vec![1, 2, 3],
+                proof: vec![4, 5, 6],
+                ciphertext: vec![7, 8, 9],
+            },
+        }
+    }
+
+    #[test]
+    fn round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.bin");
+
+        let store = FileStore::open(&path).unwrap();
+        let mut events = vec![placed_event(), placed_event()];
+        store.append(&mut events).unwrap();
+
+        assert_eq!(events[0].seq, 1);
+        assert_eq!(events[1].seq, 2);
+        assert_eq!(store.last_seq(), 2);
+
+        let read = store.read_from(0, 10).unwrap();
+        assert_eq!(read.len(), 2);
+        assert_eq!(read[0].seq, 1);
+        store.close().unwrap();
+    }
+
+    #[test]
+    fn persist_across_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.bin");
+
+        {
+            let store = FileStore::open(&path).unwrap();
+            let mut events = vec![placed_event(), placed_event()];
+            store.append(&mut events).unwrap();
+            store.close().unwrap();
+        }
+
+        let store = FileStore::open(&path).unwrap();
+        assert_eq!(store.last_seq(), 2);
+        let read = store.read_from(0, 10).unwrap();
+        assert_eq!(read.len(), 2);
+        assert_eq!(read[0].seq, 1);
+        assert_eq!(read[1].seq, 2);
+        store.close().unwrap();
+    }
+
+    #[test]
+    fn truncate_partial_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.bin");
+
+        {
+            let store = FileStore::open(&path).unwrap();
+            let mut events = vec![placed_event()];
+            store.append(&mut events).unwrap();
+            store.close().unwrap();
+        }
+
+        // Append garbage partial record
+        {
+            let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+            f.write_all(&100u32.to_be_bytes()).unwrap();
+            f.write_all(&[0xDE, 0xAD]).unwrap();
+        }
+
+        let store = FileStore::open(&path).unwrap();
+        assert_eq!(store.last_seq(), 1);
+        let read = store.read_from(0, 10).unwrap();
+        assert_eq!(read.len(), 1);
+        store.close().unwrap();
+    }
+
+    #[test]
+    fn truncate_oversize_header() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.bin");
+
+        {
+            let store = FileStore::open(&path).unwrap();
+            let mut events = vec![placed_event()];
+            store.append(&mut events).unwrap();
+            store.close().unwrap();
+        }
+
+        // Append oversize length header
+        {
+            let mut f = OpenOptions::new().append(true).open(&path).unwrap();
+            let oversize = MAX_RECORD_BYTES + 1;
+            f.write_all(&oversize.to_be_bytes()).unwrap();
+        }
+
+        let store = FileStore::open(&path).unwrap();
+        assert_eq!(store.last_seq(), 1);
+        store.close().unwrap();
+    }
+
+    #[test]
+    fn invalid_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.bin");
+        let store = FileStore::open(&path).unwrap();
+        let err = store.read_from(0, 0).unwrap_err();
+        assert!(matches!(err, EventError::LimitMustBePositive));
+    }
+}

--- a/crates/dp-event/src/lib.rs
+++ b/crates/dp-event/src/lib.rs
@@ -1,0 +1,24 @@
+mod event;
+mod file_store;
+mod mem_store;
+mod store;
+
+pub use event::{Event, EventData};
+pub use file_store::FileStore;
+pub use mem_store::MemStore;
+pub use store::{assign_seq_and_timestamp, index_after, Store};
+
+#[derive(Debug, thiserror::Error)]
+pub enum EventError {
+    #[error("limit must be > 0")]
+    LimitMustBePositive,
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Bincode(#[from] bincode::Error),
+    #[error("corrupt event at offset {offset}: {source}")]
+    CorruptEvent {
+        offset: u64,
+        source: bincode::Error,
+    },
+}

--- a/crates/dp-event/src/mem_store.rs
+++ b/crates/dp-event/src/mem_store.rs
@@ -1,0 +1,130 @@
+use parking_lot::RwLock;
+
+use crate::{assign_seq_and_timestamp, index_after, Event, EventError, Store};
+
+struct Inner {
+    events: Vec<Event>,
+    seq: u64,
+}
+
+pub struct MemStore {
+    inner: RwLock<Inner>,
+}
+
+impl MemStore {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(Inner {
+                events: Vec::new(),
+                seq: 0,
+            }),
+        }
+    }
+}
+
+impl Default for MemStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Store for MemStore {
+    fn append(&self, events: &mut [Event]) -> Result<(), EventError> {
+        let mut inner = self.inner.write();
+        for e in events.iter_mut() {
+            assign_seq_and_timestamp(e, &mut inner.seq);
+            inner.events.push(e.clone());
+        }
+        Ok(())
+    }
+
+    fn read_from(&self, after_seq: u64, limit: usize) -> Result<Vec<Event>, EventError> {
+        if limit == 0 {
+            return Err(EventError::LimitMustBePositive);
+        }
+        let inner = self.inner.read();
+        let start = index_after(&inner.events, after_seq);
+        if start >= inner.events.len() {
+            return Ok(Vec::new());
+        }
+        let end = (start + limit).min(inner.events.len());
+        Ok(inner.events[start..end].to_vec())
+    }
+
+    fn last_seq(&self) -> u64 {
+        self.inner.read().seq
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+    use crate::EventData;
+    use dp_types::EventType;
+    use uuid::Uuid;
+
+    fn placed_event() -> Event {
+        Event {
+            seq: 0,
+            event_type: EventType::OrderPlaced,
+            timestamp: DateTime::default(),
+            data: EventData::OrderPlaced {
+                order_id: Uuid::new_v4(),
+                commitment: vec![1, 2, 3],
+                proof: vec![4, 5, 6],
+                ciphertext: vec![7, 8, 9],
+            },
+        }
+    }
+
+    #[test]
+    fn append_and_read() {
+        let store = MemStore::new();
+        let mut events = vec![placed_event(), placed_event()];
+        store.append(&mut events).unwrap();
+
+        assert_eq!(events[0].seq, 1);
+        assert_eq!(events[1].seq, 2);
+        assert_eq!(store.last_seq(), 2);
+
+        let read = store.read_from(0, 10).unwrap();
+        assert_eq!(read.len(), 2);
+        assert_eq!(read[0].seq, 1);
+        assert_eq!(read[1].seq, 2);
+    }
+
+    #[test]
+    fn offset_read() {
+        let store = MemStore::new();
+        let mut events = vec![placed_event(), placed_event(), placed_event()];
+        store.append(&mut events).unwrap();
+
+        let read = store.read_from(1, 10).unwrap();
+        assert_eq!(read.len(), 2);
+        assert_eq!(read[0].seq, 2);
+    }
+
+    #[test]
+    fn invalid_limit() {
+        let store = MemStore::new();
+        let err = store.read_from(0, 0).unwrap_err();
+        assert!(matches!(err, EventError::LimitMustBePositive));
+    }
+
+    #[test]
+    fn empty_store() {
+        let store = MemStore::new();
+        assert_eq!(store.last_seq(), 0);
+        let read = store.read_from(0, 10).unwrap();
+        assert!(read.is_empty());
+    }
+
+    #[test]
+    fn sets_timestamp_when_default() {
+        let store = MemStore::new();
+        let mut events = vec![placed_event()];
+        store.append(&mut events).unwrap();
+        assert_ne!(events[0].timestamp, DateTime::<Utc>::default());
+    }
+}

--- a/crates/dp-event/src/store.rs
+++ b/crates/dp-event/src/store.rs
@@ -1,0 +1,24 @@
+use chrono::{DateTime, Utc};
+
+use crate::{Event, EventError};
+
+pub trait Store: Send + Sync {
+    fn append(&self, events: &mut [Event]) -> Result<(), EventError>;
+    fn read_from(&self, after_seq: u64, limit: usize) -> Result<Vec<Event>, EventError>;
+    fn last_seq(&self) -> u64;
+}
+
+pub fn assign_seq_and_timestamp(event: &mut Event, seq: &mut u64) {
+    *seq += 1;
+    event.seq = *seq;
+    if event.timestamp == DateTime::<Utc>::default() {
+        event.timestamp = Utc::now();
+    }
+}
+
+pub fn index_after(events: &[Event], after_seq: u64) -> usize {
+    if after_seq == 0 {
+        return 0;
+    }
+    (after_seq as usize).min(events.len())
+}


### PR DESCRIPTION
Port Go event sourcing layer (event.go, store.go, file_store.go) to Rust. Adds Event struct with 8 EventData variants, Store trait, MemStore (in-memory), and FileStore (append-only bincode-encoded file with crash-safe truncation).

Closes #32