### PR TITLE
[F0.4] DarkPoolClient interface + Mock and Rest implementations

### DIFF
--- a/front/lib/api-client.ts
+++ b/front/lib/api-client.ts
@@ -1,0 +1,27 @@
+// Convenience re-exports for the trading app. Consumers should import from
+// '@/lib/api-client' rather than reaching into '@/lib/sdk/*' so the SDK's
+// internal layout (proto/, client.ts, mocks/, provider.tsx) stays an
+// implementation detail.
+
+export {
+  createDarkPoolClient,
+  DARK_POOL_ERROR_CODES,
+  DARK_POOL_METHODS,
+  DarkPoolError,
+  MockClient,
+  methodOverridesFromEnv,
+  RestClient,
+  type CreateDarkPoolClientOptions,
+  type DarkPoolClient,
+  type DarkPoolErrorCode,
+  type DarkPoolErrorName,
+  type DarkPoolMethod,
+  type RestClientOptions,
+  type StreamOptions,
+} from './sdk/client'
+
+export {
+  DarkPoolClientProvider,
+  useDarkPoolClient,
+  type DarkPoolClientProviderProps,
+} from './sdk/provider'

--- a/front/lib/sdk/client.test.ts
+++ b/front/lib/sdk/client.test.ts
@@ -1,0 +1,470 @@
+import { create } from '@bufbuild/protobuf'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  CancelOrderRequestSchema,
+  GetAuctionHistoryRequestSchema,
+  GetOrderBookRequestSchema,
+  GetOrderRequestSchema,
+  PlaceOrderRequestSchema,
+  Side,
+} from './proto/darkpool/v1/darkpool_pb.js'
+import {
+  DARK_POOL_ERROR_CODES,
+  DARK_POOL_METHODS,
+  DarkPoolError,
+  MockClient,
+  RestClient,
+  createDarkPoolClient,
+  methodOverridesFromEnv,
+  type DarkPoolClient,
+  type DarkPoolMethod,
+} from './client'
+
+// ─── helpers ─────────────────────────────────────────────────────────────
+
+type FetchCall = { url: string; init: RequestInit }
+
+function makeJsonResponse(body: unknown, init: ResponseInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+    ...init,
+  })
+}
+
+function captureFetch(response: Response | (() => Response | Promise<Response>)) {
+  const calls: FetchCall[] = []
+  const fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init: init ?? {} })
+    return typeof response === 'function' ? await response() : response
+  }) as unknown as typeof globalThis.fetch
+  return { fetch, calls }
+}
+
+const BASE = 'https://api.example.test'
+const KEY = 'test-key'
+
+// ─── RestClient: requests ─────────────────────────────────────────────────
+
+describe('RestClient.placeOrder', () => {
+  it('POSTs base64-encoded bytes to /v1/orders with the x-api-key header', async () => {
+    const responseBody = {
+      order: {
+        id: 'order-1',
+        pair: 'ETH/USDC',
+        side: 'SIDE_BUY',
+        price: '3000.50',
+        size: '1.5',
+        remainingSize: '1.5',
+        commitmentKey: 'commit-abc',
+        submittedAtUnix: '1700000000',
+        expiresAtUnix: '0',
+      },
+    }
+    const { fetch, calls } = captureFetch(makeJsonResponse(responseBody))
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+
+    const req = create(PlaceOrderRequestSchema, {
+      commitment: new Uint8Array([0x01, 0x02, 0x03]),
+      proof: new Uint8Array([0xff]),
+      encryptedPayload: new Uint8Array([0xaa, 0xbb]),
+    })
+    const resp = await client.placeOrder(req)
+
+    expect(calls).toHaveLength(1)
+    const [call] = calls
+    expect(call.url).toBe(`${BASE}/v1/orders`)
+    expect(call.init.method).toBe('POST')
+    const headers = call.init.headers as Record<string, string>
+    expect(headers['x-api-key']).toBe(KEY)
+    expect(headers['content-type']).toBe('application/json')
+    expect(headers.accept).toBe('application/json')
+
+    // commitment 010203 → "AQID", proof ff → "/w==", encryptedPayload aabb → "qrs="
+    expect(JSON.parse(call.init.body as string)).toEqual({
+      commitment: 'AQID',
+      proof: '/w==',
+      encryptedPayload: 'qrs=',
+    })
+
+    // Response decodes int64 timestamp to bigint per proto3 JSON mapping.
+    expect(resp.order?.id).toBe('order-1')
+    expect(resp.order?.side).toBe(Side.BUY)
+    expect(resp.order?.submittedAtUnix).toBe(1700000000n)
+  })
+
+  it('strips trailing slashes from the base URL', async () => {
+    const { fetch, calls } = captureFetch(makeJsonResponse({ order: undefined }))
+    const client = new RestClient({ baseUrl: `${BASE}///`, apiKey: KEY, fetch })
+    await client.placeOrder(create(PlaceOrderRequestSchema))
+    expect(calls[0].url).toBe(`${BASE}/v1/orders`)
+  })
+})
+
+describe('RestClient.cancelOrder', () => {
+  it('issues DELETE with the reason as a query param and URL-encodes the id', async () => {
+    const { fetch, calls } = captureFetch(makeJsonResponse({}))
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+
+    await client.cancelOrder(
+      create(CancelOrderRequestSchema, {
+        orderId: 'abc def',
+        reason: 'user cancelled',
+      })
+    )
+
+    expect(calls[0].init.method).toBe('DELETE')
+    expect(calls[0].url).toBe(`${BASE}/v1/orders/abc%20def?reason=user+cancelled`)
+  })
+
+  it('omits the reason query param when empty', async () => {
+    const { fetch, calls } = captureFetch(makeJsonResponse({}))
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+
+    await client.cancelOrder(create(CancelOrderRequestSchema, { orderId: 'abc', reason: '' }))
+
+    expect(calls[0].url).toBe(`${BASE}/v1/orders/abc`)
+  })
+})
+
+describe('RestClient.getOrder', () => {
+  it('GETs /v1/orders/:id', async () => {
+    const { fetch, calls } = captureFetch(makeJsonResponse({ order: undefined }))
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+    await client.getOrder(create(GetOrderRequestSchema, { orderId: 'ord-9' }))
+    expect(calls[0].init.method).toBe('GET')
+    expect(calls[0].url).toBe(`${BASE}/v1/orders/ord-9`)
+    expect(calls[0].init.body).toBeUndefined()
+  })
+})
+
+describe('RestClient.getOrderBook', () => {
+  it('GETs /v1/orderbook with the pair query param', async () => {
+    const { fetch, calls } = captureFetch(
+      makeJsonResponse({ pair: 'ETH/USDC', bids: [], asks: [] })
+    )
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+    const resp = await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    expect(calls[0].url).toBe(`${BASE}/v1/orderbook?pair=ETH%2FUSDC`)
+    expect(resp.bids).toEqual([])
+  })
+})
+
+describe('RestClient.getAuctionHistory', () => {
+  it('appends pair and limit when set, decodes int64 timestamp to bigint', async () => {
+    const { fetch, calls } = captureFetch(
+      makeJsonResponse({
+        auctions: [
+          {
+            auctionId: 'a-1',
+            pair: 'ETH/USDC',
+            clearingPrice: '3000',
+            matchedVolume: '5',
+            matchCount: 3,
+            timestampUnix: '1700000099',
+          },
+        ],
+      })
+    )
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+    const resp = await client.getAuctionHistory(
+      create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 50 })
+    )
+    expect(calls[0].url).toBe(`${BASE}/v1/auctions?pair=ETH%2FUSDC&limit=50`)
+    expect(resp.auctions[0].timestampUnix).toBe(1700000099n)
+  })
+
+  it('omits limit when 0 (proto default = server-chosen)', async () => {
+    const { fetch, calls } = captureFetch(makeJsonResponse({ auctions: [] }))
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+    await client.getAuctionHistory(
+      create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 0 })
+    )
+    expect(calls[0].url).toBe(`${BASE}/v1/auctions?pair=ETH%2FUSDC`)
+  })
+})
+
+describe('RestClient.streamAuctions', () => {
+  it('throws UNIMPLEMENTED — SSE bridge is not wired yet', async () => {
+    const { fetch } = captureFetch(makeJsonResponse({}))
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+    const iter = client.streamAuctions({ $typeName: 'darkpool.v1.StreamAuctionsRequest', pair: '' })
+    await expect(
+      (async () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        for await (const _event of iter) {
+          // unreachable
+        }
+      })()
+    ).rejects.toMatchObject({
+      name: 'DarkPoolError',
+      code: DARK_POOL_ERROR_CODES.UNIMPLEMENTED,
+    })
+  })
+})
+
+// ─── RestClient: error mapping ────────────────────────────────────────────
+
+describe('RestClient error mapping', () => {
+  it('uses the body code when present', async () => {
+    const { fetch } = captureFetch(
+      new Response(
+        JSON.stringify({
+          code: DARK_POOL_ERROR_CODES.INVALID_ARGUMENT,
+          message: 'bad price',
+        }),
+        { status: 400, headers: { 'content-type': 'application/json' } }
+      )
+    )
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+    await expect(
+      client.getOrder(create(GetOrderRequestSchema, { orderId: 'x' }))
+    ).rejects.toMatchObject({
+      name: 'DarkPoolError',
+      code: DARK_POOL_ERROR_CODES.INVALID_ARGUMENT,
+      message: 'bad price',
+      httpStatus: 400,
+    })
+  })
+
+  it('falls back to HTTP-status mapping when the body has no code', async () => {
+    const { fetch } = captureFetch(new Response('', { status: 401 }))
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+    await expect(
+      client.getOrder(create(GetOrderRequestSchema, { orderId: 'x' }))
+    ).rejects.toMatchObject({
+      code: DARK_POOL_ERROR_CODES.UNAUTHENTICATED,
+      httpStatus: 401,
+    })
+  })
+
+  it('maps unknown body code to HTTP status mapping', async () => {
+    const { fetch } = captureFetch(
+      new Response(JSON.stringify({ code: 999, message: 'weird' }), {
+        status: 503,
+        headers: { 'content-type': 'application/json' },
+      })
+    )
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+    await expect(
+      client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    ).rejects.toMatchObject({
+      code: DARK_POOL_ERROR_CODES.UNAVAILABLE,
+      retryable: true,
+    })
+  })
+
+  it('treats fetch rejection as UNAVAILABLE with the original cause attached', async () => {
+    const cause = new TypeError('connection refused')
+    const fetch = vi.fn(async () => {
+      throw cause
+    }) as unknown as typeof globalThis.fetch
+    const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
+    let thrown: unknown
+    try {
+      await client.getOrder(create(GetOrderRequestSchema, { orderId: 'x' }))
+    } catch (e) {
+      thrown = e
+    }
+    expect(thrown).toBeInstanceOf(DarkPoolError)
+    expect((thrown as DarkPoolError).code).toBe(DARK_POOL_ERROR_CODES.UNAVAILABLE)
+    expect((thrown as DarkPoolError & { cause?: unknown }).cause).toBe(cause)
+  })
+})
+
+// ─── MockClient ───────────────────────────────────────────────────────────
+
+describe('MockClient', () => {
+  it('placeOrder stores the order so getOrder can read it back', async () => {
+    const mock = new MockClient()
+    const placed = await mock.placeOrder(
+      create(PlaceOrderRequestSchema, {
+        commitment: new Uint8Array([1, 2, 3, 4]),
+      })
+    )
+    expect(placed.order?.id).toBe('mock-1')
+    const fetched = await mock.getOrder(
+      create(GetOrderRequestSchema, { orderId: placed.order!.id })
+    )
+    expect(fetched.order?.id).toBe('mock-1')
+  })
+
+  it('getOrder throws NOT_FOUND for unknown ids', async () => {
+    const mock = new MockClient()
+    await expect(
+      mock.getOrder(create(GetOrderRequestSchema, { orderId: 'nope' }))
+    ).rejects.toMatchObject({
+      name: 'DarkPoolError',
+      code: DARK_POOL_ERROR_CODES.NOT_FOUND,
+    })
+  })
+
+  it('cancelOrder removes the order', async () => {
+    const mock = new MockClient()
+    const placed = await mock.placeOrder(create(PlaceOrderRequestSchema))
+    await mock.cancelOrder(
+      create(CancelOrderRequestSchema, {
+        orderId: placed.order!.id,
+        reason: 'user',
+      })
+    )
+    await expect(
+      mock.getOrder(create(GetOrderRequestSchema, { orderId: placed.order!.id }))
+    ).rejects.toMatchObject({ code: DARK_POOL_ERROR_CODES.NOT_FOUND })
+  })
+
+  it('getOrderBook returns an empty book for the configured pair', async () => {
+    const mock = new MockClient()
+    const book = await mock.getOrderBook(create(GetOrderBookRequestSchema, { pair: '' }))
+    expect(book.pair).toBe('ETH/USDC')
+    expect(book.bids).toEqual([])
+    expect(book.asks).toEqual([])
+  })
+
+  it('getAuctionHistory returns an empty list', async () => {
+    const mock = new MockClient()
+    const hist = await mock.getAuctionHistory(
+      create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 10 })
+    )
+    expect(hist.auctions).toEqual([])
+  })
+})
+
+// ─── Factory ──────────────────────────────────────────────────────────────
+
+describe('createDarkPoolClient', () => {
+  it('returns MockClient when useMocks=true and no overrides', () => {
+    const client = createDarkPoolClient({
+      baseUrl: BASE,
+      apiKey: KEY,
+      useMocks: true,
+    })
+    expect(client).toBeInstanceOf(MockClient)
+  })
+
+  it('returns RestClient when useMocks=false and no overrides', () => {
+    const client = createDarkPoolClient({
+      baseUrl: BASE,
+      apiKey: KEY,
+      useMocks: false,
+    })
+    expect(client).toBeInstanceOf(RestClient)
+  })
+
+  it('routes per method when overrides are set, using the same impl across calls', async () => {
+    const restCalls: DarkPoolMethod[] = []
+    const mockCalls: DarkPoolMethod[] = []
+    const stubRest = makeRecordingClient((m) => restCalls.push(m))
+    const stubMock = makeRecordingClient((m) => mockCalls.push(m))
+
+    const client = createDarkPoolClient({
+      baseUrl: BASE,
+      apiKey: KEY,
+      useMocks: true,
+      mockClient: stubMock,
+      restClient: stubRest,
+      methodOverrides: {
+        getOrderBook: false, // force REST
+        placeOrder: false, // force REST
+        // streamAuctions, getOrder, cancelOrder, getAuctionHistory fall back to global mock
+      },
+    })
+
+    await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    await client.placeOrder(create(PlaceOrderRequestSchema))
+    await client.getAuctionHistory(
+      create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 0 })
+    )
+
+    expect(restCalls).toEqual(['getOrderBook', 'placeOrder'])
+    expect(mockCalls).toEqual(['getAuctionHistory'])
+  })
+
+  it('exposes every interface method via DARK_POOL_METHODS', () => {
+    const stubMock = makeRecordingClient(() => undefined)
+    const client = createDarkPoolClient({
+      baseUrl: BASE,
+      apiKey: KEY,
+      useMocks: true,
+      mockClient: stubMock,
+    })
+    for (const m of DARK_POOL_METHODS) {
+      expect(typeof (client as unknown as Record<string, unknown>)[m]).toBe('function')
+    }
+  })
+})
+
+function makeRecordingClient(onCall: (m: DarkPoolMethod) => void): DarkPoolClient {
+  return {
+    async placeOrder() {
+      onCall('placeOrder')
+      return { $typeName: 'darkpool.v1.PlaceOrderResponse' } as never
+    },
+    async cancelOrder() {
+      onCall('cancelOrder')
+      return { $typeName: 'darkpool.v1.CancelOrderResponse' } as never
+    },
+    async getOrder() {
+      onCall('getOrder')
+      return { $typeName: 'darkpool.v1.GetOrderResponse' } as never
+    },
+    async getOrderBook() {
+      onCall('getOrderBook')
+      return { $typeName: 'darkpool.v1.GetOrderBookResponse' } as never
+    },
+    async getAuctionHistory() {
+      onCall('getAuctionHistory')
+      return { $typeName: 'darkpool.v1.GetAuctionHistoryResponse' } as never
+    },
+    streamAuctions() {
+      onCall('streamAuctions')
+      return (async function* () {})()
+    },
+  }
+}
+
+// ─── methodOverridesFromEnv ───────────────────────────────────────────────
+
+describe('methodOverridesFromEnv', () => {
+  it('parses true/false/1/0 and skips empty/undefined', () => {
+    expect(
+      methodOverridesFromEnv({
+        NEXT_PUBLIC_USE_MOCKS_PLACE_ORDER: 'true',
+        NEXT_PUBLIC_USE_MOCKS_CANCEL_ORDER: '0',
+        NEXT_PUBLIC_USE_MOCKS_GET_ORDER: 'false',
+        NEXT_PUBLIC_USE_MOCKS_ORDERBOOK: '1',
+        NEXT_PUBLIC_USE_MOCKS_AUCTION_HISTORY: '',
+        NEXT_PUBLIC_USE_MOCKS_STREAM_AUCTIONS: undefined,
+      })
+    ).toEqual({
+      placeOrder: true,
+      cancelOrder: false,
+      getOrder: false,
+      getOrderBook: true,
+    })
+  })
+
+  it('returns an empty object when nothing is set', () => {
+    expect(methodOverridesFromEnv({})).toEqual({})
+  })
+})
+
+// ─── DarkPoolError ────────────────────────────────────────────────────────
+
+describe('DarkPoolError', () => {
+  it('exposes the named code and marks transient codes as retryable', () => {
+    const e = new DarkPoolError(DARK_POOL_ERROR_CODES.UNAVAILABLE, 'engine restarting')
+    expect(e.codeName).toBe('UNAVAILABLE')
+    expect(e.retryable).toBe(true)
+  })
+
+  it('marks deterministic codes as non-retryable', () => {
+    const e = new DarkPoolError(DARK_POOL_ERROR_CODES.INVALID_ARGUMENT, 'bad input')
+    expect(e.retryable).toBe(false)
+  })
+})
+
+beforeEach(() => {
+  // No-op; vi.restoreAllMocks() would clobber the spies created in each test.
+})

