### PR TITLE
[F1.6] Orderbook view (mock-backed)

### DIFF
--- a/front/components/trade/orderbook/DepthRow.tsx
+++ b/front/components/trade/orderbook/DepthRow.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import { NumericText } from '../../NumericText'
+
+import type { DepthRow as DepthRowData } from './depth'
+
+export interface DepthRowProps {
+  row: DepthRowData
+  side: Side.BUY | Side.SELL
+  /** Best-of-book row gets one typography step up. */
+  emphasized?: boolean
+  onSelect?: (price: string, side: Side.BUY | Side.SELL) => void
+}
+
+/**
+ * Single book row. The depth bar is the row's background — a horizontal
+ * fill scaled to `barFraction`. Bids use `primary` at 10% opacity; asks
+ * use `secondary` at 20% (per DESIGN-INSPIRATIONS bid/ask tension table).
+ * No semantic color anywhere.
+ */
+export function DepthRow({ row, side, emphasized = false, onSelect }: DepthRowProps) {
+  const isBid = side === Side.BUY
+  const bar = isBid ? 'bg-brand-fg/[0.08]' : 'bg-brand-muted/20'
+  const sizeClass = emphasized ? 'text-body-md' : 'text-body-sm'
+  const handleClick = onSelect ? () => onSelect(row.level.price, side) : undefined
+  const clickable = handleClick !== undefined
+
+  const Tag = clickable ? 'button' : 'div'
+  return (
+    <Tag
+      type={clickable ? 'button' : undefined}
+      onClick={handleClick}
+      className={`relative grid w-full grid-cols-3 items-center gap-2 px-4 py-1 text-left font-mono transition-colors duration-100 hover:bg-brand-surface focus-visible:bg-brand-surface focus-visible:outline focus-visible:outline-1 focus-visible:outline-brand-accent focus-visible:outline-offset-[-1px] ${sizeClass}`}
+      aria-label={clickable ? `${isBid ? 'Bid' : 'Ask'} ${row.level.price}` : undefined}
+    >
+      <span
+        aria-hidden="true"
+        className={`pointer-events-none absolute inset-y-0 right-0 ${bar}`}
+        style={{ width: `${Math.min(100, Math.max(0, row.barFraction * 100))}%` }}
+      />
+      <NumericText
+        value={row.level.price}
+        kind="price"
+        align="left"
+        className="relative z-10 text-brand-fg"
+      />
+      <NumericText
+        value={row.level.totalSize}
+        kind="size"
+        align="right"
+        className="relative z-10 text-brand-muted"
+      />
+      <NumericText
+        value={row.cumulative}
+        kind="size"
+        align="right"
+        className="relative z-10 text-brand-fg"
+      />
+    </Tag>
+  )
+}

