### PR TITLE
[F0.1] Bootstrap trading-app pipeline inside front/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,22 @@ jobs:
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: front
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: front/package-lock.json
+      - run: npm ci
+      - run: npm run typecheck
+      - run: npm run lint
+      - run: npm run format:check
+      - run: npm run build

--- a/front/.eslintrc.json
+++ b/front/.eslintrc.json
@@ -1,3 +1,3 @@
 {
-  "extends": ["next/core-web-vitals", "next/typescript"]
+  "extends": ["next/core-web-vitals", "next/typescript", "prettier"]
 }

--- a/front/.prettierignore
+++ b/front/.prettierignore
@@ -1,0 +1,30 @@
+# Build & deps
+.next
+node_modules
+package-lock.json
+public
+
+# Markdown (often hand-aligned tables we don't want reflowed)
+*.md
+
+# Landing surface — owned independently of the trading app.
+# See docs/PARALLEL-WORK.md "off-limits" paths. Formatting on these
+# is intentionally not enforced by the trading-app pipeline.
+app/page.tsx
+app/layout.tsx
+app/globals.css
+components/Footer.tsx
+components/Hero.tsx
+components/HowItWorks.tsx
+components/Nav.tsx
+components/OrderFlowPanel.tsx
+components/TerminalFeed.tsx
+components/Ticker.tsx
+lib/shaders/
+
+# Shared scaffolding files that pre-date the trading app's formatting
+# contract. Each is owned by a Wave-0/1 issue (#63, #66, #67); leave
+# their style alone until those issues land.
+next.config.mjs
+postcss.config.mjs
+tailwind.config.ts