--- a/front/lib/sdk/client.test.ts
+++ b/front/lib/sdk/client.test.ts
@@ -8,6 +8,7 @@ import {
   GetOrderRequestSchema,
   PlaceOrderRequestSchema,
   Side,
+  StreamAuctionsRequestSchema,
 } from './proto/darkpool/v1/darkpool_pb.js'
 import {
   DARK_POOL_ERROR_CODES,
@@ -328,6 +329,61 @@ describe('MockClient', () => {
       create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 10 })
     )
     expect(hist.auctions).toEqual([])
+  })
+
+  it('streamAuctions returns immediately when no signal is provided (no leaked generator)', async () => {
+    const mock = new MockClient()
+    const iter = mock.streamAuctions(create(StreamAuctionsRequestSchema, { pair: 'ETH/USDC' }))
+    // If the generator awaited an unresolved promise this would hang the
+    // test runner; the 50 ms race guards against regressions.
+    const events: unknown[] = []
+    const drained = (async () => {
+      for await (const ev of iter) events.push(ev)
+      return 'done' as const
+    })()
+    const result = await Promise.race([
+      drained,
+      new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), 50)),
+    ])
+    expect(result).toBe('done')
+    expect(events).toEqual([])
+  })
+
+  it('streamAuctions blocks until the AbortSignal fires, then terminates cleanly', async () => {
+    const mock = new MockClient()
+    const controller = new AbortController()
+    const iter = mock.streamAuctions(create(StreamAuctionsRequestSchema, { pair: 'ETH/USDC' }), {
+      signal: controller.signal,
+    })
+    let resolved = false
+    const drained = (async () => {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      for await (const _ev of iter) {
+        // unreachable
+      }
+      resolved = true
+    })()
+
+    // Yield twice so the generator can settle on the await.
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+
+    controller.abort()
+    await drained
+    expect(resolved).toBe(true)
+  })
+
+  it('streamAuctions terminates immediately when given an already-aborted signal', async () => {
+    const mock = new MockClient()
+    const controller = new AbortController()
+    controller.abort()
+    const iter = mock.streamAuctions(create(StreamAuctionsRequestSchema, { pair: 'ETH/USDC' }), {
+      signal: controller.signal,
+    })
+    const events: unknown[] = []
+    for await (const ev of iter) events.push(ev)
+    expect(events).toEqual([])
   })
 })
 

