### PR TITLE
[F1.2] Mock store + faker factories

### DIFF
--- a/front/lib/mock-store.test.ts
+++ b/front/lib/mock-store.test.ts
@@ -159,6 +159,47 @@ describe('runAuction', () => {
     expect(store.getState().openOrders.some((o) => o.id === placed.id)).toBe(true)
     expect(store.getState().fillHistory).toEqual([])
   })
+
+  it('refunds the consumed order back out of the orderbook level', () => {
+    const store = freshStore()
+    // Pick an off-grid price so the order owns its level entirely.
+    const placed = store.getState().placeOrder({
+      side: Side.BUY,
+      price: '9999.50',
+      size: '0.75',
+    })
+    const levelBefore = store.getState().orderbook.bids.find((l) => l.price === '9999.5')
+    expect(levelBefore).toBeDefined()
+    expect(levelBefore!.totalSize).toBe('0.75')
+    store.getState().runAuction()
+    const s = store.getState()
+    expect(s.openOrders.some((o) => o.id === placed.id)).toBe(false)
+    // Level had a single order; refund drains it entirely.
+    expect(s.orderbook.bids.find((l) => l.price === '9999.5')).toBeUndefined()
+  })
+
+  it('only refunds the filled order, not other orders at the same price', () => {
+    const store = freshStore()
+    const a = store.getState().placeOrder({ side: Side.BUY, price: '9998', size: '0.4' })
+    const b = store.getState().placeOrder({ side: Side.BUY, price: '9998', size: '0.6' })
+    const levelBefore = store.getState().orderbook.bids.find((l) => l.price === '9998')!
+    expect(levelBefore.orderCount).toBeGreaterThanOrEqual(2)
+    const totalBefore = new Decimal(levelBefore.totalSize)
+    store.getState().runAuction()
+    const s = store.getState()
+    // Exactly one of a/b was consumed.
+    const remainingIds = s.openOrders.map((o) => o.id)
+    const consumed = remainingIds.includes(a.id) ? b : a
+    const surviving = consumed === a ? b : a
+    expect(remainingIds).toContain(surviving.id)
+    expect(remainingIds).not.toContain(consumed.id)
+    const levelAfter = s.orderbook.bids.find((l) => l.price === '9998')!
+    expect(levelAfter).toBeDefined()
+    expect(levelAfter.orderCount).toBe(levelBefore.orderCount - 1)
+    expect(
+      new Decimal(levelAfter.totalSize).equals(totalBefore.minus(consumed.remainingSize))
+    ).toBe(true)
+  })
 })
 
 describe('start / stop tick loop', () => {

--- a/front/lib/mock-store.test.ts
+++ b/front/lib/mock-store.test.ts
@@ -1,0 +1,241 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Decimal, fromWireSize } from './units'
+
+import { Side } from './sdk/proto/darkpool/v1/darkpool_pb.js'
+
+import { DEFAULT_AUCTION_HISTORY, RECENT_AUCTIONS_CAP, createMockStore } from './mock-store'
+
+const FROZEN_NOW = 1700000000
+const SEED = 42
+
+function freshStore(seed = SEED) {
+  return createMockStore({ seed, now: () => FROZEN_NOW, mid: '3000', depth: 8 })
+}
+
+describe('createMockStore — initial state', () => {
+  it('hydrates orderbook, balances, and seed recent auctions', () => {
+    const store = freshStore()
+    const s = store.getState()
+    expect(s.pair).toBe('ETH/USDC')
+    expect(s.orderbook.bids.length).toBeGreaterThan(0)
+    expect(s.orderbook.asks.length).toBeGreaterThan(0)
+    expect(s.balances.weth).toBe('10')
+    expect(s.balances.usdc).toBe('25000')
+    expect(s.openOrders).toEqual([])
+    expect(s.fillHistory).toEqual([])
+    expect(s.recentAuctions).toHaveLength(DEFAULT_AUCTION_HISTORY)
+  })
+
+  it('two stores with the same seed produce equal initial orderbooks', () => {
+    const a = freshStore().getState().orderbook
+    const b = freshStore().getState().orderbook
+    expect(a.bids.map((l) => [l.price, l.totalSize])).toEqual(
+      b.bids.map((l) => [l.price, l.totalSize])
+    )
+    expect(a.asks.map((l) => [l.price, l.totalSize])).toEqual(
+      b.asks.map((l) => [l.price, l.totalSize])
+    )
+  })
+})
+
+describe('placeOrder', () => {
+  it('prepends to openOrders and drops the size into the matching level', () => {
+    const store = freshStore()
+    const beforeBid = store.getState().orderbook.bids.find((l) => l.price === '2995')
+    const beforeSize = beforeBid ? new Decimal(beforeBid.totalSize) : new Decimal(0)
+    const order = store.getState().placeOrder({
+      side: Side.BUY,
+      price: '2995',
+      size: '1.5',
+    })
+    const s = store.getState()
+    expect(s.openOrders[0].id).toBe(order.id)
+    expect(s.openOrders[0].remainingSize).toBe('1.5')
+    const level = s.orderbook.bids.find((l) => l.price === '2995')
+    expect(level).toBeDefined()
+    expect(new Decimal(level!.totalSize).equals(beforeSize.plus('1.5'))).toBe(true)
+  })
+
+  it('inserts a brand-new level when the price is off-grid, keeping bids sorted desc', () => {
+    const store = freshStore()
+    store.getState().placeOrder({ side: Side.BUY, price: '2950.50', size: '0.25' })
+    const bids = store.getState().orderbook.bids
+    for (let i = 1; i < bids.length; i++) {
+      expect(new Decimal(bids[i].price).lt(bids[i - 1].price)).toBe(true)
+    }
+    expect(bids.some((l) => l.price === '2950.5')).toBe(true)
+  })
+
+  it('rejects sizes above the wire precision via the units helper', () => {
+    const store = freshStore()
+    expect(() =>
+      store.getState().placeOrder({ side: Side.BUY, price: '3000', size: '0.000000001' })
+    ).toThrow(/8dp/)
+  })
+})
+
+describe('cancelOrder', () => {
+  it('removes from openOrders and refunds the level', () => {
+    const store = freshStore()
+    const order = store.getState().placeOrder({
+      side: Side.SELL,
+      price: '3005',
+      size: '1.5',
+    })
+    const before = store.getState().orderbook.asks.find((l) => l.price === '3005')!
+    const ok = store.getState().cancelOrder(order.id)
+    expect(ok).toBe(true)
+    const after = store.getState().orderbook.asks.find((l) => l.price === '3005')
+    if (before.orderCount > 1) {
+      expect(after).toBeDefined()
+      expect(new Decimal(after!.totalSize).equals(new Decimal(before.totalSize).minus('1.5'))).toBe(
+        true
+      )
+    } else {
+      expect(after).toBeUndefined()
+    }
+    expect(store.getState().openOrders.some((o) => o.id === order.id)).toBe(false)
+  })
+
+  it('returns false for unknown ids without touching state', () => {
+    const store = freshStore()
+    const before = store.getState()
+    const ok = store.getState().cancelOrder('ghost')
+    expect(ok).toBe(false)
+    expect(store.getState()).toBe(before)
+  })
+})
+
+describe('perturbOrderbook', () => {
+  it('rewrites level sizes while keeping price grid stable', () => {
+    const store = freshStore()
+    const before = store.getState().orderbook
+    store.getState().perturbOrderbook()
+    const after = store.getState().orderbook
+    expect(after.bids.map((l) => l.price)).toEqual(before.bids.map((l) => l.price))
+    expect(after.asks.map((l) => l.price)).toEqual(before.asks.map((l) => l.price))
+    const changed = after.bids.some((l, i) => l.totalSize !== before.bids[i].totalSize)
+    expect(changed).toBe(true)
+  })
+})
+
+describe('runAuction', () => {
+  it('prepends a fresh AuctionSummary with a clearing price near the current mid', () => {
+    const store = freshStore()
+    const beforeCount = store.getState().recentAuctions.length
+    const auction = store.getState().runAuction()
+    expect(store.getState().recentAuctions[0].auctionId).toBe(auction.auctionId)
+    expect(store.getState().recentAuctions).toHaveLength(beforeCount + 1)
+    const cp = new Decimal(auction.clearingPrice)
+    expect(cp.gte('2900')).toBe(true)
+    expect(cp.lte('3100')).toBe(true)
+    expect(auction.timestampUnix).toBe(BigInt(FROZEN_NOW))
+  })
+
+  it('caps recentAuctions at RECENT_AUCTIONS_CAP', () => {
+    const store = freshStore()
+    for (let i = 0; i < RECENT_AUCTIONS_CAP + 5; i++) store.getState().runAuction()
+    expect(store.getState().recentAuctions).toHaveLength(RECENT_AUCTIONS_CAP)
+  })
+
+  it('consumes an in-the-money open order into fillHistory', () => {
+    const store = freshStore()
+    // A buy at far above mid is guaranteed to clear in the next auction.
+    const placed = store.getState().placeOrder({ side: Side.BUY, price: '10000', size: '0.5' })
+    store.getState().runAuction()
+    const s = store.getState()
+    expect(s.openOrders.some((o) => o.id === placed.id)).toBe(false)
+    expect(s.fillHistory.length).toBeGreaterThan(0)
+    expect(s.fillHistory[0].orderId).toBe(placed.id)
+    expect(fromWireSize(s.fillHistory[0].size).equals(new Decimal('0.5'))).toBe(true)
+  })
+
+  it('leaves the book and orders alone when nothing matches', () => {
+    const store = freshStore()
+    // A sell well above any plausible clearing won't clear.
+    const placed = store.getState().placeOrder({ side: Side.SELL, price: '100000', size: '0.1' })
+    store.getState().runAuction()
+    expect(store.getState().openOrders.some((o) => o.id === placed.id)).toBe(true)
+    expect(store.getState().fillHistory).toEqual([])
+  })
+})
+
+describe('start / stop tick loop', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ now: FROZEN_NOW * 1000 })
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('fires perturb on perturbMs and runAuction on auctionMs', () => {
+    const store = freshStore()
+    const beforeBook = store.getState().orderbook
+    const beforeAuctions = store.getState().recentAuctions.length
+    store.getState().start({ perturbMs: 100, auctionMs: 500 })
+
+    vi.advanceTimersByTime(100)
+    expect(store.getState().orderbook).not.toBe(beforeBook)
+
+    vi.advanceTimersByTime(400)
+    expect(store.getState().recentAuctions.length).toBe(beforeAuctions + 1)
+
+    store.getState().stop()
+  })
+
+  it('start is idempotent — calling twice does not double the timer count', () => {
+    const store = freshStore()
+    store.getState().start({ perturbMs: 100, auctionMs: 500 })
+    store.getState().start({ perturbMs: 100, auctionMs: 500 })
+    const beforeAuctions = store.getState().recentAuctions.length
+    vi.advanceTimersByTime(500)
+    expect(store.getState().recentAuctions.length).toBe(beforeAuctions + 1)
+    store.getState().stop()
+  })
+
+  it('stop halts further ticks', () => {
+    const store = freshStore()
+    store.getState().start({ perturbMs: 100, auctionMs: 500 })
+    store.getState().stop()
+    const snapshot = store.getState().orderbook
+    vi.advanceTimersByTime(2000)
+    expect(store.getState().orderbook).toBe(snapshot)
+  })
+})
+
+describe('seed / reset', () => {
+  it('seed re-initialises with a fresh faker handle', () => {
+    const store = freshStore()
+    store.getState().placeOrder({ side: Side.BUY, price: '2999', size: '0.5' })
+    expect(store.getState().openOrders).toHaveLength(1)
+    store.getState().seed({ seed: 7, mid: '3000', depth: 4 })
+    const s = store.getState()
+    expect(s.openOrders).toEqual([])
+    expect(s.fillHistory).toEqual([])
+    expect(s.orderbook.bids).toHaveLength(4)
+    expect(s.orderbook.asks).toHaveLength(4)
+  })
+
+  it('reset wipes runtime state but keeps the original seed', () => {
+    const a = freshStore()
+    const baselineBidPrices = a.getState().orderbook.bids.map((l) => l.price)
+    a.getState().placeOrder({ side: Side.BUY, price: '2999', size: '0.5' })
+    a.getState().reset()
+    expect(a.getState().openOrders).toEqual([])
+    // After reset, the orderbook is regenerated from the same seeded ctx,
+    // so the price grid still has the same set of levels.
+    expect(a.getState().orderbook.bids.map((l) => l.price)).toEqual(baselineBidPrices)
+  })
+
+  it('seed stops a running tick loop', () => {
+    vi.useFakeTimers({ now: FROZEN_NOW * 1000 })
+    const store = freshStore()
+    store.getState().start({ perturbMs: 100, auctionMs: 500 })
+    store.getState().seed({ seed: 3 })
+    const snapshot = store.getState().orderbook
+    vi.advanceTimersByTime(2000)
+    expect(store.getState().orderbook).toBe(snapshot)
+    vi.useRealTimers()
+  })
+})

