### PR TITLE
Resolve CodeRabbit follow-ups from PR 57

### DIFF
--- a/contracts/src/Groth16Verifier.sol
+++ b/contracts/src/Groth16Verifier.sol
@@ -144,12 +144,15 @@ contract Groth16Verifier {
 
     /// @notice Batch-verify N Groth16 proofs against the committed VK.
     /// @dev Uses the standard random-linear-combination soundness trick:
-    ///      sample r = H(proofs‖inputs), accumulate
-    ///        Σ r_i · A_i in G1, Σ r_i · L_i in G1, Σ r_i · C_i in G1,
-    ///      and the constant-side accumulator (Σ r_i) · α in G1, then
-    ///      verify a single pairing of size 4. This catches any tampered
-    ///      proof with overwhelming probability and never accepts a forged
-    ///      sum that would slip past a naive ΣA·B aggregation.
+    ///      sample r = H(proofs‖inputs); the prover-specific A_i/B_i pairs
+    ///      stay as N separate pairings e(r_i · -A_i, B_i) because B_i
+    ///      varies per proof, while the constant-side G1 accumulators
+    ///        Σ r_i · L_i  (pairs against γ)
+    ///        Σ r_i · C_i  (pairs against δ)
+    ///        (Σ r_i) · α  (pairs against β)
+    ///      collapse into 3 terms. Final pairing has N+3 terms, not 4.
+    ///      Any tampered proof is rejected with overwhelming probability;
+    ///      a forged sum can't slip past since each B_i is checked separately.
     function verifyProofBatch(
         uint256[2][] calldata aArr,
         uint256[2][2][] calldata bArr,

--- a/contracts/test/Groth16Verifier.t.sol
+++ b/contracts/test/Groth16Verifier.t.sol
@@ -235,60 +235,40 @@ contract Groth16VerifierTest is Test {
     }
 
     // --- Constructor validation ---
+    //
+    // Each case mutates one VK field to the point-at-infinity and asserts the
+    // matching revert. The shared helper _expectInfinityRevert keeps the
+    // pattern (load VK → poison field → expect revert → redeploy) in one place.
 
     function test_constructor_rejectsAlpha1AtInfinity() public {
-        (
-            uint256[2] memory alpha1,
-            uint256[2][2] memory beta2,
-            uint256[2][2] memory gamma2,
-            uint256[2][2] memory delta2,
-            uint256[2][7] memory ic
-        ) = _loadVk();
-        alpha1 = [uint256(0), uint256(0)];
-        vm.expectRevert("alpha1 point at infinity");
-        new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
+        _expectInfinityRevert(VkField.Alpha1);
     }
 
     function test_constructor_rejectsBeta2AtInfinity() public {
-        (
-            uint256[2] memory alpha1,
-            uint256[2][2] memory beta2,
-            uint256[2][2] memory gamma2,
-            uint256[2][2] memory delta2,
-            uint256[2][7] memory ic
-        ) = _loadVk();
-        beta2 = [[uint256(0), uint256(0)], [uint256(0), uint256(0)]];
-        vm.expectRevert("beta2 point at infinity");
-        new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
+        _expectInfinityRevert(VkField.Beta2);
     }
 
     function test_constructor_rejectsGamma2AtInfinity() public {
-        (
-            uint256[2] memory alpha1,
-            uint256[2][2] memory beta2,
-            uint256[2][2] memory gamma2,
-            uint256[2][2] memory delta2,
-            uint256[2][7] memory ic
-        ) = _loadVk();
-        gamma2 = [[uint256(0), uint256(0)], [uint256(0), uint256(0)]];
-        vm.expectRevert("gamma2 point at infinity");
-        new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
+        _expectInfinityRevert(VkField.Gamma2);
     }
 
     function test_constructor_rejectsDelta2AtInfinity() public {
-        (
-            uint256[2] memory alpha1,
-            uint256[2][2] memory beta2,
-            uint256[2][2] memory gamma2,
-            uint256[2][2] memory delta2,
-            uint256[2][7] memory ic
-        ) = _loadVk();
-        delta2 = [[uint256(0), uint256(0)], [uint256(0), uint256(0)]];
-        vm.expectRevert("delta2 point at infinity");
-        new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
+        _expectInfinityRevert(VkField.Delta2);
     }
 
     function test_constructor_rejectsIcAtInfinity() public {
+        _expectInfinityRevert(VkField.Ic);
+    }
+
+    enum VkField {
+        Alpha1,
+        Beta2,
+        Gamma2,
+        Delta2,
+        Ic
+    }
+
+    function _expectInfinityRevert(VkField field) internal {
         (
             uint256[2] memory alpha1,
             uint256[2][2] memory beta2,
@@ -296,8 +276,29 @@ contract Groth16VerifierTest is Test {
             uint256[2][2] memory delta2,
             uint256[2][7] memory ic
         ) = _loadVk();
-        ic[3] = [uint256(0), uint256(0)];
-        vm.expectRevert("ic point at infinity");
+
+        uint256[2] memory zeroG1 = [uint256(0), uint256(0)];
+        uint256[2][2] memory zeroG2 = [zeroG1, zeroG1];
+
+        string memory expectedRevert;
+        if (field == VkField.Alpha1) {
+            alpha1 = zeroG1;
+            expectedRevert = "alpha1 point at infinity";
+        } else if (field == VkField.Beta2) {
+            beta2 = zeroG2;
+            expectedRevert = "beta2 point at infinity";
+        } else if (field == VkField.Gamma2) {
+            gamma2 = zeroG2;
+            expectedRevert = "gamma2 point at infinity";
+        } else if (field == VkField.Delta2) {
+            delta2 = zeroG2;
+            expectedRevert = "delta2 point at infinity";
+        } else {
+            ic[3] = zeroG1;
+            expectedRevert = "ic point at infinity";
+        }
+
+        vm.expectRevert(bytes(expectedRevert));
         new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
     }
 

--- a/contracts/test/Groth16Verifier.t.sol
+++ b/contracts/test/Groth16Verifier.t.sol
@@ -134,14 +134,8 @@ contract Groth16VerifierTest is Test {
     // --- Batch verification ---
 
     function test_verifyProofBatch_singleMatchesSingle() public view {
-        uint256[2][] memory aArr = new uint256[2][](1);
-        uint256[2][2][] memory bArr = new uint256[2][2][](1);
-        uint256[2][] memory cArr = new uint256[2][](1);
-        uint256[6][] memory inputs = new uint256[6][](1);
-        aArr[0] = proofA;
-        bArr[0] = proofB;
-        cArr[0] = proofC;
-        inputs[0] = proofInputs;
+        (uint256[2][] memory aArr, uint256[2][2][] memory bArr, uint256[2][] memory cArr, uint256[6][] memory inputs) =
+            _replicatedBatch(1);
         bool batchOk = verifier.verifyProofBatch(aArr, bArr, cArr, inputs);
         bool singleOk = verifier.verifyProof(proofA, proofB, proofC, proofInputs);
         assertEq(batchOk, singleOk, "batch(1) must match single verify");
@@ -153,32 +147,14 @@ contract Groth16VerifierTest is Test {
     // broken cross-term. The poisoned-proof test below covers the rejection
     // branch; tampering tests cover RLC sensitivity in aggregate.
     function test_verifyProofBatch_acceptsValid() public view {
-        uint256 n = 3;
-        uint256[2][] memory aArr = new uint256[2][](n);
-        uint256[2][2][] memory bArr = new uint256[2][2][](n);
-        uint256[2][] memory cArr = new uint256[2][](n);
-        uint256[6][] memory inputs = new uint256[6][](n);
-        for (uint256 i = 0; i < n; i++) {
-            aArr[i] = proofA;
-            bArr[i] = proofB;
-            cArr[i] = proofC;
-            inputs[i] = proofInputs;
-        }
+        (uint256[2][] memory aArr, uint256[2][2][] memory bArr, uint256[2][] memory cArr, uint256[6][] memory inputs) =
+            _replicatedBatch(3);
         assertTrue(verifier.verifyProofBatch(aArr, bArr, cArr, inputs));
     }
 
     function test_verifyProofBatch_rejectsAnyInvalid() public {
-        uint256 n = 3;
-        uint256[2][] memory aArr = new uint256[2][](n);
-        uint256[2][2][] memory bArr = new uint256[2][2][](n);
-        uint256[2][] memory cArr = new uint256[2][](n);
-        uint256[6][] memory inputs = new uint256[6][](n);
-        for (uint256 i = 0; i < n; i++) {
-            aArr[i] = proofA;
-            bArr[i] = proofB;
-            cArr[i] = proofC;
-            inputs[i] = proofInputs;
-        }
+        (uint256[2][] memory aArr, uint256[2][2][] memory bArr, uint256[2][] memory cArr, uint256[6][] memory inputs) =
+            _replicatedBatch(3);
         // Poison the middle proof's public input.
         inputs[1][1] ^= 1;
         try verifier.verifyProofBatch(aArr, bArr, cArr, inputs) returns (bool ok) {
@@ -218,17 +194,8 @@ contract Groth16VerifierTest is Test {
     }
 
     function test_verifyProofBatch_inputOverflow_reverts() public {
-        uint256 n = 2;
-        uint256[2][] memory aArr = new uint256[2][](n);
-        uint256[2][2][] memory bArr = new uint256[2][2][](n);
-        uint256[2][] memory cArr = new uint256[2][](n);
-        uint256[6][] memory inputs = new uint256[6][](n);
-        for (uint256 i = 0; i < n; i++) {
-            aArr[i] = proofA;
-            bArr[i] = proofB;
-            cArr[i] = proofC;
-            inputs[i] = proofInputs;
-        }
+        (uint256[2][] memory aArr, uint256[2][2][] memory bArr, uint256[2][] memory cArr, uint256[6][] memory inputs) =
+            _replicatedBatch(2);
         inputs[1][3] = type(uint256).max;
         vm.expectRevert("input overflow");
         verifier.verifyProofBatch(aArr, bArr, cArr, inputs);
@@ -300,6 +267,30 @@ contract Groth16VerifierTest is Test {
 
         vm.expectRevert(bytes(expectedRevert));
         new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
+    }
+
+    /// @dev Build a length-N batch where every entry replays the cached fixture.
+    /// Used by the batch tests that don't care about per-proof distinctness.
+    function _replicatedBatch(uint256 n)
+        internal
+        view
+        returns (
+            uint256[2][] memory aArr,
+            uint256[2][2][] memory bArr,
+            uint256[2][] memory cArr,
+            uint256[6][] memory inputs
+        )
+    {
+        aArr = new uint256[2][](n);
+        bArr = new uint256[2][2][](n);
+        cArr = new uint256[2][](n);
+        inputs = new uint256[6][](n);
+        for (uint256 i = 0; i < n; i++) {
+            aArr[i] = proofA;
+            bArr[i] = proofB;
+            cArr[i] = proofC;
+            inputs[i] = proofInputs;
+        }
     }
 
     // --- Fixture loaders ---

--- a/contracts/test/Groth16Verifier.t.sol
+++ b/contracts/test/Groth16Verifier.t.sol
@@ -37,13 +37,26 @@ contract Groth16VerifierTest is Test {
         assertTrue(verifier.verifyProof(proofA, proofB, proofC, proofInputs));
     }
 
-    function test_noSetVerifyingKeyFunctionExists() public {
-        // The verifier must not expose any way to mutate the VK.
-        // Confirm the legacy selector is not present on the deployed bytecode.
+    function test_noSetVerifyingKeyFunctionExists() public view {
+        // The verifier must not expose any way to mutate the VK. A bare
+        // staticcall would also "fail" if the function existed but reverted
+        // on missing args, so we scan deployed bytecode for the selector.
         bytes4 legacy =
             bytes4(keccak256("setVerifyingKey(uint256[2],uint256[2][2],uint256[2][2],uint256[2][2],uint256[2][])"));
-        (bool ok,) = address(verifier).staticcall(abi.encodeWithSelector(legacy));
-        assertFalse(ok, "legacy setter still callable");
+        bytes memory code = address(verifier).code;
+        assertGt(code.length, 0, "verifier has no code");
+        bool found = _containsSelector(code, legacy);
+        assertFalse(found, "legacy setter selector present in bytecode");
+    }
+
+    function _containsSelector(bytes memory code, bytes4 sel) internal pure returns (bool) {
+        if (code.length < 4) return false;
+        for (uint256 i = 0; i + 4 <= code.length; i++) {
+            if (code[i] == sel[0] && code[i + 1] == sel[1] && code[i + 2] == sel[2] && code[i + 3] == sel[3]) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // --- Single proof ---

--- a/crates/dp-zk-cli/src/bin/dp-zk-fixture-gen.rs
+++ b/crates/dp-zk-cli/src/bin/dp-zk-fixture-gen.rs
@@ -100,7 +100,7 @@ fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let mut rng = StdRng::seed_from_u64(args.seed);
     let (pk, vk) = setup(args.batch_size, &mut rng)?;
 
-    let sol_vk = dp_zk::keys::vk_to_solidity(&vk);
+    let sol_vk = dp_zk::keys::vk_to_solidity(&vk)?;
     let vk_json = serde_json::to_string_pretty(&sol_vk)?;
     fs::write(args.out_dir.join("vk.json"), vk_json.as_bytes())?;
 

--- a/crates/dp-zk-cli/src/bin/dp-zk-vk-export.rs
+++ b/crates/dp-zk-cli/src/bin/dp-zk-vk-export.rs
@@ -22,7 +22,7 @@ struct Args {
 
 fn run(args: Args) -> Result<(), Box<dyn std::error::Error>> {
     let vk = dp_zk::keys::read_vk(&args.keys_dir)?;
-    let sol = dp_zk::keys::vk_to_solidity(&vk);
+    let sol = dp_zk::keys::vk_to_solidity(&vk)?;
     let json = serde_json::to_string_pretty(&sol)?;
 
     match args.out {

--- a/crates/dp-zk/src/keys/solidity.rs
+++ b/crates/dp-zk/src/keys/solidity.rs
@@ -11,6 +11,8 @@ use ark_ff::{BigInteger, PrimeField};
 use ark_groth16::VerifyingKey;
 use serde::Serialize;
 
+use crate::ZkError;
+
 #[derive(Clone, Debug, Serialize)]
 pub struct SolidityVk {
     pub alpha1: [String; 2],
@@ -30,27 +32,35 @@ pub fn fq_to_hex<F: PrimeField>(f: &F) -> String {
     s
 }
 
-fn g1_xy(p: &G1Affine) -> [String; 2] {
-    let (x, y) = p.xy().expect("G1 point at infinity in VK");
-    [fq_to_hex(&x), fq_to_hex(&y)]
+fn g1_xy(p: &G1Affine) -> Result<[String; 2], ZkError> {
+    let (x, y) = p
+        .xy()
+        .ok_or_else(|| ZkError::Serialize("G1 point at infinity in VK".into()))?;
+    Ok([fq_to_hex(&x), fq_to_hex(&y)])
 }
 
-fn g2_xy(p: &G2Affine) -> [[String; 2]; 2] {
-    let (x, y) = p.xy().expect("G2 point at infinity in VK");
-    [
+fn g2_xy(p: &G2Affine) -> Result<[[String; 2]; 2], ZkError> {
+    let (x, y) = p
+        .xy()
+        .ok_or_else(|| ZkError::Serialize("G2 point at infinity in VK".into()))?;
+    Ok([
         [fq_to_hex(&x.c1), fq_to_hex(&x.c0)],
         [fq_to_hex(&y.c1), fq_to_hex(&y.c0)],
-    ]
+    ])
 }
 
-pub fn vk_to_solidity(vk: &VerifyingKey<Bn254>) -> SolidityVk {
-    SolidityVk {
-        alpha1: g1_xy(&vk.alpha_g1),
-        beta2: g2_xy(&vk.beta_g2),
-        gamma2: g2_xy(&vk.gamma_g2),
-        delta2: g2_xy(&vk.delta_g2),
-        ic: vk.gamma_abc_g1.iter().map(g1_xy).collect(),
-    }
+pub fn vk_to_solidity(vk: &VerifyingKey<Bn254>) -> Result<SolidityVk, ZkError> {
+    Ok(SolidityVk {
+        alpha1: g1_xy(&vk.alpha_g1)?,
+        beta2: g2_xy(&vk.beta_g2)?,
+        gamma2: g2_xy(&vk.gamma_g2)?,
+        delta2: g2_xy(&vk.delta_g2)?,
+        ic: vk
+            .gamma_abc_g1
+            .iter()
+            .map(g1_xy)
+            .collect::<Result<Vec<_>, _>>()?,
+    })
 }
 
 #[cfg(test)]
@@ -84,7 +94,7 @@ mod tests {
     #[test]
     fn g1_xy_valid_point() {
         let g = G1Affine::generator();
-        let [x, y] = g1_xy(&g);
+        let [x, y] = g1_xy(&g).expect("generator has affine coords");
         assert!(x.starts_with("0x"));
         assert!(y.starts_with("0x"));
         assert_eq!(x.len(), 66);
@@ -92,15 +102,15 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "G1 point at infinity")]
-    fn g1_xy_panics_on_infinity() {
-        g1_xy(&G1Affine::zero());
+    fn g1_xy_errors_on_infinity() {
+        let err = g1_xy(&G1Affine::zero()).expect_err("infinity must error");
+        assert!(matches!(err, ZkError::Serialize(ref m) if m.contains("G1 point at infinity")));
     }
 
     #[test]
     fn g2_xy_valid_point() {
         let g = G2Affine::generator();
-        let coords = g2_xy(&g);
+        let coords = g2_xy(&g).expect("generator has affine coords");
         for pair in &coords {
             for s in pair {
                 assert!(s.starts_with("0x"));
@@ -110,9 +120,9 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "G2 point at infinity")]
-    fn g2_xy_panics_on_infinity() {
-        g2_xy(&G2Affine::zero());
+    fn g2_xy_errors_on_infinity() {
+        let err = g2_xy(&G2Affine::zero()).expect_err("infinity must error");
+        assert!(matches!(err, ZkError::Serialize(ref m) if m.contains("G2 point at infinity")));
     }
 
     #[test]
@@ -121,7 +131,7 @@ mod tests {
         use ark_std::rand::SeedableRng;
         let mut rng = StdRng::seed_from_u64(99);
         let (_, vk) = crate::circuit::setup(1, &mut rng).expect("setup");
-        let sol = vk_to_solidity(&vk);
+        let sol = vk_to_solidity(&vk).expect("convert VK");
 
         assert_eq!(sol.alpha1.len(), 2);
         assert_eq!(sol.beta2.len(), 2);
@@ -136,5 +146,16 @@ mod tests {
         let json = serde_json::to_string(&sol).expect("serialize");
         assert!(json.contains("alpha1"));
         assert!(json.contains("ic"));
+    }
+
+    #[test]
+    fn vk_to_solidity_errors_on_infinity_vk() {
+        use ark_std::rand::rngs::StdRng;
+        use ark_std::rand::SeedableRng;
+        let mut rng = StdRng::seed_from_u64(7);
+        let (_, mut vk) = crate::circuit::setup(1, &mut rng).expect("setup");
+        vk.alpha_g1 = G1Affine::zero();
+        let err = vk_to_solidity(&vk).expect_err("must reject infinity");
+        assert!(matches!(err, ZkError::Serialize(_)));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up cleanup for the CodeRabbit review on #57 (which merged with a few items unresolved). Focus areas: test reliability, code duplication, and removing remaining panic paths in the VK-conversion helper.

Five atomic commits:

| Commit | Concern |
|---|---|
| Return Result from vk_to_solidity | Replace `.expect()` in `g1_xy`/`g2_xy`/`vk_to_solidity` with `ZkError::Serialize`; CLI bins propagate via `?` (exit 2 on malformed VK) |
| Correct batch-verify docstring | Comment said "single pairing of size 4" but code emits N+3 pairing terms; rewrite to match algorithm |
| Detect legacy setter via bytecode scan | Old `test_noSetVerifyingKeyFunctionExists` returned `false` even when the function existed but reverted on missing args. New version scans deployed bytecode for the selector — distinguishes "missing" from "present-but-reverting" |
| Dedupe constructor-rejection tests | Five near-identical `rejects*AtInfinity` tests collapse onto a `VkField` enum + `_expectInfinityRevert` helper |
| Dedupe batch test scaffolding | Four batch tests rebuilt identical N-array fixtures; factored into `_replicatedBatch(n)` |

## Out of scope (deferred)

- **batchId/auctionId proof binding** (flagged Critical by CodeRabbit). Real fix requires extending the circuit public inputs (currently `[match_count, commitments_root, notionals_root, min_size, min_price, position_limit]`), regenerating VK + proof fixtures, and reconciling bytes32→Fr encoding. Will land as a follow-up PR per scoping discussion.

## Test plan

- [x] `cargo test -p dp-zk --lib` — 26/26 pass (includes new `vk_to_solidity_errors_on_infinity_vk`)
- [x] `cargo clippy -p dp-zk -p dp-zk-cli --bin dp-zk-vk-export --bin dp-zk-fixture-gen -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `forge test` — 63/63 pass (21/21 verifier tests including new bytecode-scan check)
- [ ] Manual smoke test of `dp-zk-vk-export` against a real VK (optional)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for batch verification soundness argument.

* **Bug Fixes**
  * Improved error handling in key conversion processes to properly propagate errors instead of panicking.

* **Tests**
  * Refactored verification test suite with improved helper functions for better maintainability and consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/58)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->