--- a/front/lib/sdk/client.ts
+++ b/front/lib/sdk/client.ts
@@ -373,12 +373,15 @@ export class MockClient implements DarkPoolClient {
     opts?: StreamOptions
   ): AsyncIterable<AuctionEvent> {
     void req
-    // Block until the caller aborts, yielding nothing. F1.2 (#69) replaces
-    // this with timer-driven synthetic events sourced from the mock store.
+    // F1.2 (#69) replaces this with timer-driven synthetic events sourced
+    // from the mock store. Until then: with a signal, block until aborted
+    // so consumers can mirror the real stream's lifecycle; without one,
+    // return immediately — otherwise the generator would await an
+    // unresolved promise and iterator.return() couldn't free it (the
+    // queued return completion only runs when the current await settles).
     const signal = opts?.signal
-    if (signal?.aborted) return
+    if (!signal || signal.aborted) return
     await new Promise<void>((resolve) => {
-      if (!signal) return // never resolves; caller must call return() on the iterator
       signal.addEventListener('abort', () => resolve(), { once: true })
     })
   }

--- a/front/lib/sdk/client.ts
+++ b/front/lib/sdk/client.ts
@@ -1,0 +1,503 @@
+// DarkPoolClient — single seam between the trading UI and the engine.
+//
+// Phase 1 wires the UI against `MockClient` (in-memory, no network); Phase 2
+// flips `NEXT_PUBLIC_USE_MOCKS=false` and the same UI hits `RestClient`.
+// Per-method env flags (`NEXT_PUBLIC_USE_MOCKS_ORDERBOOK`, etc.) let Phase 2
+// migrate one RPC at a time without flipping the whole app.
+//
+// Wire contract: the REST surface is grpc-gateway-compatible JSON over the
+// service in crates/dp-api/proto/darkpool/v1/darkpool.proto. Bytes fields
+// (`commitment`, `proof`, `encryptedPayload`) cross as standard base64
+// strings; numeric strings (`price`, `size`, …) stay strings; int64s
+// (`submittedAtUnix`, …) arrive as strings and `fromJson()` decodes them
+// into `bigint` per the *Schema definitions.
+
+import { create, fromJson, toJson } from '@bufbuild/protobuf'
+import type { DescMessage, MessageShape } from '@bufbuild/protobuf'
+
+import {
+  CancelOrderResponseSchema,
+  GetAuctionHistoryResponseSchema,
+  GetOrderBookResponseSchema,
+  GetOrderResponseSchema,
+  OrderInfoSchema,
+  PlaceOrderRequestSchema,
+  PlaceOrderResponseSchema,
+  Side,
+} from './proto/darkpool/v1/darkpool_pb.js'
+import type {
+  AuctionEvent,
+  CancelOrderRequest,
+  CancelOrderResponse,
+  GetAuctionHistoryRequest,
+  GetAuctionHistoryResponse,
+  GetOrderBookRequest,
+  GetOrderBookResponse,
+  GetOrderRequest,
+  GetOrderResponse,
+  PlaceOrderRequest,
+  PlaceOrderResponse,
+  StreamAuctionsRequest,
+} from './proto/darkpool/v1/darkpool_pb.js'
+
+// ─── Error model ──────────────────────────────────────────────────────────
+//
+// Mirrors `tonic::Code`. The REST layer returns
+// `{ "code": <i32>, "message": "..." }` (see crates/dp-api/src/rest.rs::
+// ApiError::into_response); we round-trip the numeric discriminant back so
+// callers can `switch` on it without parsing strings. When the server only
+// gives us an HTTP status (proxy errors, raw 5xx), we map back to a code
+// using the inverse of the server's mapping.
+
+export const DARK_POOL_ERROR_CODES = {
+  OK: 0,
+  CANCELLED: 1,
+  UNKNOWN: 2,
+  INVALID_ARGUMENT: 3,
+  DEADLINE_EXCEEDED: 4,
+  NOT_FOUND: 5,
+  ALREADY_EXISTS: 6,
+  PERMISSION_DENIED: 7,
+  RESOURCE_EXHAUSTED: 8,
+  FAILED_PRECONDITION: 9,
+  ABORTED: 10,
+  OUT_OF_RANGE: 11,
+  UNIMPLEMENTED: 12,
+  INTERNAL: 13,
+  UNAVAILABLE: 14,
+  DATA_LOSS: 15,
+  UNAUTHENTICATED: 16,
+} as const
+
+export type DarkPoolErrorName = keyof typeof DARK_POOL_ERROR_CODES
+export type DarkPoolErrorCode = (typeof DARK_POOL_ERROR_CODES)[DarkPoolErrorName]
+
+const CODE_NAMES = new Map<DarkPoolErrorCode, DarkPoolErrorName>(
+  (Object.entries(DARK_POOL_ERROR_CODES) as [DarkPoolErrorName, DarkPoolErrorCode][]).map(
+    ([name, code]) => [code, name]
+  )
+)
+
+export class DarkPoolError extends Error {
+  readonly code: DarkPoolErrorCode
+  readonly codeName: DarkPoolErrorName
+  readonly httpStatus: number | null
+  readonly retryable: boolean
+
+  constructor(
+    code: DarkPoolErrorCode,
+    message: string,
+    opts: { httpStatus?: number | null; cause?: unknown } = {}
+  ) {
+    super(message)
+    this.name = 'DarkPoolError'
+    this.code = code
+    this.codeName = CODE_NAMES.get(code) ?? 'UNKNOWN'
+    this.httpStatus = opts.httpStatus ?? null
+    this.retryable = isRetryableCode(code)
+    if (opts.cause !== undefined) {
+      ;(this as { cause?: unknown }).cause = opts.cause
+    }
+  }
+}
+
+function isRetryableCode(code: DarkPoolErrorCode): boolean {
+  return (
+    code === DARK_POOL_ERROR_CODES.UNAVAILABLE ||
+    code === DARK_POOL_ERROR_CODES.DEADLINE_EXCEEDED ||
+    code === DARK_POOL_ERROR_CODES.ABORTED
+  )
+}
+
+const KNOWN_CODE_VALUES = new Set<number>(Object.values(DARK_POOL_ERROR_CODES))
+
+function codeFromBody(value: unknown): DarkPoolErrorCode | null {
+  return typeof value === 'number' && KNOWN_CODE_VALUES.has(value)
+    ? (value as DarkPoolErrorCode)
+    : null
+}
+
+function codeFromHttpStatus(status: number): DarkPoolErrorCode {
+  // Inverse of crates/dp-api/src/rest.rs::ApiError::into_response.
+  switch (status) {
+    case 400:
+      return DARK_POOL_ERROR_CODES.INVALID_ARGUMENT
+    case 401:
+      return DARK_POOL_ERROR_CODES.UNAUTHENTICATED
+    case 403:
+      return DARK_POOL_ERROR_CODES.PERMISSION_DENIED
+    case 404:
+      return DARK_POOL_ERROR_CODES.NOT_FOUND
+    case 409:
+      return DARK_POOL_ERROR_CODES.ALREADY_EXISTS
+    case 429:
+      return DARK_POOL_ERROR_CODES.RESOURCE_EXHAUSTED
+    case 501:
+      return DARK_POOL_ERROR_CODES.UNIMPLEMENTED
+    case 503:
+      return DARK_POOL_ERROR_CODES.UNAVAILABLE
+    case 504:
+      return DARK_POOL_ERROR_CODES.DEADLINE_EXCEEDED
+    default:
+      if (status >= 500) return DARK_POOL_ERROR_CODES.INTERNAL
+      return DARK_POOL_ERROR_CODES.UNKNOWN
+  }
+}
+
+// ─── Client interface ─────────────────────────────────────────────────────
+
+export interface StreamOptions {
+  signal?: AbortSignal
+}
+
+export interface DarkPoolClient {
+  placeOrder(req: PlaceOrderRequest): Promise<PlaceOrderResponse>
+  cancelOrder(req: CancelOrderRequest): Promise<CancelOrderResponse>
+  getOrder(req: GetOrderRequest): Promise<GetOrderResponse>
+  getOrderBook(req: GetOrderBookRequest): Promise<GetOrderBookResponse>
+  getAuctionHistory(req: GetAuctionHistoryRequest): Promise<GetAuctionHistoryResponse>
+  streamAuctions(req: StreamAuctionsRequest, opts?: StreamOptions): AsyncIterable<AuctionEvent>
+}
+
+export const DARK_POOL_METHODS = [
+  'placeOrder',
+  'cancelOrder',
+  'getOrder',
+  'getOrderBook',
+  'getAuctionHistory',
+  'streamAuctions',
+] as const satisfies readonly (keyof DarkPoolClient)[]
+
+export type DarkPoolMethod = (typeof DARK_POOL_METHODS)[number]
+
+// ─── RestClient ───────────────────────────────────────────────────────────
+
+export interface RestClientOptions {
+  baseUrl: string
+  apiKey: string
+  /** Defaults to globalThis.fetch. Injectable so tests and SSR can swap it. */
+  fetch?: typeof fetch
+}
+
+export class RestClient implements DarkPoolClient {
+  private readonly baseUrl: string
+  private readonly apiKey: string
+  private readonly fetchImpl: typeof fetch
+
+  constructor(opts: RestClientOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, '')
+    this.apiKey = opts.apiKey
+    this.fetchImpl = opts.fetch ?? globalThis.fetch.bind(globalThis)
+  }
+
+  placeOrder(req: PlaceOrderRequest): Promise<PlaceOrderResponse> {
+    // toJson() honours the proto bytes→base64 spec, so commitment/proof/
+    // encryptedPayload arrive in the camelCase JSON shape the rest handler
+    // expects (PlaceOrderJson in crates/dp-api/src/rest.rs).
+    const body = toJson(PlaceOrderRequestSchema, req)
+    return this.requestJson('POST', '/v1/orders', PlaceOrderResponseSchema, body)
+  }
+
+  cancelOrder(req: CancelOrderRequest): Promise<CancelOrderResponse> {
+    const search = new URLSearchParams()
+    if (req.reason) search.set('reason', req.reason)
+    const qs = search.toString()
+    return this.requestJson(
+      'DELETE',
+      `/v1/orders/${encodeURIComponent(req.orderId)}${qs ? `?${qs}` : ''}`,
+      CancelOrderResponseSchema
+    )
+  }
+
+  getOrder(req: GetOrderRequest): Promise<GetOrderResponse> {
+    return this.requestJson(
+      'GET',
+      `/v1/orders/${encodeURIComponent(req.orderId)}`,
+      GetOrderResponseSchema
+    )
+  }
+
+  getOrderBook(req: GetOrderBookRequest): Promise<GetOrderBookResponse> {
+    const search = new URLSearchParams()
+    if (req.pair) search.set('pair', req.pair)
+    const qs = search.toString()
+    return this.requestJson('GET', `/v1/orderbook${qs ? `?${qs}` : ''}`, GetOrderBookResponseSchema)
+  }
+
+  getAuctionHistory(req: GetAuctionHistoryRequest): Promise<GetAuctionHistoryResponse> {
+    const search = new URLSearchParams()
+    if (req.pair) search.set('pair', req.pair)
+    if (req.limit > 0) search.set('limit', String(req.limit))
+    const qs = search.toString()
+    return this.requestJson(
+      'GET',
+      `/v1/auctions${qs ? `?${qs}` : ''}`,
+      GetAuctionHistoryResponseSchema
+    )
+  }
+
+  // eslint-disable-next-line require-yield
+  async *streamAuctions(
+    req: StreamAuctionsRequest,
+    opts?: StreamOptions
+  ): AsyncIterable<AuctionEvent> {
+    void req
+    void opts
+    // SSE bridge ships in #83 (C3); WASM streaming consumer lands with
+    // #95 (I2.6). Until either is on main, set
+    // NEXT_PUBLIC_USE_MOCKS_STREAM_AUCTIONS=true to keep panels on mocks.
+    throw new DarkPoolError(
+      DARK_POOL_ERROR_CODES.UNIMPLEMENTED,
+      'StreamAuctions over REST is not wired yet — depends on the SSE bridge in #83. ' +
+        'Use NEXT_PUBLIC_USE_MOCKS_STREAM_AUCTIONS=true until then.'
+    )
+  }
+
+  private async requestJson<S extends DescMessage>(
+    method: string,
+    path: string,
+    responseSchema: S,
+    jsonBody?: unknown
+  ): Promise<MessageShape<S>> {
+    const url = `${this.baseUrl}${path}`
+    const headers: Record<string, string> = {
+      accept: 'application/json',
+      'x-api-key': this.apiKey,
+    }
+    if (jsonBody !== undefined) headers['content-type'] = 'application/json'
+
+    let response: Response
+    try {
+      response = await this.fetchImpl(url, {
+        method,
+        headers,
+        body: jsonBody !== undefined ? JSON.stringify(jsonBody) : undefined,
+      })
+    } catch (cause) {
+      throw new DarkPoolError(
+        DARK_POOL_ERROR_CODES.UNAVAILABLE,
+        `Network error contacting ${url}: ${(cause as Error)?.message ?? cause}`,
+        { cause }
+      )
+    }
+
+    if (!response.ok) throw await parseErrorResponse(response)
+
+    const text = await response.text()
+    const json = text === '' ? {} : (JSON.parse(text) as unknown)
+    return fromJson(responseSchema, json as Parameters<typeof fromJson<S>>[1])
+  }
+}
+
+async function parseErrorResponse(response: Response): Promise<DarkPoolError> {
+  let body: { code?: unknown; message?: unknown } = {}
+  try {
+    const text = await response.text()
+    if (text) body = JSON.parse(text) as typeof body
+  } catch {
+    // Non-JSON body — fall through to HTTP-status-based mapping.
+  }
+  const code = codeFromBody(body.code) ?? codeFromHttpStatus(response.status)
+  const message =
+    typeof body.message === 'string' && body.message.length > 0
+      ? body.message
+      : `HTTP ${response.status} from ${response.url}`
+  return new DarkPoolError(code, message, { httpStatus: response.status })
+}
+
+// ─── MockClient ───────────────────────────────────────────────────────────
+//
+// Minimal in-memory client so the UI shell can mount without crashing while
+// F1.2 (#69) is in flight. Storage is intentionally trivial: order placement
+// gets a synthetic id, getOrder returns NOT_FOUND for unknown ids, and the
+// orderbook/auction surfaces return empty payloads. #69 replaces this with
+// the mock-store + faker factories.
+
+export class MockClient implements DarkPoolClient {
+  private readonly orders = new Map<string, ReturnType<typeof create<typeof OrderInfoSchema>>>()
+  private nextId = 1
+  private readonly pair: string
+
+  constructor(opts: { pair?: string } = {}) {
+    this.pair = opts.pair ?? 'ETH/USDC'
+  }
+
+  async placeOrder(req: PlaceOrderRequest): Promise<PlaceOrderResponse> {
+    const id = `mock-${this.nextId++}`
+    const order = create(OrderInfoSchema, {
+      id,
+      pair: this.pair,
+      side: Side.BUY,
+      price: '0',
+      size: '0',
+      remainingSize: '0',
+      commitmentKey: bytesPreview(req.commitment),
+      submittedAtUnix: BigInt(Math.floor(Date.now() / 1000)),
+      expiresAtUnix: 0n,
+    })
+    this.orders.set(id, order)
+    return create(PlaceOrderResponseSchema, { order })
+  }
+
+  async cancelOrder(req: CancelOrderRequest): Promise<CancelOrderResponse> {
+    if (!this.orders.delete(req.orderId)) {
+      throw new DarkPoolError(DARK_POOL_ERROR_CODES.NOT_FOUND, `Order ${req.orderId} not found`)
+    }
+    return create(CancelOrderResponseSchema, {})
+  }
+
+  async getOrder(req: GetOrderRequest): Promise<GetOrderResponse> {
+    const order = this.orders.get(req.orderId)
+    if (!order) {
+      throw new DarkPoolError(DARK_POOL_ERROR_CODES.NOT_FOUND, `Order ${req.orderId} not found`)
+    }
+    return create(GetOrderResponseSchema, { order })
+  }
+
+  async getOrderBook(req: GetOrderBookRequest): Promise<GetOrderBookResponse> {
+    return create(GetOrderBookResponseSchema, {
+      pair: req.pair || this.pair,
+      bids: [],
+      asks: [],
+    })
+  }
+
+  async getAuctionHistory(req: GetAuctionHistoryRequest): Promise<GetAuctionHistoryResponse> {
+    void req
+    return create(GetAuctionHistoryResponseSchema, { auctions: [] })
+  }
+
+  // eslint-disable-next-line require-yield
+  async *streamAuctions(
+    req: StreamAuctionsRequest,
+    opts?: StreamOptions
+  ): AsyncIterable<AuctionEvent> {
+    void req
+    // Block until the caller aborts, yielding nothing. F1.2 (#69) replaces
+    // this with timer-driven synthetic events sourced from the mock store.
+    const signal = opts?.signal
+    if (signal?.aborted) return
+    await new Promise<void>((resolve) => {
+      if (!signal) return // never resolves; caller must call return() on the iterator
+      signal.addEventListener('abort', () => resolve(), { once: true })
+    })
+  }
+}
+
+function bytesPreview(b: Uint8Array): string {
+  if (b.length === 0) return ''
+  const slice = Array.from(b.slice(0, 4))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+  return `mock-commitment-${slice}`
+}
+
+// ─── Factory + per-method routing ─────────────────────────────────────────
+
+export interface CreateDarkPoolClientOptions {
+  baseUrl: string
+  apiKey: string
+  /** Global default. Overridden per-method by `methodOverrides`. */
+  useMocks: boolean
+  fetch?: typeof fetch
+  /** Pre-built clients; useful for tests and SSR. */
+  mockClient?: DarkPoolClient
+  restClient?: DarkPoolClient
+  /**
+   * Per-method overrides. `true` forces the mock impl for that RPC,
+   * `false` forces the rest impl, `undefined` falls back to `useMocks`.
+   */
+  methodOverrides?: Partial<Record<DarkPoolMethod, boolean>>
+}
+
+export function createDarkPoolClient(opts: CreateDarkPoolClientOptions): DarkPoolClient {
+  const overrides = opts.methodOverrides ?? {}
+  const hasOverrides = Object.values(overrides).some((v) => v !== undefined)
+
+  const makeMock = (): DarkPoolClient => opts.mockClient ?? new MockClient()
+  const makeRest = (): DarkPoolClient =>
+    opts.restClient ??
+    new RestClient({
+      baseUrl: opts.baseUrl,
+      apiKey: opts.apiKey,
+      fetch: opts.fetch,
+    })
+
+  if (!hasOverrides) {
+    return opts.useMocks ? makeMock() : makeRest()
+  }
+
+  let mockImpl: DarkPoolClient | null = null
+  let restImpl: DarkPoolClient | null = null
+  const pick = (m: DarkPoolMethod): DarkPoolClient => {
+    const useMock = overrides[m] ?? opts.useMocks
+    if (useMock) {
+      mockImpl ??= makeMock()
+      return mockImpl
+    }
+    restImpl ??= makeRest()
+    return restImpl
+  }
+  return new RoutingClient(pick)
+}
+
+class RoutingClient implements DarkPoolClient {
+  constructor(private readonly pick: (m: DarkPoolMethod) => DarkPoolClient) {}
+
+  placeOrder(req: PlaceOrderRequest): Promise<PlaceOrderResponse> {
+    return this.pick('placeOrder').placeOrder(req)
+  }
+  cancelOrder(req: CancelOrderRequest): Promise<CancelOrderResponse> {
+    return this.pick('cancelOrder').cancelOrder(req)
+  }
+  getOrder(req: GetOrderRequest): Promise<GetOrderResponse> {
+    return this.pick('getOrder').getOrder(req)
+  }
+  getOrderBook(req: GetOrderBookRequest): Promise<GetOrderBookResponse> {
+    return this.pick('getOrderBook').getOrderBook(req)
+  }
+  getAuctionHistory(req: GetAuctionHistoryRequest): Promise<GetAuctionHistoryResponse> {
+    return this.pick('getAuctionHistory').getAuctionHistory(req)
+  }
+  streamAuctions(req: StreamAuctionsRequest, opts?: StreamOptions): AsyncIterable<AuctionEvent> {
+    return this.pick('streamAuctions').streamAuctions(req, opts)
+  }
+}
+
+// ─── Env helpers ──────────────────────────────────────────────────────────
+
+const METHOD_ENV_VAR: Record<DarkPoolMethod, string> = {
+  placeOrder: 'NEXT_PUBLIC_USE_MOCKS_PLACE_ORDER',
+  cancelOrder: 'NEXT_PUBLIC_USE_MOCKS_CANCEL_ORDER',
+  getOrder: 'NEXT_PUBLIC_USE_MOCKS_GET_ORDER',
+  getOrderBook: 'NEXT_PUBLIC_USE_MOCKS_ORDERBOOK',
+  getAuctionHistory: 'NEXT_PUBLIC_USE_MOCKS_AUCTION_HISTORY',
+  streamAuctions: 'NEXT_PUBLIC_USE_MOCKS_STREAM_AUCTIONS',
+}
+
+export function methodOverridesFromEnv(
+  env: Record<string, string | undefined> = readPublicEnv()
+): Partial<Record<DarkPoolMethod, boolean>> {
+  const out: Partial<Record<DarkPoolMethod, boolean>> = {}
+  for (const m of DARK_POOL_METHODS) {
+    const raw = env[METHOD_ENV_VAR[m]]
+    if (raw === undefined || raw === '') continue
+    if (raw === 'true' || raw === '1') out[m] = true
+    else if (raw === 'false' || raw === '0') out[m] = false
+  }
+  return out
+}
+
+// Inlined per-key reads keep Next's NEXT_PUBLIC_* inlining working at build
+// time (NEXT_PUBLIC vars are statically replaced; bracket-access on
+// process.env would defeat that).
+function readPublicEnv(): Record<string, string | undefined> {
+  return {
+    NEXT_PUBLIC_USE_MOCKS_PLACE_ORDER: process.env.NEXT_PUBLIC_USE_MOCKS_PLACE_ORDER,
+    NEXT_PUBLIC_USE_MOCKS_CANCEL_ORDER: process.env.NEXT_PUBLIC_USE_MOCKS_CANCEL_ORDER,
+    NEXT_PUBLIC_USE_MOCKS_GET_ORDER: process.env.NEXT_PUBLIC_USE_MOCKS_GET_ORDER,
+    NEXT_PUBLIC_USE_MOCKS_ORDERBOOK: process.env.NEXT_PUBLIC_USE_MOCKS_ORDERBOOK,
+    NEXT_PUBLIC_USE_MOCKS_AUCTION_HISTORY: process.env.NEXT_PUBLIC_USE_MOCKS_AUCTION_HISTORY,
+    NEXT_PUBLIC_USE_MOCKS_STREAM_AUCTIONS: process.env.NEXT_PUBLIC_USE_MOCKS_STREAM_AUCTIONS,
+  }
+}