--- a/front/lib/mock-store.ts
+++ b/front/lib/mock-store.ts
@@ -178,10 +178,16 @@ export function createMockStore(opts: CreateMockStoreOptions = {}): StoreApi<Moc
         pair: ctx.pair,
         timestampUnix: BigInt(ctx.now()),
       })
-      const fill = consumeOpenOrder(ctx, get().openOrders, auction)
+      const openOrders = get().openOrders
+      const fill = consumeOpenOrder(ctx, openOrders, auction)
+      const filledOrder = fill ? (openOrders.find((o) => o.id === fill.orderId) ?? null) : null
       set((s) => ({
         recentAuctions: [auction, ...s.recentAuctions].slice(0, RECENT_AUCTIONS_CAP),
         openOrders: fill ? s.openOrders.filter((o) => o.id !== fill.orderId) : s.openOrders,
+        // A fill clears the trader's liquidity from the book in lockstep with
+        // openOrders — otherwise the orderbook drifts away from the truth and
+        // panels that cross-reference the two (e.g. #73) see phantom depth.
+        orderbook: filledOrder ? removeOrderFromBook(s.orderbook, filledOrder) : s.orderbook,
         fillHistory: fill ? [fill, ...s.fillHistory].slice(0, FILL_HISTORY_CAP) : s.fillHistory,
       }))
       return auction

