### PR TITLE
Add dp-client crate for encrypted order construction

### DIFF
--- a/crates/dp-client/Cargo.toml
+++ b/crates/dp-client/Cargo.toml
@@ -1,0 +1,54 @@
+[workspace]
+
+[package]
+name = "dp-client"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["cli"]
+cli = ["dep:clap", "dep:tokio", "dep:reqwest", "dep:humantime"]
+wasm = ["dep:wasm-bindgen", "dep:js-sys", "dep:getrandom"]
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_repr = "0.1"
+rust_decimal = { version = "1", features = ["serde-with-str"] }
+hex = "0.4"
+ecies = { version = "0.2", default-features = false, features = ["pure"] }
+sha2 = "0.10"
+thiserror = "2"
+base64 = "0.22"
+rand = "0.8"
+
+ark-ff = { version = "0.5", default-features = false, features = ["std"] }
+ark-bn254 = { version = "0.5", default-features = false, features = ["std", "curve"] }
+ark-crypto-primitives = { version = "0.5", default-features = false, features = ["std", "sponge"] }
+
+# CLI-only
+clap = { version = "4", features = ["derive", "env"], optional = true }
+tokio = { version = "1", features = ["full"], optional = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"], optional = true }
+humantime = { version = "2", optional = true }
+
+# WASM-only
+wasm-bindgen = { version = "0.2", optional = true }
+js-sys = { version = "0.3", optional = true }
+getrandom = { version = "0.2", optional = true, features = ["js"] }
+
+[dev-dependencies]
+dp-crypto = { path = "../dp-crypto" }
+dp-types = { path = "../dp-types" }
+dp-zk = { path = "../dp-zk" }
+k256 = "0.13"
+tempfile = "3"
+tokio = { version = "1", features = ["full"] }
+
+[[bin]]
+name = "dp-trade"
+path = "src/bin/dp-trade.rs"
+required-features = ["cli"]

--- a/crates/dp-client/src/bin/dp-trade.rs
+++ b/crates/dp-client/src/bin/dp-trade.rs
@@ -1,0 +1,192 @@
+//! `dp-trade` — construct an encrypted order submission and either print it
+//! or POST it to a running darkpool node.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use clap::{Parser, ValueEnum};
+use rust_decimal::Decimal;
+
+use dp_client::encrypt::{load_operator_pubkey_file, parse_operator_pubkey_hex};
+use dp_client::payload::{OrderPayload, Side};
+use dp_client::{prepare_order, ClientError, OrderSubmission};
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum SideArg {
+    Buy,
+    Sell,
+}
+
+impl From<SideArg> for Side {
+    fn from(s: SideArg) -> Self {
+        match s {
+            SideArg::Buy => Side::Buy,
+            SideArg::Sell => Side::Sell,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+enum OutputFormat {
+    Json,
+    Hex,
+    Base64,
+}
+
+#[derive(Parser, Debug)]
+#[command(name = "dp-trade", about = "Build an encrypted DarkPool order submission")]
+struct Args {
+    #[arg(long)]
+    pair: String,
+
+    #[arg(long, value_enum)]
+    side: SideArg,
+
+    #[arg(long)]
+    price: Decimal,
+
+    #[arg(long)]
+    size: Decimal,
+
+    #[arg(long)]
+    commitment_key: String,
+
+    /// Order TTL (humantime, e.g. "10m", "30s"). Stored as nanoseconds.
+    #[arg(long, default_value = "10m")]
+    ttl: String,
+
+    /// SEC1 secp256k1 hex (0x-prefixed or bare) OR path to a file containing one.
+    #[arg(long)]
+    operator_key: String,
+
+    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    output: OutputFormat,
+
+    /// If set, POST base64-encoded submission to <server>/v1/orders.
+    #[arg(long)]
+    server: Option<String>,
+
+    /// API key, sent as `x-api-key` when --server is used.
+    #[arg(long)]
+    api_key: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match run().await {
+        Ok(()) => ExitCode::SUCCESS,
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+async fn run() -> Result<(), ClientError> {
+    let args = Args::parse();
+
+    let operator_pubkey = resolve_operator_key(&args.operator_key)?;
+
+    let ttl = humantime::parse_duration(&args.ttl)
+        .map_err(|e| ClientError::InvalidPayload(format!("--ttl: {e}")))?;
+    let ttl_nanos: i64 = ttl
+        .as_nanos()
+        .try_into()
+        .map_err(|_| ClientError::InvalidPayload("ttl exceeds i64 nanoseconds".into()))?;
+
+    let payload = OrderPayload {
+        pair: args.pair,
+        side: args.side.into(),
+        price: args.price,
+        size: args.size,
+        commitment_key: args.commitment_key,
+        ttl: ttl_nanos,
+    };
+
+    let sub = prepare_order(&operator_pubkey, &payload)?;
+
+    print_submission(&sub, args.output);
+
+    if let Some(server) = args.server {
+        submit_http(&server, args.api_key.as_deref(), &sub).await?;
+    }
+
+    Ok(())
+}
+
+fn resolve_operator_key(input: &str) -> Result<Vec<u8>, ClientError> {
+    let p = PathBuf::from(input);
+    if p.exists() {
+        load_operator_pubkey_file(&p)
+    } else {
+        parse_operator_pubkey_hex(input)
+    }
+}
+
+fn print_submission(sub: &OrderSubmission, fmt: OutputFormat) {
+    match fmt {
+        OutputFormat::Json => {
+            let v = serde_json::json!({
+                "commitment": hex::encode(sub.commitment),
+                "proof": hex::encode(&sub.proof),
+                "encrypted_payload": B64.encode(&sub.encrypted_payload),
+                "trader_id": hex::encode(sub.trader_id),
+                "salt": hex::encode(sub.salt),
+            });
+            println!("{}", serde_json::to_string_pretty(&v).unwrap());
+        }
+        OutputFormat::Hex => {
+            println!("commitment={}", hex::encode(sub.commitment));
+            println!("proof={}", hex::encode(&sub.proof));
+            println!("encrypted_payload={}", hex::encode(&sub.encrypted_payload));
+            println!("trader_id={}", hex::encode(sub.trader_id));
+            println!("salt={}", hex::encode(sub.salt));
+        }
+        OutputFormat::Base64 => {
+            println!("commitment={}", B64.encode(sub.commitment));
+            println!("proof={}", B64.encode(&sub.proof));
+            println!("encrypted_payload={}", B64.encode(&sub.encrypted_payload));
+            println!("trader_id={}", B64.encode(sub.trader_id));
+            println!("salt={}", B64.encode(sub.salt));
+        }
+    }
+}
+
+async fn submit_http(
+    server: &str,
+    api_key: Option<&str>,
+    sub: &OrderSubmission,
+) -> Result<(), ClientError> {
+    let url = format!("{}/v1/orders", server.trim_end_matches('/'));
+    let body = serde_json::json!({
+        "commitment": B64.encode(sub.commitment),
+        "proof": B64.encode(&sub.proof),
+        "encryptedPayload": B64.encode(&sub.encrypted_payload),
+    });
+
+    let client = reqwest::Client::new();
+    let mut req = client.post(&url).json(&body);
+    if let Some(k) = api_key {
+        req = req.header("x-api-key", k);
+    }
+
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| ClientError::Http(e.to_string()))?;
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| ClientError::Http(e.to_string()))?;
+    if !status.is_success() {
+        return Err(ClientError::Http(format!("{status}: {text}")));
+    }
+    eprintln!("submitted to {url}: {status}");
+    if !text.is_empty() {
+        eprintln!("{text}");
+    }
+    Ok(())
+}

--- a/crates/dp-client/src/commitment.rs
+++ b/crates/dp-client/src/commitment.rs
@@ -33,7 +33,15 @@ impl OrderCommitmentInput {
     ) -> Result<Self, ClientError> {
         Ok(Self {
             trader_id,
-            side: if side == 0 { Fr::zero() } else { Fr::one() },
+            side: match side {
+                0 => Fr::zero(),
+                1 => Fr::one(),
+                other => {
+                    return Err(ClientError::InvalidPayload(format!(
+                        "side must be 0 or 1, got {other}"
+                    )))
+                }
+            },
             limit_price: decimal_to_scalar(limit_price)?,
             size: decimal_to_scalar(size)?,
             salt,

--- a/crates/dp-client/src/commitment.rs
+++ b/crates/dp-client/src/commitment.rs
@@ -1,0 +1,150 @@
+//! Poseidon order-leg commitment. Copies the parameter set + absorption
+//! schedule from `dp_zk::pedersen` so client- and engine-side commitments
+//! agree byte-for-byte (verified by the interop test).
+//!
+//! Kept in this crate (rather than depending on `dp-zk`) to avoid pulling
+//! ark-groth16 / rayon into the WASM build.
+
+use ark_bn254::Fr;
+use ark_crypto_primitives::sponge::poseidon::{PoseidonConfig, PoseidonSponge};
+use ark_crypto_primitives::sponge::CryptographicSponge;
+use ark_ff::{BigInteger, One, PrimeField, Zero};
+use rust_decimal::Decimal;
+
+use crate::encoding::decimal_to_scalar;
+use crate::error::ClientError;
+
+#[derive(Clone, Debug)]
+pub struct OrderCommitmentInput {
+    pub trader_id: Fr,
+    pub side: Fr,
+    pub limit_price: Fr,
+    pub size: Fr,
+    pub salt: Fr,
+}
+
+impl OrderCommitmentInput {
+    pub fn from_decimals(
+        trader_id: Fr,
+        side: u8,
+        limit_price: Decimal,
+        size: Decimal,
+        salt: Fr,
+    ) -> Result<Self, ClientError> {
+        Ok(Self {
+            trader_id,
+            side: if side == 0 { Fr::zero() } else { Fr::one() },
+            limit_price: decimal_to_scalar(limit_price)?,
+            size: decimal_to_scalar(size)?,
+            salt,
+        })
+    }
+
+    pub fn as_field_elements(&self) -> [Fr; 5] {
+        [
+            self.trader_id,
+            self.side,
+            self.limit_price,
+            self.size,
+            self.salt,
+        ]
+    }
+}
+
+pub fn commit_native(input: &OrderCommitmentInput) -> Fr {
+    let cfg = poseidon_config();
+    let mut sponge = PoseidonSponge::<Fr>::new(&cfg);
+    sponge.absorb(&input.as_field_elements().to_vec());
+    sponge.squeeze_field_elements::<Fr>(1)[0]
+}
+
+pub fn derive_trader_id(commitment_key_bytes: &[u8]) -> Fr {
+    let scalar = Fr::from_be_bytes_mod_order(commitment_key_bytes);
+    let cfg = poseidon_config();
+    let mut sponge = PoseidonSponge::<Fr>::new(&cfg);
+    sponge.absorb(&vec![scalar]);
+    sponge.squeeze_field_elements::<Fr>(1)[0]
+}
+
+pub fn bytes_to_scalar(b: &[u8]) -> Fr {
+    Fr::from_be_bytes_mod_order(b)
+}
+
+pub fn scalar_to_be_bytes(f: Fr) -> [u8; 32] {
+    let bytes = f.into_bigint().to_bytes_be();
+    let mut out = [0u8; 32];
+    let take = bytes.len().min(32);
+    out[32 - take..].copy_from_slice(&bytes[bytes.len() - take..]);
+    out
+}
+
+pub fn poseidon_config() -> PoseidonConfig<Fr> {
+    use ark_crypto_primitives::sponge::poseidon::find_poseidon_ark_and_mds;
+
+    let full_rounds = 8;
+    let partial_rounds = 57;
+    let alpha = 5u64;
+    let rate = 2;
+    let capacity = 1;
+    let modulus_bits = <Fr as PrimeField>::MODULUS_BIT_SIZE as u64;
+
+    let (ark, mds) =
+        find_poseidon_ark_and_mds::<Fr>(modulus_bits, rate, full_rounds, partial_rounds, 0);
+
+    PoseidonConfig::new(
+        full_rounds as usize,
+        partial_rounds as usize,
+        alpha,
+        mds,
+        ark,
+        rate,
+        capacity,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn commit_is_deterministic() {
+        let inp = OrderCommitmentInput::from_decimals(
+            Fr::from(7u64),
+            0,
+            Decimal::from(100),
+            Decimal::from(10),
+            Fr::from(42u64),
+        )
+        .unwrap();
+        assert_eq!(commit_native(&inp), commit_native(&inp));
+    }
+
+    #[test]
+    fn commit_changes_with_salt() {
+        let a = OrderCommitmentInput::from_decimals(
+            Fr::from(7u64),
+            0,
+            Decimal::from(100),
+            Decimal::from(10),
+            Fr::from(1u64),
+        )
+        .unwrap();
+        let b = OrderCommitmentInput::from_decimals(
+            Fr::from(7u64),
+            0,
+            Decimal::from(100),
+            Decimal::from(10),
+            Fr::from(2u64),
+        )
+        .unwrap();
+        assert_ne!(commit_native(&a), commit_native(&b));
+    }
+
+    #[test]
+    fn trader_id_round_trips_through_bytes() {
+        let f = derive_trader_id(b"alice");
+        let bytes = scalar_to_be_bytes(f);
+        let recovered = bytes_to_scalar(&bytes);
+        assert_eq!(recovered, f);
+    }
+}

--- a/crates/dp-client/src/encoding.rs
+++ b/crates/dp-client/src/encoding.rs
@@ -1,0 +1,71 @@
+//! Decimal → BN254 scalar encoder. Mirrors `dp_zk::encoding::decimal_to_scalar`
+//! byte-for-byte; the interop test in `tests/interop.rs` enforces this.
+
+use ark_bn254::Fr;
+use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
+
+use crate::error::ClientError;
+
+pub const DECIMAL_SCALE: u32 = 8;
+pub const SCALE_FACTOR_I128: i128 = 100_000_000;
+pub const MAX_ENCODED: i128 = 1 << 60;
+
+pub fn decimal_to_scalar(d: Decimal) -> Result<Fr, ClientError> {
+    if d.is_sign_negative() {
+        return Err(ClientError::Encoding(format!("decimal {d} is negative")));
+    }
+    let scaled = d
+        .checked_mul(Decimal::from(SCALE_FACTOR_I128))
+        .ok_or_else(|| ClientError::Encoding(format!("decimal {d} overflows after scaling")))?;
+    if scaled.scale() > 0 && !scaled.fract().is_zero() {
+        return Err(ClientError::Encoding(format!(
+            "decimal {d} loses precision beyond {DECIMAL_SCALE} dp"
+        )));
+    }
+    let int = scaled
+        .trunc()
+        .to_i128()
+        .ok_or_else(|| ClientError::Encoding(format!("decimal {d} overflows to_i128")))?;
+    if !(0..MAX_ENCODED).contains(&int) {
+        return Err(ClientError::Encoding(format!("decimal {d} out of range")));
+    }
+    Ok(Fr::from(int as u128))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_negative() {
+        let d = Decimal::new(-1, 0);
+        assert!(matches!(
+            decimal_to_scalar(d),
+            Err(ClientError::Encoding(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_excess_precision() {
+        let d = Decimal::new(1, 9);
+        assert!(matches!(
+            decimal_to_scalar(d),
+            Err(ClientError::Encoding(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_overflow() {
+        let d = Decimal::from(i64::MAX);
+        assert!(matches!(
+            decimal_to_scalar(d),
+            Err(ClientError::Encoding(_))
+        ));
+    }
+
+    #[test]
+    fn accepts_zero() {
+        decimal_to_scalar(Decimal::ZERO).unwrap();
+    }
+}

--- a/crates/dp-client/src/encrypt.rs
+++ b/crates/dp-client/src/encrypt.rs
@@ -1,0 +1,75 @@
+//! ECIES encryption helpers. Operator pubkey is a SEC1 secp256k1 point.
+
+use crate::error::ClientError;
+use crate::payload::OrderPayload;
+
+const SEC1_COMPRESSED: usize = 33;
+const SEC1_UNCOMPRESSED: usize = 65;
+
+pub fn encrypt_order(operator_pubkey: &[u8], payload: &OrderPayload) -> Result<Vec<u8>, ClientError> {
+    validate_pubkey_len(operator_pubkey)?;
+    let plaintext = serde_json::to_vec(payload)?;
+    ecies::encrypt(operator_pubkey, &plaintext).map_err(|e| ClientError::Encryption(e.to_string()))
+}
+
+pub fn parse_operator_pubkey_hex(hex_str: &str) -> Result<Vec<u8>, ClientError> {
+    let trimmed = hex_str.trim().trim_start_matches("0x").trim_start_matches("0X");
+    let bytes = hex::decode(trimmed)?;
+    validate_pubkey_len(&bytes)?;
+    Ok(bytes)
+}
+
+#[cfg(feature = "cli")]
+pub fn load_operator_pubkey_file(path: &std::path::Path) -> Result<Vec<u8>, ClientError> {
+    let raw = std::fs::read_to_string(path)?;
+    parse_operator_pubkey_hex(&raw)
+}
+
+fn validate_pubkey_len(b: &[u8]) -> Result<(), ClientError> {
+    match b.len() {
+        SEC1_COMPRESSED | SEC1_UNCOMPRESSED => Ok(()),
+        n => Err(ClientError::InvalidKey(format!(
+            "expected 33 (compressed) or 65 (uncompressed) SEC1 bytes, got {n}"
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_strips_0x_prefix() {
+        let raw = vec![0x02u8; 33];
+        let with = format!("0x{}", hex::encode(&raw));
+        let no = hex::encode(&raw);
+        assert_eq!(parse_operator_pubkey_hex(&with).unwrap(), raw);
+        assert_eq!(parse_operator_pubkey_hex(&no).unwrap(), raw);
+    }
+
+    #[test]
+    fn parse_rejects_wrong_length() {
+        let bad = hex::encode([0u8; 32]);
+        assert!(matches!(
+            parse_operator_pubkey_hex(&bad),
+            Err(ClientError::InvalidKey(_))
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_non_hex() {
+        assert!(matches!(
+            parse_operator_pubkey_hex("nothex!!"),
+            Err(ClientError::Hex(_))
+        ));
+    }
+
+    #[test]
+    fn parse_accepts_uncompressed() {
+        let raw = vec![0x04u8; 65];
+        assert_eq!(
+            parse_operator_pubkey_hex(&hex::encode(&raw)).unwrap(),
+            raw
+        );
+    }
+}

--- a/crates/dp-client/src/error.rs
+++ b/crates/dp-client/src/error.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error("encryption failed: {0}")]
+    Encryption(String),
+
+    #[error("encoding error: {0}")]
+    Encoding(String),
+
+    #[error("invalid operator key: {0}")]
+    InvalidKey(String),
+
+    #[error("invalid payload: {0}")]
+    InvalidPayload(String),
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("serde_json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("hex decode: {0}")]
+    Hex(#[from] hex::FromHexError),
+
+    #[cfg(feature = "cli")]
+    #[error("http error: {0}")]
+    Http(String),
+}

--- a/crates/dp-client/src/lib.rs
+++ b/crates/dp-client/src/lib.rs
@@ -1,0 +1,20 @@
+//! Client-side order construction for the DarkPool Exchange.
+//!
+//! Ships an ECIES-encrypted order payload, a Poseidon commitment for local
+//! record-keeping, and a placeholder proof. Per-order ZK proofs are out of
+//! scope — the engine runs batch-level proofs after auction matching, and
+//! recomputes its own commitment server-side.
+
+pub mod commitment;
+pub mod encoding;
+pub mod encrypt;
+pub mod error;
+pub mod payload;
+pub mod submit;
+
+#[cfg(feature = "wasm")]
+pub mod wasm;
+
+pub use error::ClientError;
+pub use payload::{OrderPayload, Side};
+pub use submit::{prepare_order, prepare_order_with_entropy, OrderSubmission, PLACEHOLDER_PROOF};

--- a/crates/dp-client/src/payload.rs
+++ b/crates/dp-client/src/payload.rs
@@ -1,0 +1,53 @@
+//! Order payload that mirrors `dp_crypto::DecryptedOrder` byte-for-byte under
+//! `serde_json`. The engine deserializes the ECIES plaintext with that type,
+//! so any divergence here breaks submission.
+
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize_repr, Deserialize_repr)]
+#[repr(u8)]
+pub enum Side {
+    Buy = 0,
+    Sell = 1,
+}
+
+impl Side {
+    pub fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OrderPayload {
+    pub pair: String,
+    pub side: Side,
+    pub price: Decimal,
+    pub size: Decimal,
+    pub commitment_key: String,
+    pub ttl: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_shape_matches_decrypted_order() {
+        let p = OrderPayload {
+            pair: "ETH-USD".into(),
+            side: Side::Buy,
+            price: Decimal::new(250000, 2),
+            size: Decimal::new(10, 1),
+            commitment_key: "abc123".into(),
+            ttl: 5_000_000_000,
+        };
+        let json = serde_json::to_string(&p).unwrap();
+        // side must be numeric (serde_repr); price/size must be string (rust_decimal serde-with-str).
+        assert!(json.contains("\"side\":0"));
+        assert!(json.contains("\"price\":\"2500.00\""));
+        assert!(json.contains("\"size\":\"1.0\""));
+        assert!(json.contains("\"ttl\":5000000000"));
+    }
+}

--- a/crates/dp-client/src/submit.rs
+++ b/crates/dp-client/src/submit.rs
@@ -47,6 +47,12 @@ pub fn prepare_order_with_entropy(
     payload: &OrderPayload,
     entropy: &[u8; 32],
 ) -> Result<OrderSubmission, ClientError> {
+    if payload.commitment_key.trim().is_empty() {
+        return Err(ClientError::InvalidPayload(
+            "commitment_key must be non-empty".to_string(),
+        ));
+    }
+
     let key_bytes = payload.commitment_key.as_bytes();
 
     let trader_id_fr = derive_trader_id(key_bytes);

--- a/crates/dp-client/src/submit.rs
+++ b/crates/dp-client/src/submit.rs
@@ -1,0 +1,137 @@
+//! Orchestrates an order submission: derive trader id, sample salt, compute
+//! Poseidon commitment, ECIES-encrypt the payload.
+//!
+//! The engine recomputes its own commitment from the decrypted payload using a
+//! per-boot salt the client cannot know (engine.rs:469-476), so the
+//! commitment we emit here is for local record-keeping and future per-order
+//! verification — not for content-binding the engine.
+//!
+//! The proof slot is a placeholder until per-order circuits exist; the
+//! validation layer (dp-api) only checks non-emptiness and a 64 KiB upper
+//! bound today.
+
+use rand::RngCore;
+use sha2::{Digest, Sha256};
+
+use crate::commitment::{
+    bytes_to_scalar, commit_native, derive_trader_id, scalar_to_be_bytes, OrderCommitmentInput,
+};
+use crate::encrypt::encrypt_order;
+use crate::error::ClientError;
+use crate::payload::OrderPayload;
+
+pub const PLACEHOLDER_PROOF: &[u8] = b"dp-client-v0";
+const SALT_DOMAIN_TAG: &[u8] = b"dp-client-salt";
+
+#[derive(Clone, Debug)]
+pub struct OrderSubmission {
+    pub commitment: [u8; 32],
+    pub proof: Vec<u8>,
+    pub encrypted_payload: Vec<u8>,
+    pub trader_id: [u8; 32],
+    pub salt: [u8; 32],
+}
+
+pub fn prepare_order(
+    operator_pubkey: &[u8],
+    payload: &OrderPayload,
+) -> Result<OrderSubmission, ClientError> {
+    let mut rng = rand::thread_rng();
+    let mut entropy = [0u8; 32];
+    rng.fill_bytes(&mut entropy);
+    prepare_order_with_entropy(operator_pubkey, payload, &entropy)
+}
+
+pub fn prepare_order_with_entropy(
+    operator_pubkey: &[u8],
+    payload: &OrderPayload,
+    entropy: &[u8; 32],
+) -> Result<OrderSubmission, ClientError> {
+    let key_bytes = payload.commitment_key.as_bytes();
+
+    let trader_id_fr = derive_trader_id(key_bytes);
+    let trader_id = scalar_to_be_bytes(trader_id_fr);
+
+    let mut hasher = Sha256::new();
+    hasher.update(SALT_DOMAIN_TAG);
+    hasher.update(key_bytes);
+    hasher.update(entropy);
+    let salt: [u8; 32] = hasher.finalize().into();
+    let salt_fr = bytes_to_scalar(&salt);
+
+    let inp = OrderCommitmentInput::from_decimals(
+        trader_id_fr,
+        payload.side.as_u8(),
+        payload.price,
+        payload.size,
+        salt_fr,
+    )?;
+    let commitment = scalar_to_be_bytes(commit_native(&inp));
+
+    let encrypted_payload = encrypt_order(operator_pubkey, payload)?;
+
+    Ok(OrderSubmission {
+        commitment,
+        proof: PLACEHOLDER_PROOF.to_vec(),
+        encrypted_payload,
+        trader_id,
+        salt,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::payload::Side;
+    use rust_decimal::Decimal;
+
+    fn fake_pubkey() -> Vec<u8> {
+        // Deterministic SEC1 secp256k1 pubkey for non-decryption-path tests.
+        use k256::ecdsa::SigningKey;
+        let sk = SigningKey::from_bytes(&[7u8; 32].into()).unwrap();
+        sk.verifying_key().to_sec1_bytes().to_vec()
+    }
+
+    fn sample() -> OrderPayload {
+        OrderPayload {
+            pair: "ETH-USD".into(),
+            side: Side::Buy,
+            price: Decimal::new(250000, 2),
+            size: Decimal::new(10, 1),
+            commitment_key: "abc123".into(),
+            ttl: 5_000_000_000,
+        }
+    }
+
+    #[test]
+    fn prepare_is_deterministic_given_entropy() {
+        let pk = fake_pubkey();
+        let p = sample();
+        let entropy = [9u8; 32];
+        let a = prepare_order_with_entropy(&pk, &p, &entropy).unwrap();
+        let b = prepare_order_with_entropy(&pk, &p, &entropy).unwrap();
+        // Commitment + trader_id + salt are deterministic; ciphertext is not
+        // (ECIES adds an ephemeral pubkey + nonce per encryption).
+        assert_eq!(a.commitment, b.commitment);
+        assert_eq!(a.trader_id, b.trader_id);
+        assert_eq!(a.salt, b.salt);
+        assert_ne!(a.encrypted_payload, b.encrypted_payload);
+    }
+
+    #[test]
+    fn entropy_perturbs_commitment() {
+        let pk = fake_pubkey();
+        let p = sample();
+        let a = prepare_order_with_entropy(&pk, &p, &[1u8; 32]).unwrap();
+        let b = prepare_order_with_entropy(&pk, &p, &[2u8; 32]).unwrap();
+        assert_ne!(a.commitment, b.commitment);
+        assert_ne!(a.salt, b.salt);
+    }
+
+    #[test]
+    fn placeholder_proof_passes_api_validation() {
+        // Non-empty + under 64 KiB; mirrors dp-api validation.rs.
+        assert!(!PLACEHOLDER_PROOF.is_empty());
+        assert!(PLACEHOLDER_PROOF.len() <= 64 * 1024);
+    }
+}

--- a/crates/dp-client/src/wasm.rs
+++ b/crates/dp-client/src/wasm.rs
@@ -1,0 +1,74 @@
+//! Browser bindings (`wasm-pack build --target web --features wasm
+//! --no-default-features`). All inputs/outputs cross the JS boundary as
+//! strings or byte buffers — no JsValue object decoding on the hot path.
+
+use base64::engine::general_purpose::STANDARD as B64;
+use base64::Engine;
+use rust_decimal::Decimal;
+use std::str::FromStr;
+use wasm_bindgen::prelude::*;
+
+use crate::commitment::{
+    commit_native, derive_trader_id as inner_derive_trader_id, scalar_to_be_bytes,
+    OrderCommitmentInput,
+};
+use crate::encrypt::{encrypt_order, parse_operator_pubkey_hex};
+use crate::payload::OrderPayload;
+use crate::submit::prepare_order;
+
+fn js_err<E: std::fmt::Display>(e: E) -> JsError {
+    JsError::new(&e.to_string())
+}
+
+#[wasm_bindgen]
+pub fn prepare_order_wasm(operator_pubkey_hex: &str, order_json: &str) -> Result<JsValue, JsError> {
+    let pk = parse_operator_pubkey_hex(operator_pubkey_hex).map_err(js_err)?;
+    let payload: OrderPayload = serde_json::from_str(order_json).map_err(js_err)?;
+    let sub = prepare_order(&pk, &payload).map_err(js_err)?;
+    let v = serde_json::json!({
+        "commitment": hex::encode(sub.commitment),
+        "proof": hex::encode(&sub.proof),
+        "encrypted_payload": B64.encode(&sub.encrypted_payload),
+        "trader_id": hex::encode(sub.trader_id),
+        "salt": hex::encode(sub.salt),
+    });
+    serde_wasm_bindgen_serialize(&v)
+}
+
+#[wasm_bindgen]
+pub fn encrypt_order_wasm(pubkey_hex: &str, order_json: &str) -> Result<Vec<u8>, JsError> {
+    let pk = parse_operator_pubkey_hex(pubkey_hex).map_err(js_err)?;
+    let payload: OrderPayload = serde_json::from_str(order_json).map_err(js_err)?;
+    encrypt_order(&pk, &payload).map_err(js_err)
+}
+
+#[wasm_bindgen]
+pub fn compute_commitment_wasm(
+    commitment_key: &str,
+    side: u8,
+    price: &str,
+    size: &str,
+    salt_hex: &str,
+) -> Result<String, JsError> {
+    let trader_id = inner_derive_trader_id(commitment_key.as_bytes());
+    let price_d = Decimal::from_str(price).map_err(js_err)?;
+    let size_d = Decimal::from_str(size).map_err(js_err)?;
+    let salt_bytes = hex::decode(salt_hex.trim_start_matches("0x")).map_err(js_err)?;
+    let salt_fr = crate::commitment::bytes_to_scalar(&salt_bytes);
+    let inp = OrderCommitmentInput::from_decimals(trader_id, side, price_d, size_d, salt_fr)
+        .map_err(js_err)?;
+    Ok(hex::encode(scalar_to_be_bytes(commit_native(&inp))))
+}
+
+#[wasm_bindgen]
+pub fn derive_trader_id_wasm(commitment_key: &str) -> String {
+    let f = inner_derive_trader_id(commitment_key.as_bytes());
+    hex::encode(scalar_to_be_bytes(f))
+}
+
+// Avoid pulling in `serde-wasm-bindgen` as a separate dep — JSON-string the
+// payload and parse on the JS side.
+fn serde_wasm_bindgen_serialize(v: &serde_json::Value) -> Result<JsValue, JsError> {
+    let s = serde_json::to_string(v).map_err(js_err)?;
+    Ok(JsValue::from_str(&s))
+}

--- a/crates/dp-client/src/wasm.rs
+++ b/crates/dp-client/src/wasm.rs
@@ -53,7 +53,17 @@ pub fn compute_commitment_wasm(
     let trader_id = inner_derive_trader_id(commitment_key.as_bytes());
     let price_d = Decimal::from_str(price).map_err(js_err)?;
     let size_d = Decimal::from_str(size).map_err(js_err)?;
-    let salt_bytes = hex::decode(salt_hex.trim_start_matches("0x")).map_err(js_err)?;
+    let stripped = salt_hex
+        .strip_prefix("0x")
+        .or_else(|| salt_hex.strip_prefix("0X"))
+        .unwrap_or(salt_hex);
+    let salt_bytes = hex::decode(stripped).map_err(js_err)?;
+    if salt_bytes.len() != 32 {
+        return Err(JsError::new(&format!(
+            "salt must be exactly 32 bytes, got {}",
+            salt_bytes.len()
+        )));
+    }
     let salt_fr = crate::commitment::bytes_to_scalar(&salt_bytes);
     let inp = OrderCommitmentInput::from_decimals(trader_id, side, price_d, size_d, salt_fr)
         .map_err(js_err)?;

--- a/crates/dp-client/tests/interop.rs
+++ b/crates/dp-client/tests/interop.rs
@@ -1,0 +1,109 @@
+//! Cross-crate interop: lock down byte-level agreement with the engine-side
+//! crates the client must mirror.
+//!
+//!  - `dp_crypto::EciesDecrypter` must successfully decrypt the client's
+//!    ciphertext into the engine's `DecryptedOrder`.
+//!  - `dp_zk::pedersen` Poseidon commitments / trader-id derivations must
+//!    equal the client's copy field-element-for-field-element.
+//!  - `dp_zk::encoding::decimal_to_scalar` must equal the client's encoder
+//!    over the legal range.
+
+use ark_bn254::Fr;
+use k256::ecdsa::SigningKey;
+use rust_decimal::Decimal;
+
+use dp_client::commitment::{
+    bytes_to_scalar as client_bytes_to_scalar, commit_native as client_commit,
+    derive_trader_id as client_derive_trader_id, OrderCommitmentInput as ClientCommitmentInput,
+};
+use dp_client::encoding::decimal_to_scalar as client_decimal_to_scalar;
+use dp_client::encrypt::encrypt_order;
+use dp_client::payload::{OrderPayload, Side};
+
+use dp_crypto::{Decrypter, EciesDecrypter};
+use dp_zk::encoding::decimal_to_scalar as zk_decimal_to_scalar;
+use dp_zk::pedersen::{
+    commit_native as zk_commit, derive_trader_id as zk_derive_trader_id,
+    OrderCommitmentInput as ZkCommitmentInput,
+};
+
+#[tokio::test]
+async fn ecies_round_trip_decrypts_to_engine_struct() {
+    let sk = SigningKey::random(&mut rand::thread_rng());
+    let sk_bytes = sk.to_bytes();
+    let pk = sk.verifying_key().to_sec1_bytes();
+
+    let payload = OrderPayload {
+        pair: "ETH-USD".into(),
+        side: Side::Sell,
+        price: Decimal::new(180000, 2),
+        size: Decimal::new(5, 0),
+        commitment_key: "interop-key".into(),
+        ttl: 3_000_000_000,
+    };
+
+    let ciphertext = encrypt_order(&pk, &payload).unwrap();
+
+    // Engine-side decrypter materialised from the same secret key. The hex
+    // hop also covers the `0x`-prefix path through `EciesDecrypter::from_file`.
+    let key_hex = format!("0x{}", hex::encode(sk_bytes));
+    let mut tmp = tempfile::NamedTempFile::new().unwrap();
+    use std::io::Write;
+    tmp.write_all(key_hex.as_bytes()).unwrap();
+    tmp.flush().unwrap();
+    let dec = EciesDecrypter::from_file(tmp.path()).unwrap();
+    let recovered = dec.decrypt(&ciphertext).await.unwrap();
+
+    assert_eq!(recovered.pair, payload.pair);
+    assert_eq!(recovered.price, payload.price);
+    assert_eq!(recovered.size, payload.size);
+    assert_eq!(recovered.commitment_key, payload.commitment_key);
+    assert_eq!(recovered.ttl, payload.ttl);
+    assert_eq!(recovered.side, dp_types::Side::Sell);
+}
+
+#[test]
+fn poseidon_commit_matches_dp_zk() {
+    let trader_key = b"alice";
+    let salt_bytes = [0xab; 32];
+
+    let client_trader = client_derive_trader_id(trader_key);
+    let zk_trader = zk_derive_trader_id(trader_key).unwrap();
+    assert_eq!(client_trader, zk_trader, "trader_id mismatch");
+
+    let salt_fr = client_bytes_to_scalar(&salt_bytes);
+
+    for (side_u8, price_d, size_d) in [
+        (0u8, Decimal::from(100), Decimal::from(10)),
+        (1u8, Decimal::new(250000, 2), Decimal::new(15, 1)),
+        (0u8, Decimal::ZERO, Decimal::ZERO),
+    ] {
+        let c_in =
+            ClientCommitmentInput::from_decimals(client_trader, side_u8, price_d, size_d, salt_fr)
+                .unwrap();
+        let z_in =
+            ZkCommitmentInput::from_decimals(zk_trader, side_u8, price_d, size_d, salt_fr).unwrap();
+        assert_eq!(
+            client_commit(&c_in),
+            zk_commit(&z_in),
+            "commit_native diverges at side={side_u8} price={price_d} size={size_d}"
+        );
+    }
+}
+
+#[test]
+fn decimal_encoding_matches_dp_zk() {
+    let cases: &[Decimal] = &[
+        Decimal::ZERO,
+        Decimal::from(1),
+        Decimal::from(100),
+        Decimal::new(12_345, 2),
+        Decimal::new(99_999_999, 8),
+        Decimal::new(1, 8),
+    ];
+    for d in cases {
+        let a: Fr = client_decimal_to_scalar(*d).unwrap();
+        let b: Fr = zk_decimal_to_scalar(*d).unwrap();
+        assert_eq!(a, b, "decimal_to_scalar diverges at {d}");
+    }
+}


### PR DESCRIPTION
Ships a standalone crate providing CLI (`dp-trade`) and WASM bindings that build an ECIES-encrypted order payload, a Poseidon order-leg commitment for local record-keeping, and a placeholder proof slot. The engine recomputes its commitment server-side with a per-boot salt the client cannot know, and per-order ZK proofs are batch-level — so the commitment here is a local binding and the proof slot satisfies the API's non-empty/<=64KiB validation.

Poseidon parameters and the decimal encoder are copied (~80 LOC) from dp-zk rather than depended on, to keep ark-groth16 and rayon out of the WASM bundle. An interop test enforces field-element parity with dp-zk for commit_native, derive_trader_id, and decimal_to_scalar, and round-trips the ciphertext through dp-crypto's EciesDecrypter.

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new dp-client crate providing client-side order construction: deterministic commitments, decimal→scalar encoding, trader-ID derivation, ECIES encryption, and placeholder proof in submissions.
  * Added a CLI tool to build/format and optionally POST encrypted orders.
  * Added WebAssembly bindings for browser-based order preparation, encryption, commitment computation, and trader-ID derivation.

* **Tests**
  * Added unit and integration tests validating cross-crate compatibility for encryption, commitments, and encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->