--- a/front/lib/sdk/provider.tsx
+++ b/front/lib/sdk/provider.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { createContext, useContext, useMemo, type ReactNode } from 'react'
+
+import { config } from '../config'
+import { createDarkPoolClient, methodOverridesFromEnv, type DarkPoolClient } from './client'
+
+const DarkPoolClientContext = createContext<DarkPoolClient | null>(null)
+
+export interface DarkPoolClientProviderProps {
+  /**
+   * Optional pre-built client. When omitted, the provider lazily builds one
+   * from `lib/config.ts` + per-method env overrides — the production path.
+   * Tests and Storybook pass an explicit client.
+   */
+  client?: DarkPoolClient
+  children: ReactNode
+}
+
+export function DarkPoolClientProvider({
+  client,
+  children,
+}: DarkPoolClientProviderProps): JSX.Element {
+  const value = useMemo(() => client ?? getDefaultClient(), [client])
+  return <DarkPoolClientContext.Provider value={value}>{children}</DarkPoolClientContext.Provider>
+}
+
+export function useDarkPoolClient(): DarkPoolClient {
+  const ctx = useContext(DarkPoolClientContext)
+  if (!ctx) {
+    throw new Error('useDarkPoolClient must be used inside <DarkPoolClientProvider>.')
+  }
+  return ctx
+}
+
+let cachedDefault: DarkPoolClient | null = null
+
+/**
+ * Lazily-instantiated default client backed by `lib/config.ts`. Lives at
+ * module scope so navigating between trading routes keeps the same handle
+ * (and any future in-flight state inside `MockClient`).
+ */
+function getDefaultClient(): DarkPoolClient {
+  if (cachedDefault) return cachedDefault
+  cachedDefault = createDarkPoolClient({
+    baseUrl: config.apiUrl,
+    apiKey: config.apiKey,
+    useMocks: config.useMocks,
+    methodOverrides: methodOverridesFromEnv(),
+  })
+  return cachedDefault
+}