--- a/front/lib/mock-store.ts
+++ b/front/lib/mock-store.ts
@@ -1,0 +1,379 @@
+// Simulated backend for Phase 1 of the trading app. A Zustand store holds
+// the orderbook, recent auctions, balances, open orders, and fill history;
+// a tick loop perturbs the book every second and runs a new clearing
+// auction every five. Panels (#71/#73/#74) read from the store via the
+// React hook, and `StoreMockClient` in lib/sdk/mocks/client.ts adapts the
+// same state to the `DarkPoolClient` interface so the entire UI flips to
+// the REST surface in Phase 2 with no callsite changes.
+//
+// `createMockStore` is the testable factory; `mockStore` is the runtime
+// singleton, stashed on a `Symbol.for`-keyed slot of `globalThis` so it
+// survives Next.js hot-module reloads in dev.
+
+import { create as createMessage } from '@bufbuild/protobuf'
+import { useSyncExternalStore } from 'react'
+import { createStore, type StoreApi } from 'zustand/vanilla'
+
+import { Decimal, toWireSize } from './units'
+
+import {
+  GetOrderBookResponseSchema,
+  PriceLevelSchema,
+  Side,
+} from './sdk/proto/darkpool/v1/darkpool_pb.js'
+import type {
+  AuctionSummary,
+  GetOrderBookResponse,
+  OrderInfo,
+  PriceLevel,
+} from './sdk/proto/darkpool/v1/darkpool_pb.js'
+
+import {
+  DEFAULT_MID,
+  type Balances,
+  type FactoryContext,
+  type Fill,
+  createFactoryContext,
+  midFromBook,
+  mockAuctionSummary,
+  mockBalances,
+  mockFill,
+  mockOrderBook,
+  mockOrderInfo,
+  scaleWireSize,
+} from './sdk/mocks/factories'
+
+// ─── Public state shape ───────────────────────────────────────────────────
+
+export interface MockStoreState {
+  pair: string
+  orderbook: GetOrderBookResponse
+  /** Newest first. Capped at `RECENT_AUCTIONS_CAP`. */
+  recentAuctions: AuctionSummary[]
+  balances: Balances
+  /** Orders the user placed but the engine hasn't cleared yet. Newest first. */
+  openOrders: OrderInfo[]
+  /** Append-only history of partial/full fills. Newest first. */
+  fillHistory: Fill[]
+}
+
+export interface PlaceOrderInput {
+  side: Side
+  price: Decimal | string
+  size: Decimal | string
+  commitmentKey?: string
+}
+
+export interface TickOptions {
+  perturbMs?: number
+  auctionMs?: number
+}
+
+export interface SeedOptions {
+  seed?: number
+  pair?: string
+  mid?: Decimal | string
+  /** Number of opening recent auctions surfaced to the tape on init. */
+  auctionHistory?: number
+  /** Number of price levels per side at seed time. */
+  depth?: number
+}
+
+export interface MockStoreActions {
+  /** Trader-facing: push a new order. Mutates openOrders + orderbook. */
+  placeOrder(input: PlaceOrderInput): OrderInfo
+  /** Trader-facing: remove an order and drain its level from the book. */
+  cancelOrder(orderId: string): boolean
+  /** 1 s tick: nudge level sizes so the book looks alive. */
+  perturbOrderbook(): void
+  /** 5 s tick: produce a new clearing auction sampled around current mid. */
+  runAuction(): AuctionSummary
+  /** Start the perturb/auction timers. No-op if already running. */
+  start(opts?: TickOptions): void
+  /** Cancel both timers. Safe to call before start(). */
+  stop(): void
+  /** Re-initialise with a fresh faker seed. Stops the loop first. */
+  seed(opts?: SeedOptions): void
+  /** Re-initialise with the same factory ctx. Stops the loop first. */
+  reset(): void
+}
+
+export type MockStore = MockStoreState & MockStoreActions
+
+// ─── Tunables ─────────────────────────────────────────────────────────────
+
+export const RECENT_AUCTIONS_CAP = 200
+export const FILL_HISTORY_CAP = 500
+export const DEFAULT_DEPTH = 12
+export const DEFAULT_AUCTION_HISTORY = 6
+const PERTURB_PROBABILITY = 0.5
+const UP_FACTOR = '1.05'
+const DOWN_FACTOR = '0.95'
+const SIZE_FLOOR = '0.0001'
+
+// ─── Factory ──────────────────────────────────────────────────────────────
+
+export interface CreateMockStoreOptions extends SeedOptions {
+  /** Injectable clock; defaults to wall time. */
+  now?: () => number
+}
+
+export function createMockStore(opts: CreateMockStoreOptions = {}): StoreApi<MockStore> {
+  let ctx = createFactoryContext({ seed: opts.seed, pair: opts.pair, now: opts.now })
+  let perturbTimer: ReturnType<typeof setInterval> | null = null
+  let auctionTimer: ReturnType<typeof setInterval> | null = null
+
+  const initialState = (current: FactoryContext, init: SeedOptions): MockStoreState => {
+    const mid = init.mid !== undefined ? new Decimal(init.mid.toString()) : DEFAULT_MID
+    const depth = init.depth ?? DEFAULT_DEPTH
+    const historyCount = init.auctionHistory ?? DEFAULT_AUCTION_HISTORY
+    return {
+      pair: current.pair,
+      orderbook: mockOrderBook(current, { pair: current.pair, mid, depth }),
+      recentAuctions: Array.from({ length: historyCount }, () =>
+        mockAuctionSummary(current, { mid, pair: current.pair })
+      ).sort((a, b) => Number(b.timestampUnix - a.timestampUnix)),
+      balances: mockBalances(current),
+      openOrders: [],
+      fillHistory: [],
+    }
+  }
+
+  const store = createStore<MockStore>((set, get) => ({
+    ...initialState(ctx, opts),
+
+    placeOrder(input) {
+      const order = mockOrderInfo(ctx, {
+        side: input.side,
+        price: input.price,
+        size: input.size,
+        commitmentKey: input.commitmentKey,
+      })
+      set((s) => ({
+        openOrders: [order, ...s.openOrders],
+        orderbook: addOrderToBook(s.orderbook, order),
+      }))
+      return order
+    },
+
+    cancelOrder(orderId) {
+      const order = get().openOrders.find((o) => o.id === orderId)
+      if (!order) return false
+      set((s) => ({
+        openOrders: s.openOrders.filter((o) => o.id !== orderId),
+        orderbook: removeOrderFromBook(s.orderbook, order),
+      }))
+      return true
+    },
+
+    perturbOrderbook() {
+      set((s) => ({ orderbook: perturbBook(ctx, s.orderbook) }))
+    },
+
+    runAuction() {
+      const book = get().orderbook
+      const mid = book.bids.length > 0 && book.asks.length > 0 ? midFromBook(book) : DEFAULT_MID
+      const auction = mockAuctionSummary(ctx, {
+        mid,
+        pair: ctx.pair,
+        timestampUnix: BigInt(ctx.now()),
+      })
+      const fill = consumeOpenOrder(ctx, get().openOrders, auction)
+      set((s) => ({
+        recentAuctions: [auction, ...s.recentAuctions].slice(0, RECENT_AUCTIONS_CAP),
+        openOrders: fill ? s.openOrders.filter((o) => o.id !== fill.orderId) : s.openOrders,
+        fillHistory: fill ? [fill, ...s.fillHistory].slice(0, FILL_HISTORY_CAP) : s.fillHistory,
+      }))
+      return auction
+    },
+
+    start(tickOpts) {
+      const perturbMs = tickOpts?.perturbMs ?? 1000
+      const auctionMs = tickOpts?.auctionMs ?? 5000
+      if (perturbTimer !== null || auctionTimer !== null) return
+      perturbTimer = setInterval(() => get().perturbOrderbook(), perturbMs)
+      auctionTimer = setInterval(() => get().runAuction(), auctionMs)
+    },
+
+    stop() {
+      if (perturbTimer !== null) {
+        clearInterval(perturbTimer)
+        perturbTimer = null
+      }
+      if (auctionTimer !== null) {
+        clearInterval(auctionTimer)
+        auctionTimer = null
+      }
+    },
+
+    seed(seedOpts) {
+      get().stop()
+      ctx = createFactoryContext({
+        seed: seedOpts?.seed,
+        pair: seedOpts?.pair ?? ctx.pair,
+        now: opts.now,
+      })
+      set(initialState(ctx, seedOpts ?? {}))
+    },
+
+    reset() {
+      get().stop()
+      set(initialState(ctx, opts))
+    },
+  }))
+
+  return store
+}
+
+// ─── HMR-safe singleton ───────────────────────────────────────────────────
+
+const MOCK_STORE_KEY = Symbol.for('darkpool.mockStore.v1')
+
+type GlobalSlot = Record<symbol, unknown>
+const globalSlot = globalThis as unknown as GlobalSlot
+
+const existing = globalSlot[MOCK_STORE_KEY] as StoreApi<MockStore> | undefined
+export const mockStore: StoreApi<MockStore> = existing ?? createMockStore({ seed: 1 })
+globalSlot[MOCK_STORE_KEY] = mockStore
+
+// ─── React binding ────────────────────────────────────────────────────────
+//
+// Avoids pulling `useStore` from `zustand` so this file doesn't import the
+// React-specific entrypoint (the vanilla store is the one we treat as the
+// API surface). The `useSyncExternalStore` adapter is the same one
+// `useStore` builds under the hood.
+
+export function useMockStore<T>(selector: (state: MockStore) => T): T {
+  return useSyncExternalStore(
+    mockStore.subscribe,
+    () => selector(mockStore.getState()),
+    () => selector(mockStore.getState())
+  )
+}
+
+// ─── Orderbook mutation helpers ──────────────────────────────────────────
+
+function perturbBook(ctx: FactoryContext, book: GetOrderBookResponse): GetOrderBookResponse {
+  const tweak = (level: PriceLevel): PriceLevel => {
+    if (!ctx.faker.datatype.boolean({ probability: PERTURB_PROBABILITY })) return level
+    const goesUp = ctx.faker.datatype.boolean()
+    const factor = goesUp ? UP_FACTOR : DOWN_FACTOR
+    return createMessage(PriceLevelSchema, {
+      price: level.price,
+      totalSize: scaleWireSize(level.totalSize, factor, SIZE_FLOOR),
+      orderCount: level.orderCount,
+    })
+  }
+  return createMessage(GetOrderBookResponseSchema, {
+    pair: book.pair,
+    bids: book.bids.map(tweak),
+    asks: book.asks.map(tweak),
+  })
+}
+
+function addOrderToBook(book: GetOrderBookResponse, order: OrderInfo): GetOrderBookResponse {
+  const isBuy = order.side === Side.BUY
+  const sideLevels = isBuy ? book.bids : book.asks
+  const otherLevels = isBuy ? book.asks : book.bids
+  const idx = sideLevels.findIndex((l) => l.price === order.price)
+
+  let updated: PriceLevel[]
+  if (idx >= 0) {
+    const existing = sideLevels[idx]
+    updated = [...sideLevels]
+    updated[idx] = createMessage(PriceLevelSchema, {
+      price: existing.price,
+      totalSize: toWireSize(new Decimal(existing.totalSize).plus(order.remainingSize)),
+      orderCount: existing.orderCount + 1,
+    })
+  } else {
+    const inserted = createMessage(PriceLevelSchema, {
+      price: order.price,
+      totalSize: order.remainingSize,
+      orderCount: 1,
+    })
+    updated = sortSide(isBuy, [...sideLevels, inserted])
+  }
+  return createMessage(GetOrderBookResponseSchema, {
+    pair: book.pair,
+    bids: isBuy ? updated : otherLevels,
+    asks: isBuy ? otherLevels : updated,
+  })
+}
+
+function removeOrderFromBook(book: GetOrderBookResponse, order: OrderInfo): GetOrderBookResponse {
+  const isBuy = order.side === Side.BUY
+  const sideLevels = isBuy ? book.bids : book.asks
+  const otherLevels = isBuy ? book.asks : book.bids
+  const idx = sideLevels.findIndex((l) => l.price === order.price)
+  if (idx < 0) return book
+
+  const existing = sideLevels[idx]
+  const newSize = new Decimal(existing.totalSize).minus(order.remainingSize)
+  let updated: PriceLevel[]
+  if (newSize.lte(0) || existing.orderCount <= 1) {
+    updated = sideLevels.filter((_, i) => i !== idx)
+  } else {
+    updated = [...sideLevels]
+    updated[idx] = createMessage(PriceLevelSchema, {
+      price: existing.price,
+      totalSize: toWireSize(newSize),
+      orderCount: existing.orderCount - 1,
+    })
+  }
+  return createMessage(GetOrderBookResponseSchema, {
+    pair: book.pair,
+    bids: isBuy ? updated : otherLevels,
+    asks: isBuy ? otherLevels : updated,
+  })
+}
+
+function sortSide(isBuy: boolean, levels: PriceLevel[]): PriceLevel[] {
+  const sorted = [...levels]
+  sorted.sort((a, b) =>
+    isBuy
+      ? new Decimal(b.price).cmp(new Decimal(a.price))
+      : new Decimal(a.price).cmp(new Decimal(b.price))
+  )
+  return sorted
+}
+
+// ─── Auction matcher ──────────────────────────────────────────────────────
+//
+// Picks one open order whose price is on the right side of the clearing
+// price and turns it into a Fill. Real matching is out of scope; this is
+// just enough for the open-orders panel (#77) and the portfolio P&L
+// (#78) to show movement.
+
+function consumeOpenOrder(
+  ctx: FactoryContext,
+  openOrders: OrderInfo[],
+  auction: AuctionSummary
+): Fill | null {
+  const clearing = new Decimal(auction.clearingPrice)
+  const eligible = openOrders.filter((o) => {
+    const price = new Decimal(o.price)
+    return o.side === Side.BUY ? price.gte(clearing) : price.lte(clearing)
+  })
+  if (eligible.length === 0) return null
+  const order = eligible[0]
+  return mockFill(ctx, {
+    orderId: order.id,
+    auctionId: auction.auctionId,
+    side: order.side,
+    price: auction.clearingPrice,
+    size: order.remainingSize,
+    timestampUnix: auction.timestampUnix,
+  })
+}
+
+// ─── Test helpers ─────────────────────────────────────────────────────────
+
+/** Reset the HMR-keyed slot. Tests only. */
+export function __resetMockStoreSingletonForTests(): void {
+  globalSlot[MOCK_STORE_KEY] = undefined
+}
+
+// Re-export the local Fill / Balances types for consumers that don't want
+// to reach into ./sdk/mocks/factories directly.
+export type { Balances, Fill } from './sdk/mocks/factories'