--- a/front/components/trade/orderbook/DepthTable.tsx
+++ b/front/components/trade/orderbook/DepthTable.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import { DepthRow } from './DepthRow'
+
+import type { DepthRow as DepthRowData } from './depth'
+
+export type DepthTableSide = Side.BUY | Side.SELL
+
+export interface DepthTableProps {
+  rows: DepthRowData[]
+  side: DepthTableSide
+  /**
+   * Reverses the render order. Asks display from worst→best top-to-bottom
+   * (so best ask sits adjacent to the spread row beneath them); bids run
+   * best→worst.
+   */
+  reverse?: boolean
+  onSelect?: (price: string, side: DepthTableSide) => void
+}
+
+/**
+ * One side of the book. The first row (index 0 after optional reverse) is
+ * the side closest to the spread — gets one typography step up so the
+ * top of book reads with hierarchy.
+ */
+export function DepthTable({ rows, side, reverse = false, onSelect }: DepthTableProps) {
+  const ordered = reverse ? [...rows].reverse() : rows
+  const isBid = side === Side.BUY
+  const bestIndex = reverse ? ordered.length - 1 : 0
+
+  return (
+    <div role="group" aria-label={isBid ? 'Bids' : 'Asks'} className="flex flex-col">
+      <div className="flex items-center gap-2 px-4 py-1">
+        <span className="font-mono text-label-md uppercase text-brand-muted">
+          [ {isBid ? 'BIDS' : 'ASKS'} ]
+        </span>
+      </div>
+      <ul className="flex flex-col">
+        {ordered.map((row, i) => (
+          <li key={row.level.price}>
+            <DepthRow row={row} side={side} emphasized={i === bestIndex} onSelect={onSelect} />
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/front/components/trade/orderbook/OrderBook.stories.tsx
+++ b/front/components/trade/orderbook/OrderBook.stories.tsx
@@ -1,0 +1,157 @@
+import './_processShim'
+
+import * as React from 'react'
+import { create } from '@bufbuild/protobuf'
+
+import { DarkPoolClientProvider } from '../../../lib/sdk/provider'
+import type { DarkPoolClient } from '../../../lib/sdk/client'
+import { DARK_POOL_ERROR_CODES, DarkPoolError } from '../../../lib/sdk/client'
+import { createFactoryContext, mockAuctionSummary, mockOrderBook } from '../../../lib/sdk/mocks'
+import {
+  CancelOrderResponseSchema,
+  GetAuctionHistoryResponseSchema,
+  GetOrderBookResponseSchema,
+  GetOrderResponseSchema,
+  OrderInfoSchema,
+  PlaceOrderResponseSchema,
+  Side,
+} from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import { OrderBook } from './OrderBook'
+
+// ─── Minimal shell that mimics how Shell.tsx will frame the panel ────────
+
+function PanelFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-[680px] w-[360px] flex-col border border-brand-border bg-brand-bg">
+      <div className="flex h-9 items-center gap-3 border-b border-brand-border px-4">
+        <span className="font-mono text-label-md uppercase tracking-[0.2em] text-brand-muted">
+          ORDERBOOK · ETH / USDC
+        </span>
+      </div>
+      <div className="flex-1 overflow-hidden">{children}</div>
+    </div>
+  )
+}
+
+// ─── Client builders ─────────────────────────────────────────────────────
+
+interface ClientOverrides {
+  bookEmpty?: boolean
+  noAuctions?: boolean
+  raise?: 'orderbook' | 'auctions'
+  seed?: number
+}
+
+function buildClient(overrides: ClientOverrides = {}): DarkPoolClient {
+  const ctx = createFactoryContext({ seed: overrides.seed ?? 7 })
+  const book = overrides.bookEmpty
+    ? create(GetOrderBookResponseSchema, { pair: ctx.pair, bids: [], asks: [] })
+    : mockOrderBook(ctx, { depth: 12 })
+  const auctions = overrides.noAuctions
+    ? []
+    : [
+        mockAuctionSummary(ctx, { clearingPrice: '2418.10', timestampUnix: 1700000010n }),
+        mockAuctionSummary(ctx, { clearingPrice: '2405.76', timestampUnix: 1700000005n }),
+      ]
+
+  return {
+    async placeOrder() {
+      return create(PlaceOrderResponseSchema, { order: create(OrderInfoSchema, {}) })
+    },
+    async cancelOrder() {
+      return create(CancelOrderResponseSchema, {})
+    },
+    async getOrder() {
+      return create(GetOrderResponseSchema, { order: create(OrderInfoSchema, {}) })
+    },
+    async getOrderBook() {
+      if (overrides.raise === 'orderbook') {
+        throw new DarkPoolError(DARK_POOL_ERROR_CODES.UNAVAILABLE, 'engine offline')
+      }
+      return book
+    },
+    async getAuctionHistory() {
+      if (overrides.raise === 'auctions') {
+        throw new DarkPoolError(DARK_POOL_ERROR_CODES.UNAVAILABLE, 'engine offline')
+      }
+      return create(GetAuctionHistoryResponseSchema, { auctions })
+    },
+    async *streamAuctions() {
+      // Empty stream.
+    },
+  }
+}
+
+function withClient(client: DarkPoolClient, Body: React.ReactNode): React.ReactElement {
+  return (
+    <DarkPoolClientProvider client={client}>
+      <PanelFrame>{Body}</PanelFrame>
+    </DarkPoolClientProvider>
+  )
+}
+
+// ─── Stories ─────────────────────────────────────────────────────────────
+
+export const Populated = () => withClient(buildClient(), <OrderBook refetchIntervalMs={2000} />)
+
+export const PopulatedNarrow = () => (
+  <DarkPoolClientProvider client={buildClient()}>
+    <div className="flex h-[680px] w-[280px] flex-col border border-brand-border bg-brand-bg">
+      <OrderBook refetchIntervalMs={2000} />
+    </div>
+  </DarkPoolClientProvider>
+)
+
+export const Empty = () =>
+  withClient(buildClient({ bookEmpty: true }), <OrderBook refetchIntervalMs={2000} />)
+
+export const NoAuctionYet = () =>
+  withClient(buildClient({ noAuctions: true }), <OrderBook refetchIntervalMs={2000} />)
+
+export const ErrorState = () =>
+  withClient(buildClient({ raise: 'orderbook' }), <OrderBook refetchIntervalMs={2000} />)
+
+export const Loading = () => {
+  // A client whose getOrderBook never resolves — stays in loading forever.
+  const pending: DarkPoolClient = {
+    async placeOrder() {
+      return create(PlaceOrderResponseSchema, { order: create(OrderInfoSchema, {}) })
+    },
+    async cancelOrder() {
+      return create(CancelOrderResponseSchema, {})
+    },
+    async getOrder() {
+      return create(GetOrderResponseSchema, { order: create(OrderInfoSchema, {}) })
+    },
+    getOrderBook() {
+      return new Promise(() => {})
+    },
+    getAuctionHistory() {
+      return new Promise(() => {})
+    },
+    async *streamAuctions() {},
+  }
+  return withClient(pending, <OrderBook refetchIntervalMs={2000} />)
+}
+
+export const WithClickToFill = () => {
+  const [picked, setPicked] = React.useState<string | null>(null)
+  return (
+    <div className="flex flex-col gap-4">
+      <DarkPoolClientProvider client={buildClient({ seed: 11 })}>
+        <PanelFrame>
+          <OrderBook
+            refetchIntervalMs={2000}
+            onPriceSelect={(price, side) =>
+              setPicked(`${side === Side.BUY ? 'BID' : 'ASK'} @ ${price}`)
+            }
+          />
+        </PanelFrame>
+      </DarkPoolClientProvider>
+      <div className="font-mono text-label-md uppercase tracking-[0.2em] text-brand-muted">
+        Last click: <span className="text-brand-fg">{picked ?? '—'}</span>
+      </div>
+    </div>
+  )
+}

--- a/front/components/trade/orderbook/OrderBook.tsx
+++ b/front/components/trade/orderbook/OrderBook.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useMemo, type ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+import { DEFAULT_PAIR } from '../../../lib/sdk/mocks/factories'
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import { computeDepthRows, formatDelta } from './depth'
+import { DepthTable, type DepthTableSide } from './DepthTable'
+import { OrderBookHeader } from './OrderBookHeader'
+import { SpreadRow } from './SpreadRow'
+import { OrderBookEmpty, OrderBookError, OrderBookLoading } from './states'
+import { useOrderBook, useRecentAuctions } from './useOrderBook'
+
+export interface OrderBookProps {
+  pair?: string
+  /**
+   * Fires when the user clicks a price level. F1.9 (#76) wires this to the
+   * order-entry form's price input; absent that handler the row still gets
+   * its hover/focus affordances but is otherwise a no-op.
+   */
+  onPriceSelect?: (price: string, side: Side.BUY | Side.SELL) => void
+  /** Override polling cadence for Storybook / tests. */
+  refetchIntervalMs?: number
+}
+
+/**
+ * Root orderbook component.
+ *
+ * Ships its own `QueryClientProvider` because Shell.tsx + the trading-app
+ * layout are off-limits in F1.6's scope and a wave-4 follow-up has not yet
+ * hoisted a shared client. A consumer that *does* already wrap children
+ * with a `QueryClientProvider` should render `OrderBookContent` directly
+ * — it sees the ancestor's client and uses the shared cache.
+ */
+export function OrderBook({ pair, onPriceSelect, refetchIntervalMs }: OrderBookProps) {
+  return (
+    <QueryClientProvider client={getScopedClient()}>
+      <OrderBookContent
+        pair={pair}
+        onPriceSelect={onPriceSelect}
+        refetchIntervalMs={refetchIntervalMs}
+      />
+    </QueryClientProvider>
+  )
+}
+
+/**
+ * The contents, sans QueryClientProvider — usable directly when an
+ * ancestor already provides one (Wave-4 cleanup will hoist a shared
+ * client into the trading layout).
+ */
+export function OrderBookContent({
+  pair,
+  onPriceSelect,
+  refetchIntervalMs,
+}: OrderBookProps): JSX.Element {
+  const effectivePair = pair ?? DEFAULT_PAIR
+  const book = useOrderBook({ pair: effectivePair, refetchIntervalMs })
+  const auctions = useRecentAuctions({ pair: effectivePair, limit: 2, refetchIntervalMs })
+
+  const depth = useMemo(() => {
+    if (!book.data) return null
+    return computeDepthRows(book.data.bids, book.data.asks)
+  }, [book.data])
+
+  const header = useMemo(() => {
+    const last = auctions.data?.auctions[0]?.clearingPrice ?? null
+    const prev = auctions.data?.auctions[1]?.clearingPrice ?? null
+    return {
+      clearingPrice: last,
+      delta: last !== null ? formatDelta(last, prev) : null,
+    }
+  }, [auctions.data])
+
+  const handleSelect = onPriceSelect
+    ? (price: string, side: DepthTableSide) => onPriceSelect(price, side)
+    : undefined
+
+  let body: ReactNode
+  if (book.isLoading && !book.data) {
+    body = <OrderBookLoading />
+  } else if (book.isError) {
+    body = (
+      <OrderBookError
+        message={book.error instanceof Error ? book.error.message : undefined}
+        onRetry={() => void book.refetch()}
+      />
+    )
+  } else if (depth === null || (depth.bids.length === 0 && depth.asks.length === 0)) {
+    body = <OrderBookEmpty />
+  } else {
+    const bestBid = depth.bids[0]?.level.price ?? null
+    const bestAsk = depth.asks[0]?.level.price ?? null
+    body = (
+      <div className="flex flex-col">
+        <ColumnHeader />
+        <DepthTable rows={depth.asks} side={Side.SELL} reverse onSelect={handleSelect} />
+        <SpreadRow bestBid={bestBid} bestAsk={bestAsk} />
+        <DepthTable rows={depth.bids} side={Side.BUY} onSelect={handleSelect} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col" data-testid="orderbook">
+      <OrderBookHeader clearingPrice={header.clearingPrice} delta={header.delta} />
+      <div className="flex flex-1 flex-col overflow-y-auto">{body}</div>
+    </div>
+  )
+}
+
+function ColumnHeader() {
+  return (
+    <div
+      role="row"
+      className="grid grid-cols-3 gap-2 border-b border-brand-border px-4 py-2 font-mono text-label-md uppercase text-brand-muted"
+    >
+      <span className="text-left">Price</span>
+      <span className="text-right">Size</span>
+      <span className="text-right">Total</span>
+    </div>
+  )
+}
+
+/**
+ * Lazily-built QueryClient at module scope so HMR reloads in dev don't
+ * reset the in-flight orderbook query on every save. A follow-up that
+ * hoists a shared client to the trading layout can use
+ * `OrderBookContent` directly and skip this scoped instance.
+ */
+let scopedClient: QueryClient | null = null
+function getScopedClient(): QueryClient {
+  if (scopedClient) return scopedClient
+  scopedClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        // Polling-driven; we never want to retry on a transient hiccup mid
+        // tick because the next tick is 1 s away.
+        retry: false,
+        refetchOnWindowFocus: false,
+      },
+    },
+  })
+  return scopedClient
+}

