### PR TITLE
Add VerifierProxy for governance-swappable VK rotation

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -5,6 +5,7 @@ import {Script, console} from "forge-std/Script.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {DarkPool} from "../src/DarkPool.sol";
 import {Groth16Verifier} from "../src/Groth16Verifier.sol";
+import {VerifierProxy} from "../src/VerifierProxy.sol";
 
 contract DeployScript is Script {
     using stdJson for string;
@@ -13,6 +14,17 @@ contract DeployScript is Script {
         address feeRecipient = vm.envAddress("FEE_RECIPIENT");
         uint256 deployerKey = vm.envUint("PRIVATE_KEY");
         string memory vkPath = vm.envString("VK_JSON_PATH");
+        address deployer = vm.addr(deployerKey);
+        // VERIFIER_GOVERNOR: address that can rotate the verifier backend.
+        // In production this should be a TimelockController (or a multisig
+        // fronting one); the default falls back to the deployer for local
+        // and CI deploys. On mainnet we refuse the silent fallback — a single
+        // EOA holding VK-rotation rights would be a governance footgun.
+        require(
+            block.chainid != 1 || vm.envExists("VERIFIER_GOVERNOR"),
+            "VERIFIER_GOVERNOR must be set on mainnet"
+        );
+        address governor = vm.envOr("VERIFIER_GOVERNOR", deployer);
 
         (
             uint256[2] memory alpha1,
@@ -27,7 +39,11 @@ contract DeployScript is Script {
         Groth16Verifier verifier = new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
         console.log("Groth16Verifier:", address(verifier));
 
-        DarkPool pool = new DarkPool(address(verifier), feeRecipient);
+        VerifierProxy proxy = new VerifierProxy(address(verifier), governor);
+        console.log("VerifierProxy:", address(proxy));
+        console.log("VerifierProxy owner:", governor);
+
+        DarkPool pool = new DarkPool(address(proxy), feeRecipient);
         console.log("DarkPool:", address(pool));
 
         vm.stopBroadcast();

--- a/contracts/src/DarkPool.sol
+++ b/contracts/src/DarkPool.sol
@@ -34,6 +34,9 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
 
     constructor(address verifier_, address feeRecipient_) Ownable(msg.sender) {
         require(verifier_ != address(0), "zero verifier");
+        // The verifier slot is immutable — a non-contract address would brick
+        // submitBatch with no recovery path, so reject it at construction.
+        require(verifier_.code.length > 0, "verifier has no code");
         require(feeRecipient_ != address(0), "zero fee recipient");
         verifier = IVerifier(verifier_);
         feeRecipient = feeRecipient_;

--- a/contracts/src/DarkPool.sol
+++ b/contracts/src/DarkPool.sol
@@ -7,7 +7,7 @@ import {ReentrancyGuard} from "@openzeppelin/contracts/utils/ReentrancyGuard.sol
 import {Pausable} from "@openzeppelin/contracts/utils/Pausable.sol";
 import {Ownable2Step, Ownable} from "@openzeppelin/contracts/access/Ownable2Step.sol";
 import {IDarkPool} from "./interfaces/IDarkPool.sol";
-import {Groth16Verifier} from "./Groth16Verifier.sol";
+import {IVerifier} from "./interfaces/IVerifier.sol";
 
 contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
     using SafeERC20 for IERC20;
@@ -16,7 +16,7 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
     uint256 public constant MAX_BATCH_SIZE = 256;
     uint256 private constant BPS_DENOMINATOR = 10_000;
 
-    Groth16Verifier public immutable verifier;
+    IVerifier public immutable verifier;
 
     mapping(address => bool) public operators;
     mapping(bytes32 => bool) public settled;
@@ -35,7 +35,7 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
     constructor(address verifier_, address feeRecipient_) Ownable(msg.sender) {
         require(verifier_ != address(0), "zero verifier");
         require(feeRecipient_ != address(0), "zero fee recipient");
-        verifier = Groth16Verifier(verifier_);
+        verifier = IVerifier(verifier_);
         feeRecipient = feeRecipient_;
     }
 

--- a/contracts/src/Groth16Verifier.sol
+++ b/contracts/src/Groth16Verifier.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {IVerifier} from "./interfaces/IVerifier.sol";
+
 /// @title Groth16 verifier (BN254) with an immutable verifying key.
 /// @notice The verifying key is bound at construction. Upgrades require
 ///         deploying a new verifier and rewiring downstream contracts.
@@ -11,7 +13,7 @@ pragma solidity ^0.8.24;
 ///         when the precompile rejects them. G2 subgroup self-checks are
 ///         omitted intentionally (a pairing per coord would balloon deploy
 ///         gas) — the trusted-setup ceremony is the source of truth.
-contract Groth16Verifier {
+contract Groth16Verifier is IVerifier {
     uint256 internal constant SNARK_SCALAR_FIELD =
         21888242871839275222246405745257275088548364400416034343698204186575808495617;
     uint256 internal constant PRIME_Q = 21888242871839275222246405745257275088696311157297823662689037894645226208583;
@@ -128,7 +130,7 @@ contract Groth16Verifier {
         uint256[2][2] calldata b,
         uint256[2] calldata c,
         uint256[NUM_PUBLIC_INPUTS] calldata input
-    ) external view virtual returns (bool) {
+    ) external view virtual override returns (bool) {
         for (uint256 i = 0; i < NUM_PUBLIC_INPUTS; i++) {
             require(input[i] < SNARK_SCALAR_FIELD, "input overflow");
         }
@@ -158,7 +160,7 @@ contract Groth16Verifier {
         uint256[2][2][] calldata bArr,
         uint256[2][] calldata cArr,
         uint256[NUM_PUBLIC_INPUTS][] calldata inputs
-    ) external view virtual returns (bool) {
+    ) external view virtual override returns (bool) {
         uint256 n = aArr.length;
         require(n > 0, "empty batch");
         require(n <= MAX_BATCH, "batch too large");

--- a/contracts/src/VerifierProxy.sol
+++ b/contracts/src/VerifierProxy.sol
@@ -36,6 +36,10 @@ contract VerifierProxy is IVerifier, Ownable2Step {
 
     function _setVerifier(address newVerifier, address old) internal {
         require(newVerifier != address(0), "zero verifier");
+        // Self-assignment would make verifyProof() recurse into the proxy until
+        // OOG. Recoverable via another rotation, but a clear governance footgun
+        // — reject it up front.
+        require(newVerifier != address(this), "self verifier");
         require(newVerifier.code.length > 0, "verifier has no code");
         verifier = IVerifier(newVerifier);
         emit VerifierUpdated(old, newVerifier);

--- a/contracts/src/VerifierProxy.sol
+++ b/contracts/src/VerifierProxy.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Ownable2Step, Ownable} from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import {IVerifier} from "./interfaces/IVerifier.sol";
+
+/// @title Governance-swappable router in front of an immutable Groth16Verifier.
+/// @notice DarkPool talks to this proxy via a fixed address; the proxy holds a
+///         mutable pointer to a concrete IVerifier implementation. Rotating the
+///         verifying key is "deploy a fresh Groth16Verifier(newVk) → call
+///         setVerifier(newAddr)" — DarkPool itself never redeploys.
+/// @dev    This is a typed router, NOT an EIP-1967 delegatecall proxy. Each
+///         backend is a frozen, independently auditable artifact tied to one
+///         VK; governance moves the pointer, not the bytes. The proxy is
+///         intentionally minimal: no fallback, no storage writes during
+///         forwarding, no timelock baked in. Compose timelocks externally via
+///         Ownable2Step.transferOwnership(timelock).
+contract VerifierProxy is IVerifier, Ownable2Step {
+    IVerifier public verifier;
+
+    event VerifierUpdated(address indexed oldVerifier, address indexed newVerifier);
+
+    constructor(address initialVerifier, address initialOwner) Ownable(initialOwner) {
+        _setVerifier(initialVerifier, address(0));
+    }
+
+    /// @notice Point the proxy at a new IVerifier implementation.
+    /// @dev Code-bearing check catches EOAs and self-destructed contracts, but
+    ///      cannot validate that `newVerifier` actually implements IVerifier
+    ///      or carries the intended VK — that's a governance review concern.
+    function setVerifier(address newVerifier) external onlyOwner {
+        address old = address(verifier);
+        require(newVerifier != old, "same verifier");
+        _setVerifier(newVerifier, old);
+    }
+
+    function _setVerifier(address newVerifier, address old) internal {
+        require(newVerifier != address(0), "zero verifier");
+        require(newVerifier.code.length > 0, "verifier has no code");
+        verifier = IVerifier(newVerifier);
+        emit VerifierUpdated(old, newVerifier);
+    }
+
+    function verifyProof(
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[6] calldata input
+    ) external view override returns (bool) {
+        return verifier.verifyProof(a, b, c, input);
+    }
+
+    function verifyProofBatch(
+        uint256[2][] calldata aArr,
+        uint256[2][2][] calldata bArr,
+        uint256[2][] calldata cArr,
+        uint256[6][] calldata inputs
+    ) external view override returns (bool) {
+        return verifier.verifyProofBatch(aArr, bArr, cArr, inputs);
+    }
+}

--- a/contracts/src/interfaces/IVerifier.sol
+++ b/contracts/src/interfaces/IVerifier.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title Groth16 verifier surface used by DarkPool and the governance proxy.
+/// @dev The 6-element public-input shape is part of the interface. A circuit
+///      revision that changes the public-input count is a hard fork — the
+///      governance proxy's contract-address swap cannot paper over it.
+interface IVerifier {
+    function verifyProof(
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[6] calldata input
+    ) external view returns (bool);
+
+    function verifyProofBatch(
+        uint256[2][] calldata aArr,
+        uint256[2][2][] calldata bArr,
+        uint256[2][] calldata cArr,
+        uint256[6][] calldata inputs
+    ) external view returns (bool);
+}

--- a/contracts/test/DarkPool.t.sol
+++ b/contracts/test/DarkPool.t.sol
@@ -350,6 +350,13 @@ contract DarkPoolTest is Test {
         new DarkPool(address(0), feeRecipient);
     }
 
+    function test_constructor_eoaVerifier_reverts() public {
+        // The verifier slot is immutable, so a non-contract address (EOA or
+        // never-deployed) would permanently brick submitBatch.
+        vm.expectRevert("verifier has no code");
+        new DarkPool(address(0xBEEF), feeRecipient);
+    }
+
     function test_constructor_zeroFeeRecipient_reverts() public {
         vm.expectRevert("zero fee recipient");
         new DarkPool(address(verifier), address(0));

--- a/contracts/test/DarkPool.t.sol
+++ b/contracts/test/DarkPool.t.sol
@@ -4,30 +4,32 @@ pragma solidity ^0.8.24;
 import {Test} from "forge-std/Test.sol";
 import {DarkPool} from "../src/DarkPool.sol";
 import {IDarkPool} from "../src/interfaces/IDarkPool.sol";
-import {Groth16Verifier} from "../src/Groth16Verifier.sol";
+import {IVerifier} from "../src/interfaces/IVerifier.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
 
-contract MockVerifier is Groth16Verifier {
+contract MockVerifier is IVerifier {
     bool public shouldReturn;
 
-    constructor(bool shouldReturn_) Groth16Verifier(_dummyG1(), _dummyG2(), _dummyG2(), _dummyG2(), _dummyIc()) {
+    constructor(bool shouldReturn_) {
         shouldReturn = shouldReturn_;
     }
 
     function verifyProof(uint256[2] calldata, uint256[2][2] calldata, uint256[2] calldata, uint256[6] calldata)
         external
         view
-        override
         returns (bool)
     {
         return shouldReturn;
     }
 
-    function _dummyG1() private pure returns (uint256[2] memory a) { a = [uint256(1), 2]; }
-    function _dummyG2() private pure returns (uint256[2][2] memory g) { g = [[uint256(1), 2], [uint256(3), 4]]; }
-    function _dummyIc() private pure returns (uint256[2][7] memory ic) {
-        for (uint256 i = 0; i < 7; i++) ic[i] = [uint256(i + 1), uint256(i + 1)];
+    function verifyProofBatch(
+        uint256[2][] calldata,
+        uint256[2][2][] calldata,
+        uint256[2][] calldata,
+        uint256[6][] calldata
+    ) external view returns (bool) {
+        return shouldReturn;
     }
 }
 

--- a/contracts/test/Groth16Verifier.t.sol
+++ b/contracts/test/Groth16Verifier.t.sol
@@ -1,23 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {Test} from "forge-std/Test.sol";
-import {stdJson} from "forge-std/StdJson.sol";
 import {Groth16Verifier} from "../src/Groth16Verifier.sol";
+import {VkFixture} from "./VkFixture.sol";
 
-contract Groth16VerifierTest is Test {
-    using stdJson for string;
-
+contract Groth16VerifierTest is VkFixture {
     uint256 internal constant SNARK_SCALAR_FIELD =
         21888242871839275222246405745257275088548364400416034343698204186575808495617;
 
     Groth16Verifier verifier;
-
-    // Cached fixture proof for reuse across tests.
-    uint256[2] proofA;
-    uint256[2][2] proofB;
-    uint256[2] proofC;
-    uint256[6] proofInputs;
 
     function setUp() public {
         (
@@ -28,7 +19,7 @@ contract Groth16VerifierTest is Test {
             uint256[2][7] memory ic
         ) = _loadVk();
         verifier = new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
-        _loadProofInto(proofA, proofB, proofC, proofInputs);
+        _loadFixtureProof();
     }
 
     // --- Constructor / immutability ---
@@ -269,79 +260,4 @@ contract Groth16VerifierTest is Test {
         new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
     }
 
-    /// @dev Build a length-N batch where every entry replays the cached fixture.
-    /// Used by the batch tests that don't care about per-proof distinctness.
-    function _replicatedBatch(uint256 n)
-        internal
-        view
-        returns (
-            uint256[2][] memory aArr,
-            uint256[2][2][] memory bArr,
-            uint256[2][] memory cArr,
-            uint256[6][] memory inputs
-        )
-    {
-        aArr = new uint256[2][](n);
-        bArr = new uint256[2][2][](n);
-        cArr = new uint256[2][](n);
-        inputs = new uint256[6][](n);
-        for (uint256 i = 0; i < n; i++) {
-            aArr[i] = proofA;
-            bArr[i] = proofB;
-            cArr[i] = proofC;
-            inputs[i] = proofInputs;
-        }
-    }
-
-    // --- Fixture loaders ---
-
-    function _loadVk()
-        internal
-        view
-        returns (
-            uint256[2] memory alpha1,
-            uint256[2][2] memory beta2,
-            uint256[2][2] memory gamma2,
-            uint256[2][2] memory delta2,
-            uint256[2][7] memory ic
-        )
-    {
-        string memory json = vm.readFile("./test/fixtures/vk.json");
-        alpha1[0] = json.readUint(".alpha1[0]");
-        alpha1[1] = json.readUint(".alpha1[1]");
-        _loadG2(json, ".beta2", beta2);
-        _loadG2(json, ".gamma2", gamma2);
-        _loadG2(json, ".delta2", delta2);
-        for (uint256 i = 0; i < 7; i++) {
-            ic[i][0] = json.readUint(string.concat(".ic[", vm.toString(i), "][0]"));
-            ic[i][1] = json.readUint(string.concat(".ic[", vm.toString(i), "][1]"));
-        }
-    }
-
-    function _loadG2(string memory json, string memory base, uint256[2][2] memory g) internal pure {
-        g[0][0] = json.readUint(string.concat(base, "[0][0]"));
-        g[0][1] = json.readUint(string.concat(base, "[0][1]"));
-        g[1][0] = json.readUint(string.concat(base, "[1][0]"));
-        g[1][1] = json.readUint(string.concat(base, "[1][1]"));
-    }
-
-    function _loadProofInto(
-        uint256[2] storage a,
-        uint256[2][2] storage b,
-        uint256[2] storage c,
-        uint256[6] storage input
-    ) internal {
-        string memory json = vm.readFile("./test/fixtures/proof.json");
-        a[0] = json.readUint(".a[0]");
-        a[1] = json.readUint(".a[1]");
-        b[0][0] = json.readUint(".b[0][0]");
-        b[0][1] = json.readUint(".b[0][1]");
-        b[1][0] = json.readUint(".b[1][0]");
-        b[1][1] = json.readUint(".b[1][1]");
-        c[0] = json.readUint(".c[0]");
-        c[1] = json.readUint(".c[1]");
-        for (uint256 i = 0; i < 6; i++) {
-            input[i] = json.readUint(string.concat(".public_inputs[", vm.toString(i), "]"));
-        }
-    }
 }

--- a/contracts/test/VerifierProxy.t.sol
+++ b/contracts/test/VerifierProxy.t.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Groth16Verifier} from "../src/Groth16Verifier.sol";
+import {VerifierProxy} from "../src/VerifierProxy.sol";
+import {IVerifier} from "../src/interfaces/IVerifier.sol";
+import {VkFixture} from "./VkFixture.sol";
+
+contract VerifierProxyTest is VkFixture {
+    uint256 internal constant SNARK_SCALAR_FIELD =
+        21888242871839275222246405745257275088548364400416034343698204186575808495617;
+
+    Groth16Verifier backend;
+    VerifierProxy proxy;
+
+    address owner = address(this);
+
+    event VerifierUpdated(address indexed oldVerifier, address indexed newVerifier);
+
+    function setUp() public {
+        (
+            uint256[2] memory alpha1,
+            uint256[2][2] memory beta2,
+            uint256[2][2] memory gamma2,
+            uint256[2][2] memory delta2,
+            uint256[2][7] memory ic
+        ) = _loadVk();
+        backend = new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
+        proxy = new VerifierProxy(address(backend), owner);
+        _loadFixtureProof();
+    }
+
+    // --- Constructor ---
+
+    function test_constructor_setsBackend() public view {
+        assertEq(address(proxy.verifier()), address(backend));
+    }
+
+    function test_constructor_setsOwner() public view {
+        assertEq(proxy.owner(), owner);
+    }
+
+    function test_constructor_rejectsZeroVerifier() public {
+        vm.expectRevert("zero verifier");
+        new VerifierProxy(address(0), owner);
+    }
+
+    function test_constructor_rejectsEoaVerifier() public {
+        // An address with no code (EOA, or never-deployed) must fail the
+        // code-bearing check rather than silently install a dead pointer.
+        vm.expectRevert("verifier has no code");
+        new VerifierProxy(address(0xBEEF), owner);
+    }
+
+    function test_constructor_rejectsZeroOwner() public {
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableInvalidOwner.selector, address(0)));
+        new VerifierProxy(address(backend), address(0));
+    }
+
+    function test_constructor_emitsVerifierUpdated() public {
+        vm.expectEmit(true, true, false, false);
+        emit VerifierUpdated(address(0), address(backend));
+        new VerifierProxy(address(backend), owner);
+    }
+
+    // --- Forwarding ---
+
+    function test_verifyProof_forwardsToBackend() public view {
+        bool viaProxy = proxy.verifyProof(proofA, proofB, proofC, proofInputs);
+        bool direct = backend.verifyProof(proofA, proofB, proofC, proofInputs);
+        assertTrue(direct, "fixture must verify on the backend");
+        assertEq(viaProxy, direct, "proxy result must match backend");
+    }
+
+    function test_verifyProof_rejectsTamperedProof() public {
+        uint256[2] memory tamperedA = [proofA[0] ^ 1, proofA[1]];
+        // Tampered curve coords usually fail the precompile (revert) rather
+        // than return false. Either is acceptable proof of rejection.
+        try proxy.verifyProof(tamperedA, proofB, proofC, proofInputs) returns (bool ok) {
+            assertFalse(ok, "tampered proof must not verify through proxy");
+        } catch {
+            // precompile rejected — also a valid reject.
+        }
+    }
+
+    function test_verifyProofBatch_acceptsValid() public view {
+        (uint256[2][] memory aArr, uint256[2][2][] memory bArr, uint256[2][] memory cArr, uint256[6][] memory inputs) =
+            _replicatedBatch(3);
+        assertTrue(proxy.verifyProofBatch(aArr, bArr, cArr, inputs));
+    }
+
+    // --- setVerifier ---
+
+    function test_setVerifier_onlyOwner() public {
+        address attacker = address(0xdead);
+        vm.prank(attacker);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, attacker));
+        proxy.setVerifier(address(backend));
+    }
+
+    function test_setVerifier_rejectsZero() public {
+        vm.expectRevert("zero verifier");
+        proxy.setVerifier(address(0));
+    }
+
+    function test_setVerifier_rejectsEoa() public {
+        vm.expectRevert("verifier has no code");
+        proxy.setVerifier(address(0xBEEF));
+    }
+
+    function test_setVerifier_rejectsSameVerifier() public {
+        // No-op rotation must revert rather than fire a spurious VerifierUpdated
+        // event that would fool monitoring of governance rotations.
+        vm.expectRevert("same verifier");
+        proxy.setVerifier(address(backend));
+    }
+
+    function test_setVerifier_swapsBackend() public {
+        // Build a second Groth16Verifier with a structurally valid but
+        // semantically different VK by swapping two IC points. Both points
+        // are still on the curve (they came from the same trusted setup),
+        // so the precompile won't reject; the pairing simply won't equal 1
+        // for the original proof.
+        (
+            uint256[2] memory alpha1,
+            uint256[2][2] memory beta2,
+            uint256[2][2] memory gamma2,
+            uint256[2][2] memory delta2,
+            uint256[2][7] memory ic
+        ) = _loadVk();
+        uint256[2] memory tmp = ic[1];
+        ic[1] = ic[2];
+        ic[2] = tmp;
+        Groth16Verifier altered = new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
+
+        assertTrue(proxy.verifyProof(proofA, proofB, proofC, proofInputs), "sanity: proof verifies pre-swap");
+
+        proxy.setVerifier(address(altered));
+        assertEq(address(proxy.verifier()), address(altered));
+
+        try proxy.verifyProof(proofA, proofB, proofC, proofInputs) returns (bool ok) {
+            assertFalse(ok, "original proof must not verify under swapped VK");
+        } catch {
+            // pairing precompile rejected — also a valid reject.
+        }
+    }
+
+    function test_setVerifier_emitsVerifierUpdated() public {
+        Groth16Verifier next = _deployFreshBackend();
+        vm.expectEmit(true, true, false, false);
+        emit VerifierUpdated(address(backend), address(next));
+        proxy.setVerifier(address(next));
+    }
+
+    // --- Ownership (2-step) ---
+
+    function test_ownership_twoStep() public {
+        address newOwner = address(0x777);
+
+        proxy.transferOwnership(newOwner);
+        assertEq(proxy.owner(), owner, "owner unchanged before accept");
+        assertEq(proxy.pendingOwner(), newOwner);
+
+        vm.prank(newOwner);
+        proxy.acceptOwnership();
+        assertEq(proxy.owner(), newOwner);
+        assertEq(proxy.pendingOwner(), address(0));
+
+        // New owner can rotate; old owner is locked out.
+        Groth16Verifier next = _deployFreshBackend();
+        vm.prank(newOwner);
+        proxy.setVerifier(address(next));
+        assertEq(address(proxy.verifier()), address(next));
+
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, owner));
+        proxy.setVerifier(address(backend));
+    }
+
+    // --- Gas budget ---
+
+    function test_verifyProofViaProxy_overheadBounded() public view {
+        // Measure the proxy hop as a delta over a direct backend call rather
+        // than an absolute budget. The direct path is already covered by
+        // Groth16Verifier.t.sol's <300k assertion; here we just want to bound
+        // the additional cost of one typed external call + storage read.
+        //
+        // Warm both contract addresses first — EIP-2929 charges 2600 gas the
+        // first time an account is touched in a tx and 100 gas thereafter, so
+        // an unwarmed direct call would look ~2500 gas more expensive than a
+        // proxy call that piggybacks on the proxy's own warm-state.
+        backend.verifyProof(proofA, proofB, proofC, proofInputs);
+        proxy.verifyProof(proofA, proofB, proofC, proofInputs);
+
+        uint256 t0 = gasleft();
+        bool okDirect = backend.verifyProof(proofA, proofB, proofC, proofInputs);
+        uint256 directUsed = t0 - gasleft();
+
+        uint256 t1 = gasleft();
+        bool okProxy = proxy.verifyProof(proofA, proofB, proofC, proofInputs);
+        uint256 proxyUsed = t1 - gasleft();
+
+        assertTrue(okDirect, "direct call must verify");
+        assertTrue(okProxy, "proxy call must verify");
+        assertGe(proxyUsed, directUsed, "proxy should not be cheaper than direct");
+        assertLt(proxyUsed - directUsed, 10_000, "proxy overhead exceeded 10k gas");
+    }
+
+    // --- Fuzz ---
+
+    function testFuzz_verifyProofViaProxy_inputOverflow(uint256 idx, uint256 val) public {
+        idx = idx % 6;
+        vm.assume(val >= SNARK_SCALAR_FIELD);
+        uint256[6] memory bad = proofInputs;
+        bad[idx] = val;
+        // Overflow check fires in the backend; the proxy bubbles the revert
+        // (Solidity propagates the revert reason from typed external calls).
+        vm.expectRevert("input overflow");
+        proxy.verifyProof(proofA, proofB, proofC, bad);
+    }
+
+    function testFuzz_setVerifier_anyNonOwnerReverts(address caller) public {
+        vm.assume(caller != owner);
+        vm.assume(caller != address(0));
+        vm.prank(caller);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, caller));
+        proxy.setVerifier(address(backend));
+    }
+
+    // --- Helpers ---
+
+    function _deployFreshBackend() internal returns (Groth16Verifier) {
+        (
+            uint256[2] memory alpha1,
+            uint256[2][2] memory beta2,
+            uint256[2][2] memory gamma2,
+            uint256[2][2] memory delta2,
+            uint256[2][7] memory ic
+        ) = _loadVk();
+        return new Groth16Verifier(alpha1, beta2, gamma2, delta2, ic);
+    }
+
+}

--- a/contracts/test/VerifierProxy.t.sol
+++ b/contracts/test/VerifierProxy.t.sol
@@ -116,6 +116,13 @@ contract VerifierProxyTest is VkFixture {
         proxy.setVerifier(address(backend));
     }
 
+    function test_setVerifier_rejectsSelf() public {
+        // Pointing the proxy at itself would make verifyProof() recurse into
+        // the proxy and OOG on every call — a governance footgun.
+        vm.expectRevert("self verifier");
+        proxy.setVerifier(address(proxy));
+    }
+
     function test_setVerifier_swapsBackend() public {
         // Build a second Groth16Verifier with a structurally valid but
         // semantically different VK by swapping two IC points. Both points

--- a/contracts/test/VkFixture.sol
+++ b/contracts/test/VkFixture.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+
+/// @title Shared Groth16 fixture loader for tests.
+/// @dev Centralizes the proof/VK JSON parsing that every verifier-flavored
+///      test needs, plus a replicated-batch builder. Inherit and call
+///      `_loadFixtureProof()` from setUp to populate the cached proof state.
+abstract contract VkFixture is Test {
+    using stdJson for string;
+
+    // Cached fixture proof — populated by _loadFixtureProof().
+    uint256[2] internal proofA;
+    uint256[2][2] internal proofB;
+    uint256[2] internal proofC;
+    uint256[6] internal proofInputs;
+
+    function _loadFixtureProof() internal {
+        _loadProofInto(proofA, proofB, proofC, proofInputs);
+    }
+
+    function _loadVk()
+        internal
+        view
+        returns (
+            uint256[2] memory alpha1,
+            uint256[2][2] memory beta2,
+            uint256[2][2] memory gamma2,
+            uint256[2][2] memory delta2,
+            uint256[2][7] memory ic
+        )
+    {
+        string memory json = vm.readFile("./test/fixtures/vk.json");
+        alpha1[0] = json.readUint(".alpha1[0]");
+        alpha1[1] = json.readUint(".alpha1[1]");
+        _loadG2(json, ".beta2", beta2);
+        _loadG2(json, ".gamma2", gamma2);
+        _loadG2(json, ".delta2", delta2);
+        for (uint256 i = 0; i < 7; i++) {
+            ic[i][0] = json.readUint(string.concat(".ic[", vm.toString(i), "][0]"));
+            ic[i][1] = json.readUint(string.concat(".ic[", vm.toString(i), "][1]"));
+        }
+    }
+
+    function _loadG2(string memory json, string memory base, uint256[2][2] memory g) internal pure {
+        g[0][0] = json.readUint(string.concat(base, "[0][0]"));
+        g[0][1] = json.readUint(string.concat(base, "[0][1]"));
+        g[1][0] = json.readUint(string.concat(base, "[1][0]"));
+        g[1][1] = json.readUint(string.concat(base, "[1][1]"));
+    }
+
+    function _loadProofInto(
+        uint256[2] storage a,
+        uint256[2][2] storage b,
+        uint256[2] storage c,
+        uint256[6] storage input
+    ) internal {
+        string memory json = vm.readFile("./test/fixtures/proof.json");
+        a[0] = json.readUint(".a[0]");
+        a[1] = json.readUint(".a[1]");
+        b[0][0] = json.readUint(".b[0][0]");
+        b[0][1] = json.readUint(".b[0][1]");
+        b[1][0] = json.readUint(".b[1][0]");
+        b[1][1] = json.readUint(".b[1][1]");
+        c[0] = json.readUint(".c[0]");
+        c[1] = json.readUint(".c[1]");
+        for (uint256 i = 0; i < 6; i++) {
+            input[i] = json.readUint(string.concat(".public_inputs[", vm.toString(i), "]"));
+        }
+    }
+
+    /// @dev Build a length-N batch where every entry replays the cached fixture.
+    /// Used by the batch tests that don't care about per-proof distinctness.
+    function _replicatedBatch(uint256 n)
+        internal
+        view
+        returns (
+            uint256[2][] memory aArr,
+            uint256[2][2][] memory bArr,
+            uint256[2][] memory cArr,
+            uint256[6][] memory inputs
+        )
+    {
+        aArr = new uint256[2][](n);
+        bArr = new uint256[2][2][](n);
+        cArr = new uint256[2][](n);
+        inputs = new uint256[6][](n);
+        for (uint256 i = 0; i < n; i++) {
+            aArr[i] = proofA;
+            bArr[i] = proofB;
+            cArr[i] = proofC;
+            inputs[i] = proofInputs;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #22. PR #57 already shipped a hardened `Groth16Verifier` (immutable VK, single + batch verify, <300k gas, basic fuzz). The unresolved acceptance criterion — *"verifying key can be updated via governance mechanism"* — directly conflicts with PR #57's hardening (the deployed bytecode is scanned for any legacy setter).

Rather than reverse that hardening, this PR adds a routing proxy in front. DarkPool calls `VerifierProxy` at a fixed address; the proxy holds a swappable `IVerifier` pointer. VK rotation = deploy a fresh `Groth16Verifier(newVk)` and call `proxy.setVerifier(newAddr)`. Each backend stays a frozen, auditable artifact tied to one VK. **Not** an EIP-1967 delegatecall proxy — it's a typed router.

- `contracts/src/interfaces/IVerifier.sol` — interface locking the 6-input shape (a circuit revision that changes the count is a hard fork the proxy can't paper over)
- `contracts/src/VerifierProxy.sol` — `Ownable2Step` router, internal `_setVerifier` helper, code-bearing + non-zero + same-pointer checks, `VerifierUpdated` event
- `contracts/src/Groth16Verifier.sol` — declared `is IVerifier`
- `contracts/src/DarkPool.sol` — verifier slot retyped to `IVerifier`
- `contracts/script/Deploy.s.sol` — deploys impl → proxy → pool; `VERIFIER_GOVERNOR` env defaults to deployer (production should override with a Timelock or Safe)
- `contracts/test/VkFixture.sol` — extracted shared base for VK/proof loaders + replicated-batch builder
- `contracts/test/VerifierProxy.t.sol` — 18 tests covering forwarding, swap-changes-semantics, ownership 2-step, gas overhead, fuzz
- `contracts/test/DarkPool.t.sol` — `MockVerifier` now implements `IVerifier` directly (dummy VK helpers gone)

Out of scope: no timelock baked in (compose externally via `Ownable2Step.transferOwnership(timelock)`), no Rust binding changes (`submitBatch` ABI on `DarkPool` unchanged), no automated rotation script.

## Test plan

- [x] `forge build` clean (pre-existing warnings only)
- [x] `forge test`: 82/82 pass (42 DarkPool, 21 Groth16Verifier, 19 VerifierProxy)
- [x] `test_verifyProofViaProxy_overheadBounded`: proxy overhead < 10k gas over warm direct call
- [x] `test_setVerifier_swapsBackend`: original proof fails to verify after swapping to a Groth16Verifier with permuted IC points
- [x] Constructor and setter reject zero address, EOA, and (for setter) same-pointer rotations
- [x] Owner-only auth via `OwnableUnauthorizedAccount`; 2-step ownership transfer wired through `Ownable2Step`
- [x] Fuzz: `testFuzz_setVerifier_anyNonOwnerReverts`, `testFuzz_verifyProofViaProxy_inputOverflow` (256 runs each)
- [ ] Production deploy should set `VERIFIER_GOVERNOR` to a TimelockController address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a governance‑swappable verifier proxy and abstract verifier interface; core contract now accepts verifier implementations and rejects non-contract addresses.
  * Deployment flow updated to install and wire the proxy and enforce a governor guard on mainnet.

* **Tests**
  * Added centralized verification-key/proof fixture helpers and broad VerifierProxy test coverage; updated verifier and verifier-related tests to use the interface and new fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/59)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->