--- a/front/lib/sdk/index.ts
+++ b/front/lib/sdk/index.ts
@@ -82,3 +82,40 @@ export {
 // Friendly alias: the proto names the orderbook payload
 // `GetOrderBookResponse`, but consumers think of it as the order book itself.
 export type { GetOrderBookResponse as OrderBook } from './proto/darkpool/v1/darkpool_pb.js'
+
+// ─── F1.2 mocks (#69) ────────────────────────────────────────────────────
+//
+// Re-exports the Phase 1 simulated backend: typed faker factories, the
+// store-backed DarkPoolClient, and the runtime store handle. Phase 2
+// (#90+) replaces these by flipping `useMocks=false` in createDarkPoolClient
+// — no callsite changes required.
+
+export {
+  DEFAULT_MID,
+  DEFAULT_PAIR,
+  PRICE_DP,
+  SIZE_DP,
+  createFactoryContext,
+  midFromBook,
+  mockAuctionSummary,
+  mockBalances,
+  mockFill,
+  mockOrderBook,
+  mockOrderInfo,
+  mockPriceLevel,
+  scaleWireSize,
+  StoreMockClient,
+  withMockPayload,
+  type Balances,
+  type FactoryContext,
+  type FactoryContextOptions,
+  type Fill,
+  type MockAuctionSummaryOptions,
+  type MockBalancesOptions,
+  type MockFillOptions,
+  type MockOrderBookOptions,
+  type MockOrderInfoOptions,
+  type MockOrderPayload,
+  type MockPriceLevelOptions,
+  type StoreMockClientOptions,
+} from './mocks/index.js'

--- a/front/lib/sdk/mocks/client.test.ts
+++ b/front/lib/sdk/mocks/client.test.ts
@@ -1,0 +1,211 @@
+import { create } from '@bufbuild/protobuf'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Decimal } from '../../units'
+import { createMockStore } from '../../mock-store'
+
+import {
+  CancelOrderRequestSchema,
+  GetAuctionHistoryRequestSchema,
+  GetOrderBookRequestSchema,
+  GetOrderRequestSchema,
+  PlaceOrderRequestSchema,
+  Side,
+  StreamAuctionsRequestSchema,
+} from '../proto/darkpool/v1/darkpool_pb.js'
+
+import { DARK_POOL_ERROR_CODES } from '../client'
+import { StoreMockClient, withMockPayload } from './client'
+
+const FROZEN_NOW = 1700000000
+
+function freshClient(seed = 42) {
+  const store = createMockStore({ seed, now: () => FROZEN_NOW, mid: '3000', depth: 6 })
+  return { store, client: new StoreMockClient({ store }) }
+}
+
+describe('StoreMockClient.placeOrder', () => {
+  it('drops the order into the store when payload metadata is attached', async () => {
+    const { store, client } = freshClient()
+    const req = withMockPayload(
+      create(PlaceOrderRequestSchema, {
+        commitment: new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd]),
+      }),
+      { side: Side.BUY, price: '2998', size: '0.5' }
+    )
+    const resp = await client.placeOrder(req)
+    expect(resp.order?.side).toBe(Side.BUY)
+    expect(resp.order?.price).toBe('2998')
+    expect(resp.order?.size).toBe('0.5')
+    expect(store.getState().openOrders[0].id).toBe(resp.order?.id)
+    expect(resp.order?.commitmentKey).toBe('mock-commitment-aabbccdd')
+  })
+
+  it('throws INVALID_ARGUMENT without payload metadata', async () => {
+    const { client } = freshClient()
+    await expect(
+      client.placeOrder(create(PlaceOrderRequestSchema, { commitment: new Uint8Array([1]) }))
+    ).rejects.toMatchObject({
+      name: 'DarkPoolError',
+      code: DARK_POOL_ERROR_CODES.INVALID_ARGUMENT,
+    })
+  })
+
+  it('rejects SIDE_UNSPECIFIED', async () => {
+    const { client } = freshClient()
+    const req = withMockPayload(create(PlaceOrderRequestSchema), {
+      side: Side.UNSPECIFIED,
+      price: '3000',
+      size: '1',
+    })
+    await expect(client.placeOrder(req)).rejects.toMatchObject({
+      code: DARK_POOL_ERROR_CODES.INVALID_ARGUMENT,
+    })
+  })
+})
+
+describe('StoreMockClient.cancelOrder', () => {
+  it('removes the order through the store', async () => {
+    const { store, client } = freshClient()
+    const placed = store.getState().placeOrder({ side: Side.SELL, price: '3005', size: '1' })
+    await client.cancelOrder(create(CancelOrderRequestSchema, { orderId: placed.id }))
+    expect(store.getState().openOrders.some((o) => o.id === placed.id)).toBe(false)
+  })
+
+  it('throws NOT_FOUND on unknown ids', async () => {
+    const { client } = freshClient()
+    await expect(
+      client.cancelOrder(create(CancelOrderRequestSchema, { orderId: 'ghost' }))
+    ).rejects.toMatchObject({ code: DARK_POOL_ERROR_CODES.NOT_FOUND })
+  })
+})
+
+describe('StoreMockClient.getOrder', () => {
+  it('returns an order that was placed via the store', async () => {
+    const { store, client } = freshClient()
+    const placed = store.getState().placeOrder({ side: Side.BUY, price: '2990', size: '0.25' })
+    const resp = await client.getOrder(create(GetOrderRequestSchema, { orderId: placed.id }))
+    expect(resp.order?.id).toBe(placed.id)
+  })
+
+  it('throws NOT_FOUND when missing', async () => {
+    const { client } = freshClient()
+    await expect(
+      client.getOrder(create(GetOrderRequestSchema, { orderId: 'ghost' }))
+    ).rejects.toMatchObject({ code: DARK_POOL_ERROR_CODES.NOT_FOUND })
+  })
+})
+
+describe('StoreMockClient.getOrderBook', () => {
+  it('returns the live store snapshot', async () => {
+    const { store, client } = freshClient()
+    const resp = await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    expect(resp.bids).toEqual(store.getState().orderbook.bids)
+    expect(resp.asks).toEqual(store.getState().orderbook.asks)
+    expect(resp.pair).toBe('ETH/USDC')
+  })
+
+  it('falls back to the store pair when no pair is requested', async () => {
+    const { client } = freshClient()
+    const resp = await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: '' }))
+    expect(resp.pair).toBe('ETH/USDC')
+  })
+
+  it('keeps the orderbook sorted (best bid first, best ask first)', async () => {
+    const { client } = freshClient()
+    const resp = await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    for (let i = 1; i < resp.bids.length; i++) {
+      expect(new Decimal(resp.bids[i].price).lt(resp.bids[i - 1].price)).toBe(true)
+    }
+    for (let i = 1; i < resp.asks.length; i++) {
+      expect(new Decimal(resp.asks[i].price).gt(resp.asks[i - 1].price)).toBe(true)
+    }
+  })
+})
+
+describe('StoreMockClient.getAuctionHistory', () => {
+  it('returns the most recent auctions, capped by limit', async () => {
+    const { store, client } = freshClient()
+    store.getState().runAuction()
+    const resp = await client.getAuctionHistory(
+      create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 2 })
+    )
+    expect(resp.auctions).toHaveLength(2)
+    expect(resp.auctions[0]).toBe(store.getState().recentAuctions[0])
+  })
+
+  it('returns all when limit is 0 (proto default)', async () => {
+    const { store, client } = freshClient()
+    const resp = await client.getAuctionHistory(
+      create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 0 })
+    )
+    expect(resp.auctions).toHaveLength(store.getState().recentAuctions.length)
+  })
+})
+
+describe('StoreMockClient.streamAuctions', () => {
+  it('yields new auctions as they land in the store', async () => {
+    const { store, client } = freshClient()
+    const controller = new AbortController()
+    const iter = client.streamAuctions(create(StreamAuctionsRequestSchema, { pair: 'ETH/USDC' }), {
+      signal: controller.signal,
+    })
+
+    const events: string[] = []
+    const drained = (async () => {
+      for await (const ev of iter) {
+        events.push(ev.auctionId)
+        if (events.length >= 2) controller.abort()
+      }
+    })()
+
+    // Yield once so the subscription registers, then drive two auctions.
+    await Promise.resolve()
+    const a = store.getState().runAuction()
+    const b = store.getState().runAuction()
+    await drained
+    expect(events).toEqual([a.auctionId, b.auctionId])
+  })
+
+  it('terminates immediately on an already-aborted signal', async () => {
+    const { client } = freshClient()
+    const controller = new AbortController()
+    controller.abort()
+    const iter = client.streamAuctions(create(StreamAuctionsRequestSchema, { pair: 'ETH/USDC' }), {
+      signal: controller.signal,
+    })
+    const events: unknown[] = []
+    for await (const ev of iter) events.push(ev)
+    expect(events).toEqual([])
+  })
+
+  it('filters by pair when one is set on the request', async () => {
+    const { store, client } = freshClient()
+    const controller = new AbortController()
+    const iter = client.streamAuctions(create(StreamAuctionsRequestSchema, { pair: 'BTC/USDC' }), {
+      signal: controller.signal,
+    })
+    const events: unknown[] = []
+    const drained = (async () => {
+      for await (const ev of iter) events.push(ev)
+    })()
+
+    await Promise.resolve()
+    store.getState().runAuction() // emits an ETH/USDC auction
+    // Give the subscribe callback a tick to run.
+    await new Promise((r) => setTimeout(r, 5))
+    controller.abort()
+    await drained
+    expect(events).toEqual([])
+  })
+})
+
+// vi.useFakeTimers from the previous block must not leak into this file's
+// async-tick assertions; vitest scopes timers per-test but the explicit
+// teardown keeps that contract obvious to readers.
+beforeEach(() => {
+  vi.useRealTimers()
+})
+afterEach(() => {
+  vi.useRealTimers()
+})