--- a/front/.prettierrc.json
+++ b/front/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/front/README.md
+++ b/front/README.md
@@ -1,0 +1,64 @@
+# front/
+
+Next.js 14 App Router app that hosts **both** the marketing landing
+page at `/` and the trading app under `/app/...`.
+
+Landing is already live at https://front-five-flax.vercel.app and is
+**off-limits** to trading-app issues — see
+[`docs/PARALLEL-WORK.md`](../docs/PARALLEL-WORK.md) for the file-scope
+rules.
+
+## Develop
+
+```bash
+cd front
+npm install
+npm run dev          # http://localhost:3000
+```
+
+## Scripts
+
+| Script                 | What it does                                   |
+| ---------------------- | ---------------------------------------------- |
+| `npm run dev`          | Next dev server with HMR                       |
+| `npm run build`        | Production build (verified in CI)              |
+| `npm run start`        | Serve the production build                     |
+| `npm run typecheck`    | `tsc --noEmit` against strict TS               |
+| `npm run lint`         | `next lint` (next/core-web-vitals + typescript)|
+| `npm run format`       | Prettier write                                 |
+| `npm run format:check` | Prettier check (verified in CI)                |
+
+CI runs `typecheck`, `lint`, `format:check`, and `build` against every
+PR via the `Frontend` job in `.github/workflows/ci.yml`.
+
+## Environment variables
+
+The trading app reads its runtime config from `front/lib/config.ts`,
+which is established by [F0.6 (#67)](https://github.com/Dnreikronos/DarkPool-Exchange/issues/67).
+Until that lands no env vars are required.
+
+Document each new variable here as it gets introduced.
+
+## Structure
+
+```
+front/
+├── app/
+│   ├── page.tsx              # landing (/)
+│   ├── layout.tsx            # root layout (fonts, dot-grid overlay)
+│   ├── globals.css           # site-wide CSS (crosshair cursor, overlay)
+│   └── app/                  # trading app routes — built out by F1.x
+│       └── ...               # owned per docs/PARALLEL-WORK.md
+├── components/
+│   ├── (landing components)  # Nav, Hero, Footer, Ticker, ... — off-limits
+│   └── trade/                # trading-app components — built by F1.x
+├── lib/
+│   ├── shaders/              # landing-only — off-limits
+│   └── sdk/                  # generated TS SDK — F0.3
+└── public/                   # static assets
+```
+
+The trading app builds against the design system in
+[`DESIGN.md`](../DESIGN.md) (brutalist trading-terminal aesthetic, lime
+accent `#D4FF00`, Bebas Neue + IBM Plex Mono, zero radius, no semantic
+colors, no icons). Read it before adding any UI.

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "temp-app",
+  "name": "darkpool-exchange",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "temp-app",
+      "name": "darkpool-exchange",
       "version": "0.1.0",
       "dependencies": {
         "@gsap/react": "^2.1.2",
@@ -20,7 +20,9 @@
         "@types/react-dom": "^18",
         "eslint": "^8",
         "eslint-config-next": "14.2.35",
+        "eslint-config-prettier": "^9.1.0",
         "postcss": "^8",
+        "prettier": "^3.3.3",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
       }
@@ -2235,6 +2237,19 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+      "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -4614,6 +4629,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prop-types": {

--- a/front/package.json
+++ b/front/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@gsap/react": "^2.1.2",
@@ -21,7 +24,9 @@
     "@types/react-dom": "^18",
     "eslint": "^8",
     "eslint-config-next": "14.2.35",
+    "eslint-config-prettier": "^9.1.0",
     "postcss": "^8",
+    "prettier": "^3.3.3",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"
   }


### PR DESCRIPTION
Closes #63

## Summary
- Add Prettier + `eslint-config-prettier` to `front/`, plus `.prettierrc.json` and `.prettierignore`.
- Add `typecheck`, `format`, `format:check` npm scripts (build / lint / dev already existed).
- Add a `Frontend` job to `.github/workflows/ci.yml` running typecheck, lint, format:check, and build.
- Add `front/README.md` covering dev scripts, env vars, and the landing-vs-trading split inside `front/`.

## Translation from the issue body
The issue was written when the plan was a separate `apps/trading/` workspace. Per `CLAUDE.md` and `docs/PARALLEL-WORK.md` we decided to host the trading app inside the existing `front/` Next app (landing at `/`, trading at `/app`). Concretely:

| Issue says | This PR does |
|---|---|
| `Repository becomes an npm workspaces root with apps/trading/ + packages/*` | Skipped — no monorepo split. Single `front/` package. |
| `apps/trading/ initialized with Next 14 + TS strict + Tailwind v3` | Already true in `front/` (TS strict was already on). Verified by CI. |
| `apps/trading/ ESLint + Prettier` | Added Prettier + `eslint-config-prettier`. |
| `npm -w apps/trading run build` succeeds | `npm run build` inside `front/` succeeds, verified by the new `Frontend` job. |
| `.github/workflows/ci.yml frontend job` | Done. |
| `Vercel project re-pointed to apps/trading` | Out of scope for this PR (infra). Existing Vercel project still serves the landing at `/`, which is correct — the same project will pick up `/app/...` once F1.x lands. |
| `apps/trading/README.md` | `front/README.md`. |
| `transpilePackages` for shared packages | Skipped — the SDK lives at `front/lib/sdk/`, not a separate package. F0.3 (#64) will codegen into that path directly. |

## Deferred to other issues (per `docs/PARALLEL-WORK.md` file scope)
- `front/app/app/layout.tsx`, `page.tsx`, `trade/page.tsx` → F1.1 (#68).
- Tailwind config extension (tokens, shadcn primitives) → F0.5 (#66).
- SDK codegen at `front/lib/sdk/` → F0.3 (#64).
- Env config `front/lib/config.ts` → F0.6 (#67).

## Prettier scope
`.prettierignore` excludes the landing surface (off-limits per `docs/PARALLEL-WORK.md`) plus `tailwind.config.ts` / `next.config.mjs` / `postcss.config.mjs`, so this PR doesn't reformat files owned by other issues. Each subsequent F-issue will format its own new files.

## Verification
Ran locally inside `front/`:
- `npm run typecheck` — clean
- `npm run lint` — `No issues found`
- `npm run format:check` — `All matched files use Prettier code style!`
- `npm run build` — `Compiled successfully`, 4 static pages

## Test plan
- [ ] CI `Frontend` job goes green (parallel with the Rust jobs).
- [ ] `npm run dev` inside `front/` still serves the landing at `/`.
- [ ] No unrelated landing-surface diff (off-limits paths untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Established automated frontend code quality pipeline with continuous integration supporting type checking, linting, format validation, and build verification
  * Integrated code formatting standards and style enforcement for consistency across the codebase

* **Documentation**
  * Added comprehensive frontend development guide covering project structure, local development setup, available development scripts, and design system guidelines

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/103?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->