--- a/front/components/trade/orderbook/OrderBookHeader.tsx
+++ b/front/components/trade/orderbook/OrderBookHeader.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { NumericText } from '../../NumericText'
+
+import type { FormattedDelta } from './depth'
+
+export interface OrderBookHeaderProps {
+  /** Latest clearing price as a wire-string. `null` while no auctions have run yet. */
+  clearingPrice: string | null
+  /** Signed delta vs the previous auction. `null` mirrors `clearingPrice == null`. */
+  delta: FormattedDelta | null
+}
+
+/**
+ * Top of the orderbook column: the latest auction's clearing price + its
+ * signed delta against the prior auction. Renders a placeholder when no
+ * auction has been observed yet. Per DESIGN, the delta has no semantic
+ * hue — sign is conveyed by the leading `+` / `-` and a luminance step.
+ */
+export function OrderBookHeader({ clearingPrice, delta }: OrderBookHeaderProps) {
+  const hasPrice = clearingPrice !== null
+  const deltaTone =
+    delta?.sign === 'pos' || delta?.sign === 'zero' ? 'text-brand-fg' : 'text-brand-muted'
+
+  return (
+    <div className="flex flex-col items-center gap-1 border-b border-brand-border px-4 py-4">
+      {hasPrice ? (
+        <NumericText
+          value={clearingPrice}
+          kind="price"
+          align="right"
+          className="font-display text-display-sm leading-none tracking-tight"
+          aria-label="Last clearing price"
+        />
+      ) : (
+        <span
+          className="font-display text-display-sm leading-none text-brand-muted"
+          aria-label="No clearing price yet"
+        >
+          —
+        </span>
+      )}
+      <span className="font-mono text-label-md uppercase text-brand-muted" aria-live="polite">
+        [ LAST{delta && delta.sign !== 'na' ? ' · Δ ' : ' · '}
+        <span className={deltaTone}>{delta?.text ?? '—'}</span>
+        {' ]'}
+      </span>
+    </div>
+  )
+}

--- a/front/components/trade/orderbook/SpreadRow.tsx
+++ b/front/components/trade/orderbook/SpreadRow.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { Decimal } from '../../../lib/units'
+import { NumericText } from '../../NumericText'
+
+export interface SpreadRowProps {
+  bestBid: string | null
+  bestAsk: string | null
+}
+
+/**
+ * Single-row band between asks and bids reporting the spread (absolute and
+ * as a basis-point ratio of the mid). Renders an em-dash placeholder when
+ * either side of the book is empty.
+ */
+export function SpreadRow({ bestBid, bestAsk }: SpreadRowProps) {
+  const { absolute, bps } = computeSpread(bestBid, bestAsk)
+  return (
+    <div
+      className="flex items-center justify-between border-y border-brand-border bg-brand-surface px-4 py-2"
+      aria-label="Spread"
+    >
+      <span className="font-mono text-label-md uppercase text-brand-muted">[ SPREAD ]</span>
+      <div className="flex items-center gap-3">
+        {absolute !== null ? (
+          <NumericText value={absolute} kind="price" align="right" className="text-brand-fg" />
+        ) : (
+          <span className="font-mono text-body-sm text-brand-muted">—</span>
+        )}
+        <span className="font-mono text-body-sm text-brand-muted">
+          {bps !== null ? `${bps} bps` : '—'}
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function computeSpread(
+  bestBid: string | null,
+  bestAsk: string | null
+): { absolute: string | null; bps: string | null } {
+  if (bestBid === null || bestAsk === null) return { absolute: null, bps: null }
+  const bid = new Decimal(bestBid)
+  const ask = new Decimal(bestAsk)
+  const diff = ask.minus(bid)
+  if (!diff.isFinite() || diff.isNegative()) return { absolute: null, bps: null }
+  const mid = ask.plus(bid).div(2)
+  const bps = mid.gt(0) ? diff.div(mid).times(10000).toDecimalPlaces(1).toFixed(1) : null
+  return { absolute: diff.toFixed(2), bps }
+}

--- a/front/components/trade/orderbook/_processShim.ts
+++ b/front/components/trade/orderbook/_processShim.ts
@@ -1,0 +1,21 @@
+// Ladle/Vite-only side-effect: lib/config.ts reads process.env at module
+// load and the browser bundle has no `process` global. This shim fills it
+// with sensible mock defaults so `parseConfig()` succeeds with `useMocks=true`.
+// Production Next.js builds inline NEXT_PUBLIC_* at compile time and never
+// hit this branch.
+
+const g = globalThis as unknown as { process?: { env: Record<string, string | undefined> } }
+
+if (typeof g.process === 'undefined') {
+  g.process = {
+    env: {
+      NEXT_PUBLIC_USE_MOCKS: 'true',
+      NEXT_PUBLIC_DARKPOOL_API_URL: 'http://localhost:8080',
+      NEXT_PUBLIC_DARKPOOL_API_KEY: 'ladle-dev',
+      NEXT_PUBLIC_CHAIN_ID: '42161',
+      NEXT_PUBLIC_OPERATOR_PUBKEY_URL: 'http://localhost:8080/v1/operator/pubkey',
+    },
+  }
+}
+
+export {}

--- a/front/components/trade/orderbook/depth.test.ts
+++ b/front/components/trade/orderbook/depth.test.ts
@@ -1,0 +1,87 @@
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it } from 'vitest'
+
+import { PriceLevelSchema } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import { computeDepthRows, formatDelta } from './depth'
+
+function level(price: string, totalSize: string, orderCount = 1) {
+  return create(PriceLevelSchema, { price, totalSize, orderCount })
+}
+
+describe('computeDepthRows', () => {
+  it('returns empty rows and zero max when both sides are empty', () => {
+    const out = computeDepthRows([], [])
+    expect(out.bids).toEqual([])
+    expect(out.asks).toEqual([])
+    expect(out.maxCumulative).toBe('0')
+  })
+
+  it('accumulates bids from the top of book downward', () => {
+    const bids = [level('100', '2'), level('99', '3'), level('98', '5')]
+    const out = computeDepthRows(bids, [])
+    expect(out.bids.map((r) => r.cumulative)).toEqual(['2', '5', '10'])
+  })
+
+  it('accumulates asks from the top of book upward', () => {
+    const asks = [level('101', '1'), level('102', '4'), level('103', '5')]
+    const out = computeDepthRows([], asks)
+    expect(out.asks.map((r) => r.cumulative)).toEqual(['1', '5', '10'])
+  })
+
+  it('normalizes barFraction against the larger side', () => {
+    const bids = [level('100', '5'), level('99', '5')] // cumulative max 10
+    const asks = [level('101', '1'), level('102', '1')] // cumulative max 2
+    const out = computeDepthRows(bids, asks)
+    // bids max is 10 → that's the global max, so bids end at 1.0
+    expect(out.bids.at(-1)?.barFraction).toBeCloseTo(1.0, 5)
+    // asks end at 2 / 10 = 0.2
+    expect(out.asks.at(-1)?.barFraction).toBeCloseTo(0.2, 5)
+    expect(out.maxCumulative).toBe('10')
+  })
+
+  it('handles decimal sizes precisely (no float drift)', () => {
+    const bids = [level('100', '0.1'), level('99', '0.2')]
+    const out = computeDepthRows(bids, [])
+    // 0.1 + 0.2 must equal 0.3 exactly through Decimal arithmetic
+    expect(out.bids.at(-1)?.cumulative).toBe('0.3')
+  })
+
+  it('preserves level identity for click-through', () => {
+    const a = level('100', '1')
+    const b = level('99', '1')
+    const out = computeDepthRows([a, b], [])
+    expect(out.bids[0].level).toBe(a)
+    expect(out.bids[1].level).toBe(b)
+  })
+})
+
+describe('formatDelta', () => {
+  it('returns na when previous is null', () => {
+    expect(formatDelta('100.00', null)).toEqual({ text: '—', sign: 'na' })
+  })
+
+  it('returns na when previous is undefined', () => {
+    expect(formatDelta('100.00', undefined)).toEqual({ text: '—', sign: 'na' })
+  })
+
+  it('flags a positive delta with a + prefix', () => {
+    expect(formatDelta('100.00', '95.50')).toEqual({ text: '+4.50', sign: 'pos' })
+  })
+
+  it('flags a negative delta with a - prefix', () => {
+    expect(formatDelta('95.50', '100.00')).toEqual({ text: '-4.50', sign: 'neg' })
+  })
+
+  it('flags zero delta', () => {
+    expect(formatDelta('100.00', '100.00')).toEqual({ text: '0.00', sign: 'zero' })
+  })
+
+  it('respects the displayDp argument', () => {
+    expect(formatDelta('100.123', '100', 3)).toEqual({ text: '+0.123', sign: 'pos' })
+  })
+
+  it('rounds half-up to displayDp', () => {
+    expect(formatDelta('100.005', '100', 2)).toEqual({ text: '+0.01', sign: 'pos' })
+  })
+})

--- a/front/components/trade/orderbook/depth.ts
+++ b/front/components/trade/orderbook/depth.ts
@@ -1,0 +1,96 @@
+import { Decimal } from '../../../lib/units'
+
+import type { PriceLevel } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+export interface DepthRow {
+  level: PriceLevel
+  /** Cumulative wire-string size from the top of book down to (and including) this level. */
+  cumulative: string
+  /** [0,1] — share of `maxCumulative`, drives the depth-bar width. */
+  barFraction: number
+}
+
+export interface DepthRows {
+  bids: DepthRow[]
+  asks: DepthRow[]
+  /** Larger of the two sides' deepest cumulative size. Use it to keep bid + ask bars on the same scale. */
+  maxCumulative: string
+}
+
+/**
+ * Accumulates `totalSize` along each side. Bids and asks arrive pre-sorted
+ * (bids high→low, asks low→high — best of book at index 0), so cumulative
+ * sums grow away from the spread.
+ *
+ * Both sides share a single normalization denominator so the deeper side
+ * doesn't visually dwarf the thinner one — a 10-ETH ask shouldn't render
+ * the same width as a 1-ETH bid just because their sides happen to clear
+ * differently.
+ */
+export function computeDepthRows(bids: PriceLevel[], asks: PriceLevel[]): DepthRows {
+  const bidsAcc = accumulate(bids)
+  const asksAcc = accumulate(asks)
+  const bidsMax = bidsAcc.at(-1)?.runningTotal ?? new Decimal(0)
+  const asksMax = asksAcc.at(-1)?.runningTotal ?? new Decimal(0)
+  const max = bidsMax.gte(asksMax) ? bidsMax : asksMax
+  const maxStr = max.toFixed()
+  const bidRows = bidsAcc.map((entry) => toRow(entry, max))
+  const askRows = asksAcc.map((entry) => toRow(entry, max))
+  return { bids: bidRows, asks: askRows, maxCumulative: maxStr }
+}
+
+interface AccEntry {
+  level: PriceLevel
+  runningTotal: Decimal
+}
+
+function accumulate(levels: PriceLevel[]): AccEntry[] {
+  const out: AccEntry[] = []
+  let running = new Decimal(0)
+  for (const level of levels) {
+    running = running.plus(level.totalSize)
+    out.push({ level, runningTotal: running })
+  }
+  return out
+}
+
+function toRow(entry: AccEntry, max: Decimal): DepthRow {
+  const fraction = max.gt(0) ? entry.runningTotal.div(max).toNumber() : 0
+  return {
+    level: entry.level,
+    cumulative: entry.runningTotal.toFixed(),
+    barFraction: fraction,
+  }
+}
+
+export type DeltaSign = 'pos' | 'neg' | 'zero' | 'na'
+
+export interface FormattedDelta {
+  text: string
+  sign: DeltaSign
+}
+
+/**
+ * Signed-prefix delta between two wire-string prices. Returns `na` when
+ * there's no prior reference (first ever auction). The brutalist palette
+ * has no green / red — consumers map `sign` to typography weight or
+ * opacity, never to hue.
+ */
+export function formatDelta(
+  current: string,
+  previous: string | null | undefined,
+  displayDp = 2
+): FormattedDelta {
+  if (previous == null) return { text: '—', sign: 'na' }
+  const diff = new Decimal(current).minus(previous)
+  const rounded = diff.toDecimalPlaces(displayDp, Decimal.ROUND_HALF_UP)
+  if (rounded.isZero()) {
+    return { text: rounded.toFixed(displayDp), sign: 'zero' }
+  }
+  const fixed = rounded.toFixed(displayDp)
+  if (rounded.isPositive()) {
+    return { text: `+${fixed}`, sign: 'pos' }
+  }
+  // toFixed() already includes the leading minus sign for negatives.
+  return { text: fixed, sign: 'neg' }
+}

--- a/front/components/trade/orderbook/index.ts
+++ b/front/components/trade/orderbook/index.ts
@@ -1,0 +1,16 @@
+// Public API for the F1.6 orderbook panel.
+//
+// Consumers default to the `<OrderBook />` root component — it ships with
+// its own QueryClientProvider and a `useDarkPoolClient()` read, so it
+// works the moment it's rendered inside the trading shell (which already
+// provides DarkPoolClientProvider via app/app/layout.tsx). When a
+// follow-up hoists a single QueryClient up to the layout, the inner
+// content (`<OrderBookContent />`) can be used directly to share the
+// upstream cache.
+
+export { OrderBook, OrderBookContent } from './OrderBook'
+export type { OrderBookProps } from './OrderBook'
+export { useOrderBook, useRecentAuctions, ORDERBOOK_POLL_MS } from './useOrderBook'
+export type { UseOrderBookOptions, UseRecentAuctionsOptions } from './useOrderBook'
+export { computeDepthRows, formatDelta } from './depth'
+export type { DepthRow, DepthRows, DeltaSign, FormattedDelta } from './depth'

--- a/front/components/trade/orderbook/states.tsx
+++ b/front/components/trade/orderbook/states.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+const SKELETON_BAR = '████░░░░'
+
+/**
+ * Box-drawing skeleton — per DESIGN-INSPIRATIONS, loading uses skeleton
+ * blocks (`█ ░`) rather than spinners. Each row's mask offset is fixed so
+ * the skeleton reads as orderbook-shaped rather than uniform noise.
+ */
+export function OrderBookLoading({ rows = 8 }: { rows?: number }) {
+  return (
+    <div
+      role="status"
+      aria-label="Loading orderbook"
+      aria-live="polite"
+      className="flex flex-col gap-1 px-4 py-3"
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <div
+          key={i}
+          className="flex items-center justify-between font-mono text-body-sm text-brand-border2 animate-pulse"
+          aria-hidden="true"
+        >
+          <span>{shift(SKELETON_BAR, i)}</span>
+          <span>{shift(SKELETON_BAR, i + 3)}</span>
+          <span>{shift(SKELETON_BAR, i + 5)}</span>
+        </div>
+      ))}
+      <span className="sr-only">Loading orderbook…</span>
+    </div>
+  )
+}
+
+function shift(bar: string, by: number): string {
+  const offset = ((by % bar.length) + bar.length) % bar.length
+  return bar.slice(offset) + bar.slice(0, offset)
+}
+
+/**
+ * Empty state — visually distinct from loading per the acceptance
+ * criteria. Terse copy per DESIGN-INSPIRATIONS tone-of-copy table.
+ */
+export function OrderBookEmpty() {
+  return (
+    <div
+      role="status"
+      className="flex flex-1 items-center justify-center px-4 py-8 font-mono text-label-lg uppercase text-brand-muted"
+    >
+      [ NO ORDERS YET ]
+    </div>
+  )
+}
+
+export interface OrderBookErrorProps {
+  message?: string
+  onRetry?: () => void
+}
+
+export function OrderBookError({ message, onRetry }: OrderBookErrorProps) {
+  return (
+    <div
+      role="alert"
+      className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-8 text-center"
+    >
+      <span className="font-mono text-label-lg uppercase text-brand-muted">
+        [ ORDERBOOK UNAVAILABLE ]
+      </span>
+      {message ? (
+        <span className="max-w-xs font-mono text-body-sm text-brand-muted">{message}</span>
+      ) : null}
+      {onRetry ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="border border-brand-border2 px-4 py-2 font-mono text-label-md uppercase text-brand-fg transition-colors hover:border-brand-accent hover:text-brand-accent focus-visible:border-brand-accent focus-visible:text-brand-accent focus-visible:outline-none"
+        >
+          [ RETRY ]
+        </button>
+      ) : null}
+    </div>
+  )
+}