--- a/front/lib/sdk/mocks/client.ts
+++ b/front/lib/sdk/mocks/client.ts
@@ -109,10 +109,6 @@ export class StoreMockClient implements DarkPoolClient {
   async placeOrder(req: PlaceOrderRequest): Promise<PlaceOrderResponse> {
     const payload = readMockPayload(req)
     if (!payload) {
-      // No payload attached → fall back to a synthetic order driven by the
-      // commitment bytes. Lets the existing client.test.ts assertions
-      // (which place orders without a payload) keep passing if a panel
-      // forgets to use `withMockPayload`.
       throw new DarkPoolError(
         DARK_POOL_ERROR_CODES.INVALID_ARGUMENT,
         'StoreMockClient.placeOrder requires mock payload metadata; ' +

--- a/front/lib/sdk/mocks/client.ts
+++ b/front/lib/sdk/mocks/client.ts
@@ -1,0 +1,236 @@
+// Store-backed implementation of the DarkPoolClient interface. The trivial
+// MockClient in ../client.ts unblocked the UI shell; this one is what the
+// trading panels actually wire against. All five unary RPCs and the
+// auction stream read from the Zustand mock-store at lib/mock-store.ts.
+//
+// Hand it to `createDarkPoolClient({ mockClient: new StoreMockClient(...) })`
+// from F0.4's factory, or call it directly in panel-level tests.
+
+import { create as createMessage } from '@bufbuild/protobuf'
+
+import { mockStore as defaultMockStore } from '../../mock-store'
+import type { MockStore } from '../../mock-store'
+import type { StoreApi } from 'zustand/vanilla'
+
+import { DEFAULT_PAIR } from './factories'
+
+import {
+  DARK_POOL_ERROR_CODES,
+  DarkPoolError,
+  type DarkPoolClient,
+  type StreamOptions,
+} from '../client'
+
+import {
+  AuctionEventSchema,
+  CancelOrderResponseSchema,
+  GetAuctionHistoryResponseSchema,
+  GetOrderBookResponseSchema,
+  GetOrderResponseSchema,
+  PlaceOrderResponseSchema,
+} from '../proto/darkpool/v1/darkpool_pb.js'
+import type {
+  AuctionEvent,
+  AuctionSummary,
+  CancelOrderRequest,
+  CancelOrderResponse,
+  GetAuctionHistoryRequest,
+  GetAuctionHistoryResponse,
+  GetOrderBookRequest,
+  GetOrderBookResponse,
+  GetOrderRequest,
+  GetOrderResponse,
+  PlaceOrderRequest,
+  PlaceOrderResponse,
+  StreamAuctionsRequest,
+} from '../proto/darkpool/v1/darkpool_pb.js'
+import { Side } from '../proto/darkpool/v1/darkpool_pb.js'
+
+// ─── PlaceOrder payload bridge ────────────────────────────────────────────
+//
+// The wire's PlaceOrderRequest only carries the commitment + proof +
+// encrypted_payload trio (the engine decrypts server-side). For the mock
+// surface we need a price / size / side to actually drop the order into
+// the book, so consumers pass a `mockPayload` alongside the wire request.
+//
+// In Phase 2 the browser ECIES + WASM prover (#96, #97, #98) populate the
+// real commitment/proof/payload, and `placeOrder` calls flow to the REST
+// client instead — at which point this bridge falls out of the hot path.
+
+export interface MockOrderPayload {
+  side: Side
+  price: string
+  size: string
+}
+
+const MOCK_PAYLOAD_KEY = Symbol.for('darkpool.mocks.placeOrderPayload')
+
+type PlaceOrderRequestWithPayload = PlaceOrderRequest & {
+  [MOCK_PAYLOAD_KEY]?: MockOrderPayload
+}
+
+/**
+ * Attach mock order details (side/price/size) to a `PlaceOrderRequest`
+ * so the store-backed client can drop it into the book. The annotation
+ * is keyed by a `Symbol.for(...)` slot so it never leaks into the proto
+ * serialization (`toJson` ignores symbols) — Phase 2's real placeOrder
+ * call is byte-identical regardless of whether this key was set.
+ */
+export function withMockPayload(
+  req: PlaceOrderRequest,
+  payload: MockOrderPayload
+): PlaceOrderRequest {
+  ;(req as PlaceOrderRequestWithPayload)[MOCK_PAYLOAD_KEY] = payload
+  return req
+}
+
+function readMockPayload(req: PlaceOrderRequest): MockOrderPayload | undefined {
+  return (req as PlaceOrderRequestWithPayload)[MOCK_PAYLOAD_KEY]
+}
+
+// ─── StoreMockClient ──────────────────────────────────────────────────────
+
+export interface StoreMockClientOptions {
+  /** Defaults to the HMR-singleton `mockStore`. */
+  store?: StoreApi<MockStore>
+  /** Defaults to ETH/USDC; overrides the response.pair field. */
+  pair?: string
+}
+
+export class StoreMockClient implements DarkPoolClient {
+  private readonly store: StoreApi<MockStore>
+  private readonly pair: string
+
+  constructor(opts: StoreMockClientOptions = {}) {
+    this.store = opts.store ?? defaultMockStore
+    this.pair = opts.pair ?? DEFAULT_PAIR
+  }
+
+  async placeOrder(req: PlaceOrderRequest): Promise<PlaceOrderResponse> {
+    const payload = readMockPayload(req)
+    if (!payload) {
+      // No payload attached → fall back to a synthetic order driven by the
+      // commitment bytes. Lets the existing client.test.ts assertions
+      // (which place orders without a payload) keep passing if a panel
+      // forgets to use `withMockPayload`.
+      throw new DarkPoolError(
+        DARK_POOL_ERROR_CODES.INVALID_ARGUMENT,
+        'StoreMockClient.placeOrder requires mock payload metadata; ' +
+          'wrap the request with `withMockPayload(req, { side, price, size })`.'
+      )
+    }
+    if (payload.side === Side.UNSPECIFIED) {
+      throw new DarkPoolError(DARK_POOL_ERROR_CODES.INVALID_ARGUMENT, 'side must be BUY or SELL')
+    }
+    const order = this.store.getState().placeOrder({
+      side: payload.side,
+      price: payload.price,
+      size: payload.size,
+      commitmentKey: bytesPreview(req.commitment),
+    })
+    return createMessage(PlaceOrderResponseSchema, { order })
+  }
+
+  async cancelOrder(req: CancelOrderRequest): Promise<CancelOrderResponse> {
+    const ok = this.store.getState().cancelOrder(req.orderId)
+    if (!ok) {
+      throw new DarkPoolError(DARK_POOL_ERROR_CODES.NOT_FOUND, `Order ${req.orderId} not found`)
+    }
+    return createMessage(CancelOrderResponseSchema, {})
+  }
+
+  async getOrder(req: GetOrderRequest): Promise<GetOrderResponse> {
+    const order = this.store.getState().openOrders.find((o) => o.id === req.orderId)
+    if (!order) {
+      throw new DarkPoolError(DARK_POOL_ERROR_CODES.NOT_FOUND, `Order ${req.orderId} not found`)
+    }
+    return createMessage(GetOrderResponseSchema, { order })
+  }
+
+  async getOrderBook(req: GetOrderBookRequest): Promise<GetOrderBookResponse> {
+    const book = this.store.getState().orderbook
+    // Echo the requested pair when the client asked for one (mirroring the
+    // REST handler's behavior). Empty `pair` → fall back to the store pair.
+    return createMessage(GetOrderBookResponseSchema, {
+      pair: req.pair || book.pair || this.pair,
+      bids: book.bids,
+      asks: book.asks,
+    })
+  }
+
+  async getAuctionHistory(req: GetAuctionHistoryRequest): Promise<GetAuctionHistoryResponse> {
+    const all = this.store.getState().recentAuctions
+    const limit = req.limit > 0 ? req.limit : all.length
+    return createMessage(GetAuctionHistoryResponseSchema, {
+      auctions: all.slice(0, limit),
+    })
+  }
+
+  async *streamAuctions(
+    req: StreamAuctionsRequest,
+    opts?: StreamOptions
+  ): AsyncIterable<AuctionEvent> {
+    const signal = opts?.signal
+    const pairFilter = req.pair
+    const queue: AuctionSummary[] = []
+    let waker: (() => void) | null = null
+    const wake = () => {
+      const w = waker
+      waker = null
+      if (w) w()
+    }
+
+    const unsubscribe = this.store.subscribe((state, prev) => {
+      const next = state.recentAuctions
+      const prior = prev.recentAuctions
+      // Push only entries that landed since the last notification, in
+      // chronological order, so consumers see the same event sequence
+      // they would over the real server-side stream.
+      const newOnes: AuctionSummary[] = []
+      for (const auction of next) {
+        if (prior.includes(auction)) break
+        newOnes.unshift(auction)
+      }
+      for (const a of newOnes) {
+        if (pairFilter && a.pair !== pairFilter) continue
+        queue.push(a)
+      }
+      if (newOnes.length > 0) wake()
+    })
+
+    const onAbort = () => wake()
+    signal?.addEventListener('abort', onAbort, { once: true })
+
+    try {
+      if (signal?.aborted) return
+      while (!signal?.aborted) {
+        while (queue.length > 0) {
+          const a = queue.shift()!
+          yield createMessage(AuctionEventSchema, {
+            auctionId: a.auctionId,
+            pair: a.pair,
+            clearingPrice: a.clearingPrice,
+            matchedVolume: a.matchedVolume,
+            matchCount: a.matchCount,
+            timestampUnix: a.timestampUnix,
+          })
+        }
+        if (signal?.aborted) return
+        await new Promise<void>((resolve) => {
+          waker = resolve
+        })
+      }
+    } finally {
+      unsubscribe()
+      signal?.removeEventListener('abort', onAbort)
+    }
+  }
+}
+
+function bytesPreview(b: Uint8Array): string {
+  if (b.length === 0) return ''
+  const slice = Array.from(b.slice(0, 4))
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('')
+  return `mock-commitment-${slice}`
+}

--- a/front/lib/sdk/mocks/factories.test.ts
+++ b/front/lib/sdk/mocks/factories.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest'
+
+import { Decimal, fromWirePrice, fromWireSize } from '../../units'
+
+import { Side } from '../proto/darkpool/v1/darkpool_pb.js'
+
+import {
+  DEFAULT_MID,
+  DEFAULT_PAIR,
+  createFactoryContext,
+  midFromBook,
+  mockAuctionSummary,
+  mockBalances,
+  mockFill,
+  mockOrderBook,
+  mockOrderInfo,
+  mockPriceLevel,
+  scaleWireSize,
+} from './factories'
+
+const SEED = 42
+
+describe('createFactoryContext', () => {
+  it('returns a deterministic context when seeded', () => {
+    const a = createFactoryContext({ seed: SEED })
+    const b = createFactoryContext({ seed: SEED })
+    expect(mockOrderInfo(a).id).toEqual(mockOrderInfo(b).id)
+  })
+
+  it('defaults pair to ETH/USDC', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    expect(ctx.pair).toBe(DEFAULT_PAIR)
+  })
+
+  it('uses the injected clock', () => {
+    const ctx = createFactoryContext({ seed: SEED, now: () => 1700000000 })
+    expect(ctx.now()).toBe(1700000000)
+    expect(mockOrderInfo(ctx).submittedAtUnix).toBe(1700000000n)
+  })
+})
+
+describe('mockPriceLevel', () => {
+  it('emits wire-canonical price and size strings', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const level = mockPriceLevel(ctx, { price: '3000.50' })
+    // price keeps requested value, normalized through toWirePrice.
+    expect(level.price).toBe('3000.5')
+    expect(typeof level.totalSize).toBe('string')
+    expect(() => fromWireSize(level.totalSize)).not.toThrow()
+    expect(level.orderCount).toBeGreaterThanOrEqual(1)
+    expect(level.orderCount).toBeLessThanOrEqual(12)
+  })
+
+  it('honours an explicit totalSize override', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const level = mockPriceLevel(ctx, { price: '3000', totalSize: '2.5' })
+    expect(level.totalSize).toBe('2.5')
+  })
+
+  it('refuses to coerce numeric inputs to JS number', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const level = mockPriceLevel(ctx, { price: new Decimal('0.00000001'), totalSize: '0.00000001' })
+    // Round-trip through fromWire to prove no precision was lost on the way.
+    expect(fromWirePrice(level.price).equals(new Decimal('0.00000001'))).toBe(true)
+    expect(fromWireSize(level.totalSize).equals(new Decimal('0.00000001'))).toBe(true)
+  })
+})
+
+describe('mockOrderBook', () => {
+  it('returns sorted bids descending and asks ascending around the mid', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const book = mockOrderBook(ctx, { mid: '3000', depth: 5, tickSize: '1' })
+    expect(book.pair).toBe(DEFAULT_PAIR)
+    expect(book.bids).toHaveLength(5)
+    expect(book.asks).toHaveLength(5)
+
+    for (let i = 1; i < book.bids.length; i++) {
+      expect(new Decimal(book.bids[i].price).lt(book.bids[i - 1].price)).toBe(true)
+    }
+    for (let i = 1; i < book.asks.length; i++) {
+      expect(new Decimal(book.asks[i].price).gt(book.asks[i - 1].price)).toBe(true)
+    }
+
+    const bestBid = new Decimal(book.bids[0].price)
+    const bestAsk = new Decimal(book.asks[0].price)
+    expect(bestBid.lt(bestAsk)).toBe(true)
+    expect(midFromBook(book).equals(new Decimal('3000'))).toBe(true)
+  })
+
+  it('drops bids that would go below zero (small mid, deep depth)', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const book = mockOrderBook(ctx, { mid: '3', depth: 10, tickSize: '1' })
+    for (const bid of book.bids) {
+      expect(new Decimal(bid.price).gt(0)).toBe(true)
+    }
+  })
+})
+
+describe('mockOrderInfo', () => {
+  it('uses ctx defaults when nothing is overridden', () => {
+    const ctx = createFactoryContext({ seed: SEED, now: () => 1700000000 })
+    const order = mockOrderInfo(ctx)
+    expect(order.pair).toBe(DEFAULT_PAIR)
+    expect(order.id.startsWith('mock-')).toBe(true)
+    expect([Side.BUY, Side.SELL]).toContain(order.side)
+    expect(order.submittedAtUnix).toBe(1700000000n)
+    expect(order.remainingSize).toBe(order.size)
+  })
+
+  it('honours every override field', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const order = mockOrderInfo(ctx, {
+      id: 'fixed-id',
+      side: Side.SELL,
+      price: '3000.50',
+      size: '2.5',
+      remainingSize: '1.25',
+      pair: 'ETH/USDC',
+      submittedAtUnix: 17n,
+      expiresAtUnix: 42n,
+      commitmentKey: 'forced',
+    })
+    expect(order.id).toBe('fixed-id')
+    expect(order.side).toBe(Side.SELL)
+    expect(order.price).toBe('3000.5')
+    expect(order.size).toBe('2.5')
+    expect(order.remainingSize).toBe('1.25')
+    expect(order.submittedAtUnix).toBe(17n)
+    expect(order.expiresAtUnix).toBe(42n)
+    expect(order.commitmentKey).toBe('forced')
+  })
+})
+
+describe('mockAuctionSummary', () => {
+  it('draws clearing price within ±noise of mid', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const auction = mockAuctionSummary(ctx, { mid: '3000', noise: '1.5' })
+    const cp = new Decimal(auction.clearingPrice)
+    expect(cp.gte('2998.5')).toBe(true)
+    expect(cp.lte('3001.5')).toBe(true)
+  })
+
+  it('respects an explicit clearingPrice', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const auction = mockAuctionSummary(ctx, { clearingPrice: '3142.00' })
+    expect(auction.clearingPrice).toBe('3142')
+  })
+
+  it('emits int64 timestamp as bigint per proto3 JSON mapping', () => {
+    const ctx = createFactoryContext({ seed: SEED, now: () => 1700000099 })
+    expect(mockAuctionSummary(ctx).timestampUnix).toBe(1700000099n)
+  })
+})
+
+describe('mockFill', () => {
+  it('canonicalizes price and size into wire strings', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const fill = mockFill(ctx, {
+      orderId: 'ord-1',
+      side: Side.BUY,
+      price: '3000.50',
+      size: '0.500000',
+    })
+    expect(fill.orderId).toBe('ord-1')
+    expect(fill.side).toBe(Side.BUY)
+    expect(fill.price).toBe('3000.5')
+    expect(fill.size).toBe('0.5')
+  })
+})
+
+describe('mockBalances', () => {
+  it('falls back to sane defaults and canonicalizes overrides', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    expect(mockBalances(ctx)).toEqual({ weth: '10', usdc: '25000' })
+    expect(mockBalances(ctx, { weth: '0.5000', usdc: '1500.000' })).toEqual({
+      weth: '0.5',
+      usdc: '1500',
+    })
+  })
+})
+
+describe('scaleWireSize', () => {
+  it('scales without leaking JS floats', () => {
+    // 0.3 * 0.1 in binary floats drifts to 0.029999999...; the helper
+    // routes through Decimal, so the wire string is exact.
+    expect(scaleWireSize('0.3', '0.1', '0')).toBe('0.03')
+  })
+
+  it('floors at the provided minimum', () => {
+    expect(scaleWireSize('0.0002', '0.1', '0.0001')).toBe('0.0001')
+  })
+})
+
+describe('midFromBook', () => {
+  it('returns the midpoint of best bid and best ask', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const book = mockOrderBook(ctx, { mid: '3000', depth: 3, tickSize: '2' })
+    // best bid = 2998, best ask = 3002 → mid = 3000
+    expect(midFromBook(book).toString()).toBe('3000')
+  })
+
+  it('throws on an empty side', () => {
+    const ctx = createFactoryContext({ seed: SEED })
+    const book = mockOrderBook(ctx, { mid: DEFAULT_MID, depth: 1 })
+    book.bids = []
+    expect(() => midFromBook(book)).toThrow(/empty/)
+  })
+})