### PR DESCRIPTION
Closes #65

## Why

Single seam between the trading UI and the engine. The whole UI talks to one
`DarkPoolClient` interface; flipping `NEXT_PUBLIC_USE_MOCKS` swaps the
implementation, with no UI changes. Per-method env flags let Phase 2 swap
endpoints one at a time without flipping everything.

## What

**`front/lib/sdk/client.ts`** — the SDK itself.

- `DarkPoolClient` interface over the six RPCs from `DarkPoolService`:
  `placeOrder`, `cancelOrder`, `getOrder`, `getOrderBook`,
  `getAuctionHistory` (Promise) + `streamAuctions` (AsyncIterable). Uses
  the generated message types from F0.3 (#64).
- `RestClient` — fetch against `NEXT_PUBLIC_DARKPOOL_API_URL`. Sends
  `x-api-key` on every call. `placeOrder` runs the request through
  `toJson(PlaceOrderRequestSchema, …)`, which honours the proto
  `bytes`→base64 mapping, so `commitment` / `proof` / `encryptedPayload`
  arrive in the exact camelCase JSON shape `PlaceOrderJson` expects in
  `crates/dp-api/src/rest.rs`. Responses go through `fromJson()` so
  `int64` timestamps land as `bigint` per the proto3 JSON spec
  (mirrored in the rest handler). `streamAuctions` throws
  `UNIMPLEMENTED` until #83 lands the SSE bridge — set
  `NEXT_PUBLIC_USE_MOCKS_STREAM_AUCTIONS=true` to keep panels on mocks
  in the meantime.
- `MockClient` — minimal in-memory stub. F1.2 (#69) will replace it
  with the mock store + faker factories. For now: placed orders go in
  a `Map`, `getOrder` / `cancelOrder` round-trip the same map (with
  `NOT_FOUND` on miss), and orderbook / auction history return empty
  payloads. Enough that #68's shell can mount without throwing.
- `DarkPoolError` — typed error mirroring `tonic::Code`. We round-trip
  the numeric discriminant returned by `ApiError::into_response` so
  callers can `switch` on it without parsing strings. If the body has
  no `code` (proxy errors, raw 5xx, network failures) we map back from
  the HTTP status with the inverse of the server's mapping. Transient
  codes (`UNAVAILABLE`, `DEADLINE_EXCEEDED`, `ABORTED`) are flagged
  `retryable`.
- `createDarkPoolClient` + `RoutingClient` — factory honours
  `useMocks` plus optional per-method overrides. Without overrides it
  returns a pure `MockClient` or `RestClient`; with overrides it wraps
  both in a thin router that dispatches per RPC.
- `methodOverridesFromEnv` — parses the six
  `NEXT_PUBLIC_USE_MOCKS_*` per-method flags (`PLACE_ORDER`,
  `CANCEL_ORDER`, `GET_ORDER`, `ORDERBOOK`, `AUCTION_HISTORY`,
  `STREAM_AUCTIONS`). Uses explicit per-key reads so Next's
  compile-time inlining of `NEXT_PUBLIC_*` still works.

**`front/lib/sdk/provider.tsx`** — `DarkPoolClientProvider` +
`useDarkPoolClient()` hook. Provider accepts an optional pre-built
client (for tests / Storybook); otherwise lazily builds one from
`lib/config.ts` + per-method env overrides. The default handle is
memoised at module scope so navigating between trading routes keeps
the same `MockClient` instance (and any in-flight state inside it).

**`front/lib/api-client.ts`** — convenience re-exports of the public
SDK surface. The acceptance criteria asks consumers to import from
`@/lib/api-client` rather than reaching into `@/lib/sdk/*`, so the
internal layout (`proto/`, `client.ts`, `mocks/`, `provider.tsx`)
stays an implementation detail.

## Acceptance criteria

- [x] `DarkPoolClient` interface exposed with `placeOrder` / `cancelOrder`
      / `getOrder` / `getOrderBook` / `getAuctionHistory` /
      `streamAuctions`.
- [x] `MockClient` (in-memory) and `RestClient` (`fetch`, `x-api-key`,
      base64-encoded `commitment` / `proof` / `encryptedPayload`).
- [x] `createDarkPoolClient(config)` factory selects via
      `NEXT_PUBLIC_USE_MOCKS`.
- [x] React provider + `useDarkPoolClient()` hook.
- [x] Per-method env flags supported
      (`NEXT_PUBLIC_USE_MOCKS_ORDERBOOK`, etc.) so Phase 2 can
      integrate one endpoint at a time without flipping everything.
- [x] Generated message types from F0.3 used in the interface signature.
- [x] `RestClient` maps `tonic::Code` (body discriminant + HTTP-status
      fallback) to a typed `DarkPoolError` — prep for F4.4 / I2.10.

## File scope

Per `docs/PARALLEL-WORK.md` this PR only touches the F0.4 scope:
`front/lib/sdk/client.ts`, `front/lib/api-client.ts`, plus a sibling
`front/lib/sdk/provider.tsx` for the React layer the issue explicitly
asks for. No other files modified.

## Test plan

- [x] `npm test` — 26 new tests, 72 total passing
  - RestClient fetch shape (URL, method, `x-api-key`, base64-encoded
    body fields, trailing-slash baseUrl normalisation)
  - URL encoding for ids / query params; `limit=0` omitted (proto
    default = server-chosen)
  - `int64` decoded to `bigint` on responses
  - Error mapping: body `code`, HTTP-status fallback, unknown body
    code, network-level `fetch` rejection
  - `MockClient` round-trips and `NOT_FOUND` semantics
  - Factory selection: pure mock / pure rest / per-method routing
  - `methodOverridesFromEnv` parses `true|false|1|0` and skips
    empty / undefined
  - `DarkPoolError` `codeName` + `retryable` flags
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build`