--- a/front/components/trade/orderbook/useOrderBook.ts
+++ b/front/components/trade/orderbook/useOrderBook.ts
@@ -1,0 +1,70 @@
+'use client'
+
+import { create } from '@bufbuild/protobuf'
+import { keepPreviousData, useQuery, type UseQueryResult } from '@tanstack/react-query'
+
+import { useDarkPoolClient } from '../../../lib/sdk/provider'
+import { DEFAULT_PAIR } from '../../../lib/sdk/mocks/factories'
+import {
+  GetAuctionHistoryRequestSchema,
+  GetOrderBookRequestSchema,
+  type GetAuctionHistoryResponse,
+  type GetOrderBookResponse,
+} from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+/**
+ * 1000 ms = cadence of the F1.2 mock store's perturb tick. Faster polling
+ * wastes ticks; slower polling drops mutations between refetches. When
+ * I2.4 (#93) swaps the mock for the REST surface and I2.6 (#95) lands the
+ * streaming bridge, refetchInterval drops to 0 and the stream takes over.
+ */
+export const ORDERBOOK_POLL_MS = 1000
+
+export interface UseOrderBookOptions {
+  pair?: string
+  /** Override polling cadence — primarily for Storybook + tests. */
+  refetchIntervalMs?: number
+}
+
+export function useOrderBook(opts: UseOrderBookOptions = {}): UseQueryResult<GetOrderBookResponse> {
+  const client = useDarkPoolClient()
+  const pair = opts.pair ?? DEFAULT_PAIR
+  const refetchInterval = opts.refetchIntervalMs ?? ORDERBOOK_POLL_MS
+  return useQuery({
+    queryKey: ['darkpool', 'orderbook', pair],
+    queryFn: () => client.getOrderBook(create(GetOrderBookRequestSchema, { pair })),
+    refetchInterval,
+    // Keep the prior snapshot visible during the in-flight refetch so the
+    // table doesn't flash a loading state on every tick.
+    placeholderData: keepPreviousData,
+  })
+}
+
+export interface UseRecentAuctionsOptions {
+  pair?: string
+  /** Number of auctions to fetch. Default 2 (last + previous, for delta). */
+  limit?: number
+  refetchIntervalMs?: number
+}
+
+/**
+ * Polls the last N auction summaries so the orderbook header can render the
+ * latest clearing price and its delta vs the prior auction. The mock store
+ * clears a new auction every 5 s; 1 s polling cheaply picks them up at the
+ * top of the next tick.
+ */
+export function useRecentAuctions(
+  opts: UseRecentAuctionsOptions = {}
+): UseQueryResult<GetAuctionHistoryResponse> {
+  const client = useDarkPoolClient()
+  const pair = opts.pair ?? DEFAULT_PAIR
+  const limit = opts.limit ?? 2
+  const refetchInterval = opts.refetchIntervalMs ?? ORDERBOOK_POLL_MS
+  return useQuery({
+    queryKey: ['darkpool', 'auctions', pair, limit],
+    queryFn: () =>
+      client.getAuctionHistory(create(GetAuctionHistoryRequestSchema, { pair, limit })),
+    refetchInterval,
+    placeholderData: keepPreviousData,
+  })
+}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-tabs": "^1.1.3",
         "@radix-ui/react-toast": "^1.2.6",
         "@radix-ui/react-tooltip": "^1.1.8",