--- a/front/lib/sdk/mocks/factories.ts
+++ b/front/lib/sdk/mocks/factories.ts
@@ -1,0 +1,344 @@
+// Typed faker factories for the simulated backend that powers Phase 1 of
+// the trading app. Every output is shaped against the proto types generated
+// by F0.3 (../proto/darkpool/v1/darkpool_pb.ts) — no parallel type
+// definitions live here. Decimal math always goes through Decimal/units.ts
+// so wire fields stay canonical decimal strings (see docs/adr/0002-decimals.md).
+//
+// `createFactoryContext({ seed })` returns a deterministic Faker handle:
+// tests pass a fixed seed for reproducible fixtures, runtime callers omit
+// the seed for fresh randomness on every tick.
+
+import { create } from '@bufbuild/protobuf'
+import { Faker, en } from '@faker-js/faker'
+
+import { Decimal, toWirePrice, toWireSize } from '../../units'
+
+import {
+  AuctionSummarySchema,
+  GetOrderBookResponseSchema,
+  OrderInfoSchema,
+  PriceLevelSchema,
+  Side,
+} from '../proto/darkpool/v1/darkpool_pb.js'
+import type {
+  AuctionSummary,
+  GetOrderBookResponse,
+  OrderInfo,
+  PriceLevel,
+} from '../proto/darkpool/v1/darkpool_pb.js'
+
+// ─── Pair / market defaults ───────────────────────────────────────────────
+//
+// MVP is single-pair ETH/USDC (see CLAUDE.md "Locked-in product decisions").
+// Multi-pair gates on backend #29 (pair registry); when that lands we keep
+// the same shape but read the default from a config.
+
+export const DEFAULT_PAIR = 'ETH/USDC'
+export const DEFAULT_MID = new Decimal('3000')
+
+/**
+ * Display precision the orderbook snaps prices to. Levels are spaced by
+ * 10^(-PRICE_DP) USDC; the perturbation tick rounds to this grid so the
+ * book doesn't visibly drift off-tick between renders.
+ */
+export const PRICE_DP = 2
+/**
+ * Display precision sizes snap to. Wire allows 8dp; the panels only show 4.
+ */
+export const SIZE_DP = 4
+
+// ─── Local Fill type ──────────────────────────────────────────────────────
+//
+// The proto has no Fill message — a Fill is an entry in the mock fill
+// history, surfaced by F1.11 (#78). When/if the backend gains a Fill
+// message we replace this with the generated type.
+
+export interface Fill {
+  fillId: string
+  orderId: string
+  auctionId: string
+  side: Side
+  price: string
+  size: string
+  timestampUnix: bigint
+}
+
+export interface Balances {
+  weth: string
+  usdc: string
+}
+
+// ─── Factory context ──────────────────────────────────────────────────────
+
+export interface FactoryContextOptions {
+  /** Seed the underlying Faker for deterministic test output. */
+  seed?: number
+  /** Market pair the factories tag onto generated messages. */
+  pair?: string
+  /** Injectable clock so tests can pin timestamp_unix. */
+  now?: () => number
+}
+
+export interface FactoryContext {
+  readonly faker: Faker
+  readonly pair: string
+  /** Returns the current unix timestamp in seconds. */
+  readonly now: () => number
+}
+
+export function createFactoryContext(opts: FactoryContextOptions = {}): FactoryContext {
+  const faker = new Faker({ locale: en })
+  if (opts.seed !== undefined) faker.seed(opts.seed)
+  return {
+    faker,
+    pair: opts.pair ?? DEFAULT_PAIR,
+    now: opts.now ?? (() => Math.floor(Date.now() / 1000)),
+  }
+}
+
+// ─── Decimal sampling ─────────────────────────────────────────────────────
+//
+// faker.number.float returns a JS number; routing that straight into a
+// Decimal works for small magnitudes but invites binary-float drift on
+// values like 0.1. We sample an integer in scaled-up space and divide by
+// 10^dp inside Decimal so the result is exact at the target precision.
+
+function sampleDecimal(
+  faker: Faker,
+  range: { min: Decimal | string; max: Decimal | string; dp: number }
+): Decimal {
+  const dp = range.dp
+  if (!Number.isInteger(dp) || dp < 0 || dp > 8) {
+    throw new RangeError(`factories: dp out of range [0, 8] (got ${dp})`)
+  }
+  const min = range.min instanceof Decimal ? range.min : new Decimal(range.min)
+  const max = range.max instanceof Decimal ? range.max : new Decimal(range.max)
+  if (max.lt(min)) {
+    throw new RangeError(`factories: max < min (${max} < ${min})`)
+  }
+  const scale = new Decimal(10).pow(dp)
+  const minScaled = min.times(scale).round().toNumber()
+  const maxScaled = max.times(scale).round().toNumber()
+  const sampled = faker.number.int({ min: minScaled, max: maxScaled })
+  return new Decimal(sampled).div(scale)
+}
+
+// ─── mockPriceLevel ───────────────────────────────────────────────────────
+
+export interface MockPriceLevelOptions {
+  price: Decimal | string
+  totalSize?: Decimal | string
+  orderCount?: number
+}
+
+export function mockPriceLevel(ctx: FactoryContext, opts: MockPriceLevelOptions): PriceLevel {
+  const size =
+    opts.totalSize !== undefined
+      ? opts.totalSize
+      : sampleDecimal(ctx.faker, { min: '0.5', max: '50', dp: SIZE_DP })
+  const orderCount = opts.orderCount ?? ctx.faker.number.int({ min: 1, max: 12 })
+  return create(PriceLevelSchema, {
+    price: toWirePrice(opts.price),
+    totalSize: toWireSize(size),
+    orderCount,
+  })
+}
+
+// ─── mockOrderBook ────────────────────────────────────────────────────────
+
+export interface MockOrderBookOptions {
+  /** Mid price the bids/asks straddle. */
+  mid?: Decimal | string
+  /** How many levels per side. Defaults to 12. */
+  depth?: number
+  /** Distance (in USDC) between adjacent levels. Defaults to 1. */
+  tickSize?: Decimal | string
+  /** Optional override for the pair name. */
+  pair?: string
+}
+
+export function mockOrderBook(
+  ctx: FactoryContext,
+  opts: MockOrderBookOptions = {}
+): GetOrderBookResponse {
+  const mid = opts.mid !== undefined ? new Decimal(opts.mid.toString()) : DEFAULT_MID
+  const depth = opts.depth ?? 12
+  const tick = opts.tickSize !== undefined ? new Decimal(opts.tickSize.toString()) : new Decimal(1)
+  const pair = opts.pair ?? ctx.pair
+
+  const bids: PriceLevel[] = []
+  const asks: PriceLevel[] = []
+  for (let i = 1; i <= depth; i++) {
+    const bidPrice = mid.minus(tick.times(i))
+    const askPrice = mid.plus(tick.times(i))
+    if (bidPrice.gt(0)) bids.push(mockPriceLevel(ctx, { price: bidPrice }))
+    asks.push(mockPriceLevel(ctx, { price: askPrice }))
+  }
+  // Proto repeated fields don't enforce ordering; we sort for the UI so the
+  // top of book is always the first element (panels read [0] without a
+  // comparator).
+  bids.sort((a, b) => new Decimal(b.price).cmp(new Decimal(a.price)))
+  asks.sort((a, b) => new Decimal(a.price).cmp(new Decimal(b.price)))
+
+  return create(GetOrderBookResponseSchema, { pair, bids, asks })
+}
+
+// ─── mockOrderInfo ────────────────────────────────────────────────────────
+
+export interface MockOrderInfoOptions {
+  id?: string
+  side?: Side
+  price?: Decimal | string
+  size?: Decimal | string
+  remainingSize?: Decimal | string
+  commitmentKey?: string
+  submittedAtUnix?: bigint
+  expiresAtUnix?: bigint
+  pair?: string
+}
+
+export function mockOrderInfo(ctx: FactoryContext, opts: MockOrderInfoOptions = {}): OrderInfo {
+  const side =
+    opts.side ?? (ctx.faker.datatype.boolean({ probability: 0.5 }) ? Side.BUY : Side.SELL)
+  const price =
+    opts.price !== undefined
+      ? new Decimal(opts.price.toString())
+      : DEFAULT_MID.plus(sampleDecimal(ctx.faker, { min: '-20', max: '20', dp: PRICE_DP }))
+  const size =
+    opts.size !== undefined
+      ? new Decimal(opts.size.toString())
+      : sampleDecimal(ctx.faker, { min: '0.1', max: '5', dp: SIZE_DP })
+  const remainingSize =
+    opts.remainingSize !== undefined ? new Decimal(opts.remainingSize.toString()) : size
+
+  return create(OrderInfoSchema, {
+    id: opts.id ?? `mock-${ctx.faker.string.uuid()}`,
+    pair: opts.pair ?? ctx.pair,
+    side,
+    price: toWirePrice(price),
+    size: toWireSize(size),
+    remainingSize: toWireSize(remainingSize),
+    commitmentKey:
+      opts.commitmentKey ??
+      `mock-${ctx.faker.string.hexadecimal({ length: 8, casing: 'lower', prefix: '' })}`,
+    submittedAtUnix: opts.submittedAtUnix ?? BigInt(ctx.now()),
+    expiresAtUnix: opts.expiresAtUnix ?? 0n,
+  })
+}
+
+// ─── mockAuctionSummary ───────────────────────────────────────────────────
+
+export interface MockAuctionSummaryOptions {
+  auctionId?: string
+  pair?: string
+  /** Mid the clearing price is drawn from; defaults to DEFAULT_MID. */
+  mid?: Decimal | string
+  /** ± noise around mid in absolute price units. Defaults to 0.5% of mid. */
+  noise?: Decimal | string
+  clearingPrice?: Decimal | string
+  matchedVolume?: Decimal | string
+  matchCount?: number
+  timestampUnix?: bigint
+}
+
+export function mockAuctionSummary(
+  ctx: FactoryContext,
+  opts: MockAuctionSummaryOptions = {}
+): AuctionSummary {
+  const mid = opts.mid !== undefined ? new Decimal(opts.mid.toString()) : DEFAULT_MID
+  const noise = opts.noise !== undefined ? new Decimal(opts.noise.toString()) : mid.times('0.005')
+  const clearingPrice =
+    opts.clearingPrice !== undefined
+      ? new Decimal(opts.clearingPrice.toString())
+      : mid.plus(sampleDecimal(ctx.faker, { min: noise.neg(), max: noise, dp: PRICE_DP }))
+
+  const matchedVolume =
+    opts.matchedVolume !== undefined
+      ? new Decimal(opts.matchedVolume.toString())
+      : sampleDecimal(ctx.faker, { min: '0.01', max: '12', dp: SIZE_DP })
+
+  return create(AuctionSummarySchema, {
+    auctionId:
+      opts.auctionId ?? `auc-${ctx.faker.string.alphanumeric({ length: 10, casing: 'lower' })}`,
+    pair: opts.pair ?? ctx.pair,
+    clearingPrice: toWirePrice(clearingPrice),
+    matchedVolume: toWireSize(matchedVolume),
+    matchCount: opts.matchCount ?? ctx.faker.number.int({ min: 0, max: 24 }),
+    timestampUnix: opts.timestampUnix ?? BigInt(ctx.now()),
+  })
+}
+
+// ─── mockFill ─────────────────────────────────────────────────────────────
+
+export interface MockFillOptions {
+  fillId?: string
+  orderId: string
+  auctionId?: string
+  side: Side
+  price: Decimal | string
+  size: Decimal | string
+  timestampUnix?: bigint
+}
+
+export function mockFill(ctx: FactoryContext, opts: MockFillOptions): Fill {
+  return {
+    fillId: opts.fillId ?? `fill-${ctx.faker.string.alphanumeric({ length: 8, casing: 'lower' })}`,
+    orderId: opts.orderId,
+    auctionId:
+      opts.auctionId ?? `auc-${ctx.faker.string.alphanumeric({ length: 10, casing: 'lower' })}`,
+    side: opts.side,
+    price: toWirePrice(opts.price),
+    size: toWireSize(opts.size),
+    timestampUnix: opts.timestampUnix ?? BigInt(ctx.now()),
+  }
+}
+
+// ─── mockBalances ─────────────────────────────────────────────────────────
+
+export interface MockBalancesOptions {
+  weth?: Decimal | string
+  usdc?: Decimal | string
+}
+
+export function mockBalances(_ctx: FactoryContext, opts: MockBalancesOptions = {}): Balances {
+  const weth = opts.weth !== undefined ? new Decimal(opts.weth.toString()) : new Decimal('10')
+  const usdc = opts.usdc !== undefined ? new Decimal(opts.usdc.toString()) : new Decimal('25000')
+  return {
+    weth: toWireSize(weth),
+    usdc: toWireSize(usdc),
+  }
+}
+
+// ─── Helpers for the store ────────────────────────────────────────────────
+//
+// The mock-store layers small per-tick mutations on top of these factories.
+// Exposing the primitives keeps the store from re-implementing decimal math
+// inline.
+
+/**
+ * Multiply a wire-string size by a Decimal scalar and return a new wire
+ * string. Used by the 1s perturb tick. The product is truncated to
+ * SIZE_DP so repeated perturbations don't drift past the wire's 8dp
+ * ceiling, and floored at `min` so a level never disappears through
+ * repeated downward perturbations.
+ */
+export function scaleWireSize(
+  wire: string,
+  scalar: Decimal | string,
+  min: Decimal | string = '0.0001'
+): string {
+  const product = new Decimal(wire).times(scalar.toString())
+  const snapped = product.toDecimalPlaces(SIZE_DP, Decimal.ROUND_DOWN)
+  const floor = new Decimal(min.toString())
+  return toWireSize(snapped.lt(floor) ? floor : snapped)
+}
+
+/** Return the midpoint of best bid / best ask. Throws if either side is empty. */
+export function midFromBook(book: GetOrderBookResponse): Decimal {
+  if (book.bids.length === 0 || book.asks.length === 0) {
+    throw new Error('factories: cannot compute mid on an empty side')
+  }
+  const bestBid = new Decimal(book.bids[0].price)
+  const bestAsk = new Decimal(book.asks[0].price)
+  return bestBid.plus(bestAsk).div(2)
+}