+        "@tanstack/react-query": "^5.62.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "decimal.js": "^10.4.3",
@@ -3253,6 +3254,32 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.10.tgz",
+      "integrity": "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.10.tgz",
+      "integrity": "sha512-FLaZf2RCrA/Zgp4aiu5tG3TyasTRO7aZ99skxQpr3Hg/zXOhu6yq5FZCYQ/tRaJtM9ylnoK8tFK7PolXQadv6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/front/package.json
+++ b/front/package.json
@@ -25,6 +25,7 @@
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-toast": "^1.2.6",
     "@radix-ui/react-tooltip": "^1.1.8",
+    "@tanstack/react-query": "^5.62.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "decimal.js": "^10.4.3",


### PR DESCRIPTION
Closes #73

## Summary
- Stacked orderbook view: asks on top (high→spread), spread row in the middle, bids below (best bid→down). Cumulative-size depth bars normalized against the deeper side so bid and ask widths share a scale.
- Bid/ask differentiation by position + luminance only — no semantic hue. Bids fill `brand-fg/8%`, asks fill `brand-muted/20%`. Best-of-book row gets one typography step up (`body-md` vs `body-sm`).
- Header shows the last clearing price (`display-sm` Bebas Neue) and the signed delta against the previous auction. Sign is encoded with `+`/`-` prefix; positive uses `brand-fg`, negative drops to `brand-muted` — never a hue.
- `useOrderBook` and `useRecentAuctions` hooks wrap `useQuery` with `refetchInterval = 1000ms` (matches the mock store's perturb cadence) and `placeholderData: keepPreviousData` so the table doesn't flash a loading state on every tick.
- `onPriceSelect` callback for F1.9 (#76) click-to-fill — ships as a no-op until wired.
- Loading uses box-drawing skeleton rows per DESIGN-INSPIRATIONS; empty (`[ NO ORDERS YET ]`) and error (`[ ORDERBOOK UNAVAILABLE ]` + retry) are visually distinct.

## File scope (kept strict)
- New: `front/components/trade/orderbook/` (12 files).
- Additive only: `front/package.json` (+ `@tanstack/react-query@^5.62.7`) and the matching lockfile bump.
- Did **not** touch: `Shell.tsx`, `app/app/layout.tsx`, sibling panels (`/balances`, `/tape`, `/entry`), `mock-store.ts`.

## Follow-ups not in this PR
- **Shell wiring.** Off-limits by file scope; the orderbook is viewable via Ladle today. A small later PR (or the F1.13 polish wave) drops `<OrderBook />` into `Shell.tsx`'s `OrderbookPanel`.
- **Hoist a shared `QueryClient`** into the trading-app layout. Right now `<OrderBook />` ships its own `QueryClientProvider` (also off-limits to touch in F1.6). A follow-up can switch consumers to `<OrderBookContent />` so it sees the ancestor's cache.
- `_processShim.ts` is a Ladle/Vite-only side-effect (`lib/config.ts` reads `process.env` at module load, which the browser doesn't have). Production Next.js builds inline `NEXT_PUBLIC_*` and never hit it — happy to extract if F0.5 owners prefer to host this centrally.

## Test plan
- [x] `npm run typecheck` — 0 errors.
- [x] `npm run lint` — 0 issues.
- [x] `npx vitest run` — 142/142 pass (13 new in `depth.test.ts` for cumulative + delta).
- [x] `npx prettier --check components/trade/orderbook` — clean.
- [x] Ladle visual pass on all 7 stories: `Populated`, `PopulatedNarrow` (280 px), `Empty`, `NoAuctionYet`, `Loading`, `ErrorState`, `WithClickToFill`. Click-to-fill callback fires with `(price, side)`.