--- a/front/lib/sdk/mocks/index.ts
+++ b/front/lib/sdk/mocks/index.ts
@@ -1,0 +1,36 @@
+// Public surface for the Phase 1 mock layer. Panels and tests should
+// import from '@/lib/sdk' (re-exported there) or this barrel — never
+// reach into the individual modules.
+
+export {
+  DEFAULT_MID,
+  DEFAULT_PAIR,
+  PRICE_DP,
+  SIZE_DP,
+  createFactoryContext,
+  midFromBook,
+  mockAuctionSummary,
+  mockBalances,
+  mockFill,
+  mockOrderBook,
+  mockOrderInfo,
+  mockPriceLevel,
+  scaleWireSize,
+  type Balances,
+  type FactoryContext,
+  type FactoryContextOptions,
+  type Fill,
+  type MockAuctionSummaryOptions,
+  type MockBalancesOptions,
+  type MockFillOptions,
+  type MockOrderBookOptions,
+  type MockOrderInfoOptions,
+  type MockPriceLevelOptions,
+} from './factories'
+
+export {
+  StoreMockClient,
+  withMockPayload,
+  type MockOrderPayload,
+  type StoreMockClientOptions,
+} from './client'

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@bufbuild/protobuf": "^2.12.0",
+        "@faker-js/faker": "^10.4.0",
         "@gsap/react": "^2.1.2",
         "@radix-ui/react-dialog": "^1.1.6",
         "@radix-ui/react-slot": "^1.1.2",
@@ -24,7 +25,8 @@
         "react-dom": "^18",
         "tailwind-merge": "^2.5.5",
         "viem": "^2.21.0",
-        "zod": "^4.4.3"
+        "zod": "^4.4.3",
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@bufbuild/buf": "^1.69.0",
@@ -1093,6 +1095,22 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+      "integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0",
+        "npm": ">=10"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -13687,6 +13705,35 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
+      "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/front/package.json
+++ b/front/package.json
@@ -18,6 +18,7 @@
   },
   "dependencies": {
     "@bufbuild/protobuf": "^2.12.0",
+    "@faker-js/faker": "^10.4.0",
     "@gsap/react": "^2.1.2",
     "@radix-ui/react-dialog": "^1.1.6",
     "@radix-ui/react-slot": "^1.1.2",
@@ -33,7 +34,8 @@
     "react-dom": "^18",
     "tailwind-merge": "^2.5.5",
     "viem": "^2.21.0",
-    "zod": "^4.4.3"
+    "zod": "^4.4.3",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@bufbuild/buf": "^1.69.0",


### PR DESCRIPTION
Closes #69

## Summary

Phase 1's simulated backend. One Zustand store keeps the orderbook, recent auctions, balances, open orders, and fill history coherent; a tick loop nudges level sizes every second and produces a clearing auction every five. A store-backed `DarkPoolClient` makes the same state available to the trading UI through the F0.4 seam, so panels in Wave 4 (#71, #73, #74) can be wired against the real interface today and flip to REST in Phase 2 without callsite changes.

### What landed

- **`front/lib/sdk/mocks/factories.ts`** — typed faker factories (`mockOrderInfo`, `mockPriceLevel`, `mockAuctionSummary`, `mockOrderBook`, `mockFill`, `mockBalances`) shaped against the F0.3-generated proto types. `createFactoryContext({ seed })` returns a deterministic Faker handle for tests. All decimal math routes through `lib/units.ts` (#89) — wire fields stay canonical strings.
- **`front/lib/mock-store.ts`** — `createMockStore` factory + an HMR-safe singleton stashed on a `Symbol.for(...)` slot of `globalThis`. Actions: `placeOrder`, `cancelOrder`, `perturbOrderbook` (1 s tick), `runAuction` (5 s tick), `start`/`stop` for the timers, `seed` / `reset`. `runAuction` also consumes any in-the-money open order into the fill history.
- **`front/lib/sdk/mocks/client.ts`** — `StoreMockClient` implements `DarkPoolClient` against the store. `placeOrder` accepts a `withMockPayload(req, { side, price, size })` annotation (a `Symbol.for`-keyed slot that `toJson()` ignores), so the wire request stays byte-identical to Phase 2's real call. `streamAuctions` subscribes to the store and yields each new auction as it lands.
- **`front/lib/sdk/index.ts`** — append-only re-exports of the new mock surface.
- Added `zustand` and `@faker-js/faker` to `front/package.json`; ran a full `npm install`.

### Scope

Stayed strictly within the F1.2 scope from `docs/PARALLEL-WORK.md`:

- `front/lib/mock-store.ts` + colocated test
- `front/lib/sdk/mocks/` (factories, store-backed client, barrel, tests)
- `front/lib/sdk/index.ts` — append-only block at the bottom
- `front/package.json` + `front/package-lock.json` — dep additions

The existing trivial `MockClient` in `front/lib/sdk/client.ts` is left untouched; consumers opt into the store-backed one via `createDarkPoolClient({ mockClient: new StoreMockClient(...) })`.

## Test plan

- [x] `npm test` — 127 / 127 passing (37 new factory + store tests, 15 new client tests, plus all existing).
- [x] `npm run lint` — clean.
- [x] `npm run typecheck` — clean.
- [x] `npm run format:check` — clean.
- [ ] Manual: drive `useMockStore` from a temporary panel and confirm the 1 s / 5 s ticks render the orderbook flicker and tape inserts. *(Wave 4 panels do this; not blocking F1.2 merge.)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive mock trading backend simulation supporting order placement, cancellation, auction execution, and orderbook queries for enhanced testing capabilities.

* **Chores**
  * Added faker and zustand dependencies to support development and testing infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->