### PR TITLE
[F1.7] Auction tape (mock-backed)

### DIFF
--- a/docs/superpowers/plans/2026-05-17-f17-auction-tape.md
+++ b/docs/superpowers/plans/2026-05-17-f17-auction-tape.md
@@ -1,0 +1,1422 @@
+# F1.7 Auction Tape Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the auction tape panel for `/app/trade` — a vertical strip of recently-settled auctions backed by the F1.2 mock store, with a lime countdown header, per-row drawer, and motion-respectful entrance animation. Closes [#74](https://github.com/Dnreikronos/DarkPool-Exchange/issues/74).
+
+**Architecture:** Pure selector + thin React hook reads `recentAuctions` from the existing Zustand mock store; UI is a `<Countdown/>` ticker-bar header above an `<ol>` of memoized `<TapeRow/>` buttons; a Radix-Dialog `<TapeDrawer/>` opens on row select. Entrance animation is a CSS Module keyframe gated by `prefers-reduced-motion`. No new runtime dependencies.
+
+**Tech Stack:** Next 14 App Router, React 18 (`useSyncExternalStore`, `useTransition`-free), TypeScript, Tailwind v3.4 (existing tokens), CSS Modules (Next built-in), Radix `Dialog` (already in deps), Vitest 4 (existing), Ladle (existing) for visual stories. `Decimal` math via `decimal.js`. Reuses `<NumericText/>` from F0.5 for price/size formatting.
+
+**Spec:** `docs/superpowers/specs/2026-05-17-f17-auction-tape-design.md`
+
+**Worktree:** `/home/mario/darkpool-wt/74-tape` · branch `feat/issue-74-tape`
+
+**File scope (strict):** Only `front/components/trade/tape/*` is created or modified. The SDK index stays untouched. `Shell.tsx`, `mock-store.ts`, and sibling panel directories are off-limits. Manual browser verification (Task 10) edits `Shell.tsx` **locally only** and reverts before commit.
+
+**Testing note (deviation from spec §10):** The project currently has no `@testing-library/react` or `jsdom`; every existing test is a pure module-level Vitest. To stay inside scope (no new deps) and follow established patterns, this plan tests:
+- formatters and the selector as pure functions (unit)
+- components via Ladle stories (visual)
+- the full strip via the temporary Shell.tsx swap (manual)
+
+The deviation is captured in the PR body so reviewers don't expect render-tested React components.
+
+---
+
+## File Structure
+
+All paths under `front/components/trade/tape/`:
+
+| File                       | Responsibility                                                          |
+|----------------------------|--------------------------------------------------------------------------|
+| `format.ts`                | Pure formatters: `formatRelativeTime`, `formatFullTimestamp`, `formatCount`, `secondsToNextAuction`. |
+| `format.test.ts`           | Vitest unit tests for each formatter.                                   |
+| `useAuctionHistory.ts`     | `selectLatestAuctions(state, limit)` pure selector + `useAuctionHistory(opts)` React hook. |
+| `useAuctionHistory.test.ts`| Vitest unit tests for the selector (deterministic, no React).           |
+| `useNow.ts`                | Shared 1Hz tick hook returning `unixSeconds: number`.                   |
+| `tape.module.css`          | `@keyframes tape-enter` and `.enter` class, gated by `prefers-reduced-motion`. Also `.drawer-in`/`.drawer-out` overrides. |
+| `TapeRow.tsx`              | `React.memo` row: 4-col grid, button semantics, onSelect callback.      |
+| `TapeRow.stories.tsx`      | Ladle story: single row, list of rows, hover state, new-row class.      |
+| `Countdown.tsx`            | Ticker-bar header, lime text, `[ NEXT AUCTION IN NN ]`.                 |
+| `Countdown.stories.tsx`    | Ladle story: full countdown, waiting state, zero-state.                 |
+| `TapeDrawer.tsx`           | Radix Dialog wrapping `front/components/ui/dialog`, right-side panel.   |
+| `TapeDrawer.stories.tsx`   | Ladle story: open with a seeded auction.                                |
+| `Tape.tsx`                 | `'use client'` container: hook + Countdown + ordered list + drawer.    |
+| `Tape.stories.tsx`         | Ladle story: full panel with `createMockStore` seeded and `start()`ed.  |
+| `index.ts`                 | Barrel: `export { Tape } from './Tape'`.                                |
+
+---
+
+## Task 1: Scaffold directory and barrel
+
+**Files:**
+- Create: `front/components/trade/tape/index.ts`
+- Create: `front/components/trade/tape/.gitkeep` (removed in Task 2; only for the initial directory commit)
+
+- [ ] **Step 1: Create the directory and an empty barrel**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+mkdir -p front/components/trade/tape
+```
+
+Create `front/components/trade/tape/index.ts` with placeholder content (the real export lands in Task 9):
+
+```ts
+// Barrel for the auction tape panel (F1.7 / issue #74).
+// Populated as components are implemented per
+// docs/superpowers/plans/2026-05-17-f17-auction-tape.md.
+export {}
+```
+
+- [ ] **Step 2: Verify the directory exists and is empty otherwise**
+
+```bash
+ls front/components/trade/tape/
+```
+
+Expected: `index.ts` only.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add front/components/trade/tape/index.ts
+git commit -m "[F1.7] Scaffold auction tape directory"
+```
+
+---
+
+## Task 2: format.ts — `formatRelativeTime` (red → green)
+
+**Files:**
+- Create: `front/components/trade/tape/format.test.ts`
+- Create: `front/components/trade/tape/format.ts`
+
+Timestamps in `AuctionSummary.timestampUnix` are **seconds** (bigint). `useNow()` will return `unixSeconds: number`. All formatter inputs are typed accordingly.
+
+- [ ] **Step 1: Write the failing test for `formatRelativeTime`**
+
+Create `front/components/trade/tape/format.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { formatRelativeTime } from './format'
+
+describe('formatRelativeTime', () => {
+  // (auctionUnix, nowUnix) — both seconds.
+  it('renders a fresh auction as "0s"', () => {
+    expect(formatRelativeTime(1_700_000_000n, 1_700_000_000)).toBe('0s')
+  })
+
+  it('renders sub-minute ages in seconds', () => {
+    expect(formatRelativeTime(1_700_000_000n, 1_700_000_005)).toBe('5s')
+    expect(formatRelativeTime(1_700_000_000n, 1_700_000_059)).toBe('59s')
+  })
+
+  it('switches to minutes at and above 60s', () => {
+    expect(formatRelativeTime(1_700_000_000n, 1_700_000_060)).toBe('1m')
+    expect(formatRelativeTime(1_700_000_000n, 1_700_003_599)).toBe('59m')
+  })
+
+  it('switches to hours at and above 60m', () => {
+    expect(formatRelativeTime(1_700_000_000n, 1_700_003_600)).toBe('1h')
+    expect(formatRelativeTime(1_700_000_000n, 1_700_086_399)).toBe('23h')
+  })
+
+  it('switches to days at and above 24h', () => {
+    expect(formatRelativeTime(1_700_000_000n, 1_700_086_400)).toBe('1d')
+    expect(formatRelativeTime(1_700_000_000n, 1_700_259_200)).toBe('3d')
+  })
+
+  it('clamps negative ages (clock skew) to 0s', () => {
+    expect(formatRelativeTime(1_700_000_010n, 1_700_000_000)).toBe('0s')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape/front
+npx vitest run components/trade/tape/format.test.ts
+```
+
+Expected: FAIL — `Cannot find module './format'`.
+
+- [ ] **Step 3: Implement `formatRelativeTime`**
+
+Create `front/components/trade/tape/format.ts`:
+
+```ts
+// Pure formatters for the auction tape. No React, no DOM.
+// Timestamps from AuctionSummary.timestampUnix arrive as seconds (bigint).
+
+const SECONDS_PER_MINUTE = 60
+const SECONDS_PER_HOUR = 60 * 60
+const SECONDS_PER_DAY = 60 * 60 * 24
+
+export function formatRelativeTime(auctionUnixSeconds: bigint, nowUnixSeconds: number): string {
+  const ageSeconds = Math.max(0, nowUnixSeconds - Number(auctionUnixSeconds))
+  if (ageSeconds < SECONDS_PER_MINUTE) return `${ageSeconds}s`
+  if (ageSeconds < SECONDS_PER_HOUR) return `${Math.floor(ageSeconds / SECONDS_PER_MINUTE)}m`
+  if (ageSeconds < SECONDS_PER_DAY) return `${Math.floor(ageSeconds / SECONDS_PER_HOUR)}h`
+  return `${Math.floor(ageSeconds / SECONDS_PER_DAY)}d`
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run components/trade/tape/format.test.ts
+```
+
+Expected: PASS — 6/6 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git add front/components/trade/tape/format.ts front/components/trade/tape/format.test.ts
+git commit -m "[F1.7] Add formatRelativeTime for tape rows"
+```
+
+---
+
+## Task 3: format.ts — `formatFullTimestamp`, `formatCount`, `secondsToNextAuction`
+
+**Files:**
+- Modify: `front/components/trade/tape/format.test.ts`
+- Modify: `front/components/trade/tape/format.ts`
+
+- [ ] **Step 1: Append failing tests for the remaining formatters**
+
+Append to `front/components/trade/tape/format.test.ts`:
+
+```ts
+import { formatCount, formatFullTimestamp, secondsToNextAuction } from './format'
+
+describe('formatFullTimestamp', () => {
+  it('renders HH:MM:SS · DD MMM YYYY in UTC', () => {
+    // 1700000000 = 2023-11-14 22:13:20 UTC
+    expect(formatFullTimestamp(1_700_000_000n)).toBe('22:13:20 · 14 NOV 2023')
+  })
+
+  it('zero-pads time components', () => {
+    // 1672531200 = 2023-01-01 00:00:00 UTC
+    expect(formatFullTimestamp(1_672_531_200n)).toBe('00:00:00 · 01 JAN 2023')
+  })
+})
+
+describe('formatCount', () => {
+  it('renders an integer as-is', () => {
+    expect(formatCount(0)).toBe('0')
+    expect(formatCount(1)).toBe('1')
+    expect(formatCount(42)).toBe('42')
+  })
+
+  it('clamps negative inputs to 0', () => {
+    expect(formatCount(-3)).toBe('0')
+  })
+})
+
+describe('secondsToNextAuction', () => {
+  it('returns intervalSeconds when no auction has landed yet', () => {
+    expect(secondsToNextAuction(null, 1_700_000_000, 5)).toBe(5)
+  })
+
+  it('counts down from intervalSeconds after the last auction', () => {
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_000, 5)).toBe(5)
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_002, 5)).toBe(3)
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_004, 5)).toBe(1)
+  })
+
+  it('wraps to a fresh interval after the boundary passes (clock keeps moving past 5s when the mock is paused)', () => {
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_005, 5)).toBe(5)
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_006, 5)).toBe(4)
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_012, 5)).toBe(3)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape/front
+npx vitest run components/trade/tape/format.test.ts
+```
+
+Expected: FAIL — `formatFullTimestamp is not a function`, etc.
+
+- [ ] **Step 3: Implement the new formatters**
+
+Append to `front/components/trade/tape/format.ts`:
+
+```ts
+const MONTHS = [
+  'JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN',
+  'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC',
+] as const
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`
+}
+
+export function formatFullTimestamp(unixSeconds: bigint): string {
+  const d = new Date(Number(unixSeconds) * 1000)
+  const hh = pad2(d.getUTCHours())
+  const mm = pad2(d.getUTCMinutes())
+  const ss = pad2(d.getUTCSeconds())
+  const day = pad2(d.getUTCDate())
+  const mon = MONTHS[d.getUTCMonth()]
+  const year = d.getUTCFullYear()
+  return `${hh}:${mm}:${ss} · ${day} ${mon} ${year}`
+}
+
+export function formatCount(n: number): string {
+  return `${Math.max(0, Math.floor(n))}`
+}
+
+/**
+ * Seconds remaining until the next auction tick. `intervalSeconds` is the
+ * cadence configured on the mock store (default 5). When no auction has
+ * landed yet (`lastAuctionUnix === null`), returns a full interval so the
+ * countdown shows a valid number on first render.
+ *
+ * If `now` has drifted past `lastAuctionUnix + intervalSeconds` (e.g. the
+ * mock store was paused), wraps with `mod` so the countdown stays inside
+ * `[1, intervalSeconds]`.
+ */
+export function secondsToNextAuction(
+  lastAuctionUnixSeconds: bigint | null,
+  nowUnixSeconds: number,
+  intervalSeconds: number
+): number {
+  if (lastAuctionUnixSeconds === null) return intervalSeconds
+  const elapsed = nowUnixSeconds - Number(lastAuctionUnixSeconds)
+  if (elapsed < 0) return intervalSeconds
+  const remainder = elapsed % intervalSeconds
+  return remainder === 0 ? intervalSeconds : intervalSeconds - remainder
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+npx vitest run components/trade/tape/format.test.ts
+```
+
+Expected: PASS — all suites green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git add front/components/trade/tape/format.ts front/components/trade/tape/format.test.ts
+git commit -m "[F1.7] Add timestamp, count, and countdown formatters"
+```
+
+---
+
+## Task 4: useAuctionHistory — pure selector
+
+**Files:**
+- Create: `front/components/trade/tape/useAuctionHistory.test.ts`
+- Create: `front/components/trade/tape/useAuctionHistory.ts`
+
+The hook is split in two: a pure `selectLatestAuctions(state, limit)` that the React hook composes, and the React wrapper itself. Only the selector is unit-tested — the wrapper is a one-liner around `useMockStore`.
+
+- [ ] **Step 1: Write the failing selector test**
+
+Create `front/components/trade/tape/useAuctionHistory.test.ts`:
+
+```ts
+import { describe, expect, it } from 'vitest'
+
+import { createMockStore } from '@/lib/mock-store'
+
+import { DEFAULT_AUCTION_HISTORY_LIMIT, selectLatestAuctions } from './useAuctionHistory'
+
+const FROZEN_NOW_SECONDS = 1_700_000_000
+const SEED = 11
+
+function freshState(seed = SEED) {
+  return createMockStore({
+    seed,
+    now: () => FROZEN_NOW_SECONDS,
+    mid: '3000',
+    depth: 4,
+    auctionHistory: 8,
+  }).getState()
+}
+
+describe('selectLatestAuctions', () => {
+  it('returns at most `limit` rows, newest first', () => {
+    const state = freshState()
+    const rows = selectLatestAuctions(state, 5)
+    expect(rows).toHaveLength(5)
+    // newest-first ordering: each row's timestamp is >= the next
+    for (let i = 0; i < rows.length - 1; i++) {
+      expect(rows[i].timestampUnix >= rows[i + 1].timestampUnix).toBe(true)
+    }
+  })
+
+  it('returns the full history when limit exceeds available rows', () => {
+    const state = freshState()
+    const rows = selectLatestAuctions(state, 999)
+    expect(rows).toHaveLength(state.recentAuctions.length)
+  })
+
+  it('returns the same reference for identical inputs (memo seam)', () => {
+    const state = freshState()
+    // The selector itself is referentially stable across calls because it
+    // returns a slice of the same source array; the React hook wraps this
+    // in a useMemo for the same reason.
+    const a = selectLatestAuctions(state, 3)
+    const b = selectLatestAuctions(state, 3)
+    // Different array instances are OK; per-element identity is what
+    // downstream React.memo cares about.
+    expect(a[0]).toBe(b[0])
+    expect(a[1]).toBe(b[1])
+  })
+
+  it('honors the default limit when called without an explicit value', () => {
+    const state = freshState()
+    const rows = selectLatestAuctions(state)
+    expect(rows.length).toBeLessThanOrEqual(DEFAULT_AUCTION_HISTORY_LIMIT)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape/front
+npx vitest run components/trade/tape/useAuctionHistory.test.ts
+```
+
+Expected: FAIL — `Cannot find module './useAuctionHistory'`.
+
+- [ ] **Step 3: Implement the selector and the hook**
+
+Create `front/components/trade/tape/useAuctionHistory.ts`:
+
+```ts
+'use client'
+
+import { useMemo } from 'react'
+
+import type { AuctionSummary } from '@/lib/sdk'
+import { type MockStoreState, useMockStore } from '@/lib/mock-store'
+
+export const DEFAULT_AUCTION_HISTORY_LIMIT = 50
+
+/**
+ * Pure selector over the mock store. Returns the newest `limit` auctions,
+ * preserving the store's newest-first ordering. Exported separately so it
+ * can be unit-tested without a React renderer.
+ */
+export function selectLatestAuctions(
+  state: MockStoreState,
+  limit: number = DEFAULT_AUCTION_HISTORY_LIMIT
+): readonly AuctionSummary[] {
+  if (state.recentAuctions.length <= limit) return state.recentAuctions
+  return state.recentAuctions.slice(0, limit)
+}
+
+export interface UseAuctionHistoryOptions {
+  /** Max rows to surface. Defaults to {@link DEFAULT_AUCTION_HISTORY_LIMIT}. */
+  limit?: number
+  /**
+   * Phase 2 seam. In Phase 1 the store push beats any polling interval;
+   * this is a documented no-op for the mock backend. Default 2000.
+   * The REST swap (#94) will reuse this prop with setInterval.
+   */
+  pollMs?: number
+}
+
+/**
+ * Subscribes to the mock store and returns the latest `limit` auctions.
+ * The returned array is referentially stable when the underlying
+ * `recentAuctions` reference is unchanged — important for `React.memo`
+ * row components, which would otherwise re-render on every 1s perturb.
+ */
+export function useAuctionHistory(opts: UseAuctionHistoryOptions = {}): readonly AuctionSummary[] {
+  const limit = opts.limit ?? DEFAULT_AUCTION_HISTORY_LIMIT
+  const recentAuctions = useMockStore((s) => s.recentAuctions)
+  return useMemo(() => {
+    if (recentAuctions.length <= limit) return recentAuctions
+    return recentAuctions.slice(0, limit)
+  }, [recentAuctions, limit])
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+npx vitest run components/trade/tape/useAuctionHistory.test.ts
+```
+
+Expected: PASS — 4/4 tests green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git add front/components/trade/tape/useAuctionHistory.ts front/components/trade/tape/useAuctionHistory.test.ts
+git commit -m "[F1.7] Add useAuctionHistory selector + hook"
+```
+
+---
+
+## Task 5: useNow — shared 1Hz tick
+
+**Files:**
+- Create: `front/components/trade/tape/useNow.ts`
+
+Trivially small. No unit test; covered indirectly by Tape rendering correctly under Ladle and the browser swap.
+
+- [ ] **Step 1: Implement the hook**
+
+Create `front/components/trade/tape/useNow.ts`:
+
+```ts
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Returns the current Unix time in seconds and updates once per second.
+ * Single shared subscription pattern: every consumer mounts its own
+ * interval, but the cost is one setState per second per consumer —
+ * negligible for the tape (one parent component).
+ *
+ * Pass `nowSecondsOverride` (tests, Ladle stories) to freeze time.
+ */
+export function useNow(nowSecondsOverride?: number): number {
+  const [now, setNow] = useState<number>(() =>
+    nowSecondsOverride ?? Math.floor(Date.now() / 1000)
+  )
+  useEffect(() => {
+    if (nowSecondsOverride !== undefined) return
+    const id = setInterval(() => {
+      setNow(Math.floor(Date.now() / 1000))
+    }, 1000)
+    return () => clearInterval(id)
+  }, [nowSecondsOverride])
+  return now
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape/front
+npx tsc --noEmit
+```
+
+Expected: no errors related to `useNow.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git add front/components/trade/tape/useNow.ts
+git commit -m "[F1.7] Add useNow 1Hz tick hook"
+```
+
+---
+
+## Task 6: tape.module.css — keyframes gated by reduced-motion
+
+**Files:**
+- Create: `front/components/trade/tape/tape.module.css`
+
+- [ ] **Step 1: Author the stylesheet**
+
+Create `front/components/trade/tape/tape.module.css`:
+
+```css
+/*
+ * Keyframes for the tape row entrance and drawer transitions.
+ * Both are gated by `prefers-reduced-motion: no-preference` so that
+ * users who request reduced motion get instant appearance.
+ */
+
+@keyframes tape-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes drawer-in {
+  from {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes drawer-out {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+}
+
+.enter {
+  /* No animation when reduced-motion is requested — rows appear instantly. */
+}
+
+.drawer {
+  /* Default no animation; the media query below enables it. */
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .enter {
+    animation: tape-enter 240ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  .drawer[data-state='open'] {
+    animation: drawer-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .drawer[data-state='closed'] {
+    animation: drawer-out 140ms ease-in;
+  }
+}
+```
+
+- [ ] **Step 2: Verify the file parses (Next dev build does this on first import; pre-commit type-check skips CSS)**
+
+No standalone command; correctness is exercised by Tasks 7–10 importing it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git add front/components/trade/tape/tape.module.css
+git commit -m "[F1.7] Add tape keyframes gated by prefers-reduced-motion"
+```
+
+---
+
+## Task 7: TapeRow component + Ladle story
+
+**Files:**
+- Create: `front/components/trade/tape/TapeRow.tsx`
+- Create: `front/components/trade/tape/TapeRow.stories.tsx`
+
+- [ ] **Step 1: Implement `TapeRow`**
+
+Create `front/components/trade/tape/TapeRow.tsx`:
+
+```tsx
+'use client'
+
+import * as React from 'react'
+
+import { NumericText } from '@/components/NumericText'
+import type { AuctionSummary } from '@/lib/sdk'
+
+import { formatCount, formatRelativeTime } from './format'
+import styles from './tape.module.css'
+
+export interface TapeRowProps {
+  auction: AuctionSummary
+  /** Current Unix seconds; passed down so all rows share one tick source. */
+  nowUnixSeconds: number
+  /** Click / Enter / Space handler. */
+  onSelect: (auctionId: string) => void
+}
+
+function TapeRowImpl({ auction, nowUnixSeconds, onSelect }: TapeRowProps): JSX.Element {
+  const handleClick = React.useCallback(() => {
+    onSelect(auction.auctionId)
+  }, [auction.auctionId, onSelect])
+
+  return (
+    <li className="border-b border-brand-border">
+      <button
+        type="button"
+        onClick={handleClick}
+        className={`${styles.enter} grid w-full grid-cols-[3rem_minmax(0,1fr)_minmax(0,1fr)_2rem] items-center gap-3 px-4 py-2 text-left font-mono text-body-sm tabular-nums text-brand-fg transition-colors hover:bg-brand-surface focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-accent`}
+        aria-label={`Auction ${auction.auctionId}, clearing price ${auction.clearingPrice}`}
+      >
+        <span className="text-brand-muted">
+          {formatRelativeTime(auction.timestampUnix, nowUnixSeconds)}
+        </span>
+        <NumericText
+          value={auction.clearingPrice}
+          kind="price"
+          align="right"
+          className="text-brand-fg"
+        />
+        <NumericText
+          value={auction.matchedVolume}
+          kind="size"
+          align="right"
+          className="text-brand-fg"
+        />
+        <span className="text-right text-brand-muted">{formatCount(auction.matchCount)}</span>
+      </button>
+    </li>
+  )
+}
+
+export const TapeRow = React.memo(TapeRowImpl)
+TapeRow.displayName = 'TapeRow'
+```
+
+- [ ] **Step 2: Write a Ladle story exercising the row**
+
+Create `front/components/trade/tape/TapeRow.stories.tsx`:
+
+```tsx
+import * as React from 'react'
+import { create } from '@bufbuild/protobuf'
+
+import { AuctionSummarySchema } from '@/lib/sdk'
+
+import { TapeRow } from './TapeRow'
+
+const NOW = 1_700_000_120
+
+function mkAuction(opts: Partial<{
+  auctionId: string
+  clearingPrice: string
+  matchedVolume: string
+  matchCount: number
+  ageSeconds: number
+}> = {}) {
+  return create(AuctionSummarySchema, {
+    auctionId: opts.auctionId ?? 'a-001',
+    pair: 'ETH/USDC',
+    clearingPrice: opts.clearingPrice ?? '2418.10',
+    matchedVolume: opts.matchedVolume ?? '0.0453',
+    matchCount: opts.matchCount ?? 3,
+    timestampUnix: BigInt(NOW - (opts.ageSeconds ?? 5)),
+  })
+}
+
+const noop = (_id: string): void => undefined
+
+export const SingleRow = () => (
+  <ol className="w-[320px] border border-brand-border bg-brand-bg">
+    <TapeRow auction={mkAuction()} nowUnixSeconds={NOW} onSelect={noop} />
+  </ol>
+)
+
+export const ListOfRows = () => (
+  <ol className="w-[320px] border border-brand-border bg-brand-bg">
+    <TapeRow
+      auction={mkAuction({ auctionId: 'a-100', ageSeconds: 2, clearingPrice: '2419.85', matchedVolume: '0.0121', matchCount: 1 })}
+      nowUnixSeconds={NOW}
+      onSelect={noop}
+    />
+    <TapeRow
+      auction={mkAuction({ auctionId: 'a-099', ageSeconds: 7, clearingPrice: '12345.6789', matchedVolume: '0.089', matchCount: 5 })}
+      nowUnixSeconds={NOW}
+      onSelect={noop}
+    />
+    <TapeRow
+      auction={mkAuction({ auctionId: 'a-098', ageSeconds: 17, matchedVolume: '0', matchCount: 0 })}
+      nowUnixSeconds={NOW}
+      onSelect={noop}
+    />
+    <TapeRow
+      auction={mkAuction({ auctionId: 'a-097', ageSeconds: 65, clearingPrice: '2417.42', matchedVolume: '0.0023', matchCount: 1 })}
+      nowUnixSeconds={NOW}
+      onSelect={noop}
+    />
+  </ol>
+)
+```
+
+- [ ] **Step 3: Run Ladle to verify rows render correctly**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape/front
+npx ladle serve --port 61000 &
+LADLE_PID=$!
+sleep 4
+curl -sf http://localhost:61000/ > /dev/null && echo "Ladle up"
+kill $LADLE_PID 2>/dev/null
+```
+
+Expected: `Ladle up` printed. (Visual inspection of `TapeRow` happens in Task 10.)
+
+- [ ] **Step 4: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: no errors in `TapeRow.tsx` or `TapeRow.stories.tsx`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git add front/components/trade/tape/TapeRow.tsx front/components/trade/tape/TapeRow.stories.tsx
+git commit -m "[F1.7] Add TapeRow with NumericText columns"
+```
+
+---
+
+## Task 8: Countdown component + Ladle story
+
+**Files:**
+- Create: `front/components/trade/tape/Countdown.tsx`
+- Create: `front/components/trade/tape/Countdown.stories.tsx`
+
+- [ ] **Step 1: Implement `Countdown`**
+
+Create `front/components/trade/tape/Countdown.tsx`:
+
+```tsx
+'use client'
+
+import * as React from 'react'
+
+import { secondsToNextAuction } from './format'
+
+export interface CountdownProps {
+  latestAuctionUnixSeconds: bigint | null
+  nowUnixSeconds: number
+  /** Cadence of the auction tick. Mock store defaults to 5s. */
+  intervalSeconds?: number
+}
+
+const DEFAULT_INTERVAL_SECONDS = 5
+
+export function Countdown({
+  latestAuctionUnixSeconds,
+  nowUnixSeconds,
+  intervalSeconds = DEFAULT_INTERVAL_SECONDS,
+}: CountdownProps): JSX.Element {
+  const waiting = latestAuctionUnixSeconds === null
+
+  const label = waiting
+    ? '[ WAITING FOR FIRST AUCTION ]'
+    : `[ NEXT AUCTION IN ${pad2(
+        secondsToNextAuction(latestAuctionUnixSeconds, nowUnixSeconds, intervalSeconds)
+      )} ]`
+
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      className={`flex h-9 items-center justify-center border-b border-brand-border bg-brand-bg px-4 font-mono text-label-lg uppercase tracking-label ${
+        waiting ? 'text-brand-muted' : 'text-brand-accent'
+      }`}
+    >
+      {label}
+    </div>
+  )
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`
+}
+```
+
+- [ ] **Step 2: Write a Ladle story**
+
+Create `front/components/trade/tape/Countdown.stories.tsx`:
+
+```tsx
+import * as React from 'react'
+
+import { Countdown } from './Countdown'
+
+const NOW = 1_700_000_000
+
+export const Waiting = () => (
+  <div className="w-[320px]">
+    <Countdown latestAuctionUnixSeconds={null} nowUnixSeconds={NOW} />
+  </div>
+)
+
+export const JustAfterAuction = () => (
+  <div className="w-[320px]">
+    <Countdown latestAuctionUnixSeconds={BigInt(NOW)} nowUnixSeconds={NOW} />
+  </div>
+)
+
+export const HalfwayToNext = () => (
+  <div className="w-[320px]">
+    <Countdown latestAuctionUnixSeconds={BigInt(NOW - 2)} nowUnixSeconds={NOW} />
+  </div>
+)
+
+export const OneSecondLeft = () => (
+  <div className="w-[320px]">
+    <Countdown latestAuctionUnixSeconds={BigInt(NOW - 4)} nowUnixSeconds={NOW} />
+  </div>
+)
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape/front
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git add front/components/trade/tape/Countdown.tsx front/components/trade/tape/Countdown.stories.tsx
+git commit -m "[F1.7] Add Countdown ticker-bar header"
+```
+
+---
+
+## Task 9: TapeDrawer component + Ladle story
+
+**Files:**
+- Create: `front/components/trade/tape/TapeDrawer.tsx`
+- Create: `front/components/trade/tape/TapeDrawer.stories.tsx`
+
+The drawer overrides the centered positioning of `front/components/ui/dialog`'s `DialogContent` by adding right-anchored Tailwind classes. The Radix portal + overlay are reused as-is.
+
+- [ ] **Step 1: Implement `TapeDrawer`**
+
+Create `front/components/trade/tape/TapeDrawer.tsx`:
+
+```tsx
+'use client'
+
+import * as React from 'react'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import type { AuctionSummary } from '@/lib/sdk'
+
+import { formatFullTimestamp } from './format'
+import styles from './tape.module.css'
+
+export interface TapeDrawerProps {
+  auction: AuctionSummary | null
+  onClose: () => void
+}
+
+export function TapeDrawer({ auction, onClose }: TapeDrawerProps): JSX.Element {
+  const open = auction !== null
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+    >
+      <DialogContent
+        className={`${styles.drawer} fixed left-auto right-0 top-0 h-screen w-full max-w-[420px] translate-x-0 translate-y-0 border-l border-brand-border bg-brand-surface p-8`}
+        aria-describedby={undefined}
+      >
+        {auction && (
+          <>
+            <DialogTitle className="font-display text-display-sm uppercase">
+              [ AUCTION {auction.auctionId} ]
+            </DialogTitle>
+            <DialogDescription className="mt-2 font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+              {auction.pair}
+            </DialogDescription>
+
+            <dl className="mt-8 grid grid-cols-[max-content_minmax(0,1fr)] gap-y-3 font-mono text-body-sm">
+              <Row label="TIMESTAMP" value={formatFullTimestamp(auction.timestampUnix)} mono />
+              <Row label="CLEARING" value={auction.clearingPrice} mono />
+              <Row label="VOLUME" value={auction.matchedVolume} mono />
+              <Row label="MATCHES" value={String(auction.matchCount)} mono />
+            </dl>
+
+            <div className="mt-10 flex flex-col gap-2">
+              <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+                ETHERSCAN
+              </span>
+              <span
+                aria-label="Etherscan link pending Phase 2 integration"
+                className="font-mono text-label-lg uppercase tracking-label text-brand-muted"
+              >
+                [ ETHERSCAN · PENDING ]
+              </span>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }): JSX.Element {
+  return (
+    <>
+      <dt className="pr-4 font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+        {label}
+      </dt>
+      <dd className={`${mono ? 'tabular-nums' : ''} text-brand-fg`}>{value}</dd>
+    </>
+  )
+}
+```
+
+- [ ] **Step 2: Ladle story for the open drawer**
+
+Create `front/components/trade/tape/TapeDrawer.stories.tsx`:
+
+```tsx
+import * as React from 'react'
+import { create } from '@bufbuild/protobuf'
+
+import { AuctionSummarySchema } from '@/lib/sdk'
+
+import { TapeDrawer } from './TapeDrawer'
+
+const sample = create(AuctionSummarySchema, {
+  auctionId: '0xa1b2c3-1042',
+  pair: 'ETH/USDC',
+  clearingPrice: '2418.10',
+  matchedVolume: '0.045300',
+  matchCount: 3,
+  timestampUnix: 1_700_000_000n,
+})
+
+export const Open = () => {
+  const [auction, setAuction] = React.useState<typeof sample | null>(sample)
+  return (
+    <div className="min-h-screen bg-brand-bg p-8">
+      <button
+        type="button"
+        onClick={() => setAuction(sample)}
+        className="bg-brand-accent px-4 py-2 font-mono text-label-lg uppercase text-brand-on-accent"
+      >
+        [ OPEN DRAWER ]
+      </button>
+      <TapeDrawer auction={auction} onClose={() => setAuction(null)} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape/front
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git add front/components/trade/tape/TapeDrawer.tsx front/components/trade/tape/TapeDrawer.stories.tsx
+git commit -m "[F1.7] Add TapeDrawer right-anchored Radix panel"
+```
+
+---
+
+## Task 10: Tape container + Ladle story + barrel export
+
+**Files:**
+- Create: `front/components/trade/tape/Tape.tsx`
+- Create: `front/components/trade/tape/Tape.stories.tsx`
+- Modify: `front/components/trade/tape/index.ts`
+
+- [ ] **Step 1: Implement `Tape`**
+
+Create `front/components/trade/tape/Tape.tsx`:
+
+```tsx
+'use client'
+
+import * as React from 'react'
+
+import type { AuctionSummary } from '@/lib/sdk'
+
+import { Countdown } from './Countdown'
+import { TapeDrawer } from './TapeDrawer'
+import { TapeRow } from './TapeRow'
+import { useAuctionHistory } from './useAuctionHistory'
+import { useNow } from './useNow'
+
+export interface TapeProps {
+  limit?: number
+}
+
+export function Tape({ limit }: TapeProps = {}): JSX.Element {
+  const auctions = useAuctionHistory({ limit })
+  const nowSeconds = useNow()
+  const [selectedId, setSelectedId] = React.useState<string | null>(null)
+
+  const selected = React.useMemo<AuctionSummary | null>(() => {
+    if (selectedId === null) return null
+    return auctions.find((a) => a.auctionId === selectedId) ?? null
+  }, [auctions, selectedId])
+
+  const latestUnix: bigint | null = auctions.length > 0 ? auctions[0].timestampUnix : null
+
+  return (
+    <div className="flex h-full min-h-[200px] flex-col">
+      <Countdown latestAuctionUnixSeconds={latestUnix} nowUnixSeconds={nowSeconds} />
+      <TableHeader />
+      {auctions.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <ol aria-live="polite" aria-atomic="false" className="flex-1 overflow-y-auto">
+          {auctions.map((a) => (
+            <TapeRow
+              key={a.auctionId}
+              auction={a}
+              nowUnixSeconds={nowSeconds}
+              onSelect={setSelectedId}
+            />
+          ))}
+        </ol>
+      )}
+      <TapeDrawer auction={selected} onClose={() => setSelectedId(null)} />
+    </div>
+  )
+}
+
+function TableHeader(): JSX.Element {
+  return (
+    <div className="grid grid-cols-[3rem_minmax(0,1fr)_minmax(0,1fr)_2rem] gap-3 border-b border-brand-border bg-brand-surface px-4 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+      <span>TIME</span>
+      <span className="text-right">PRICE</span>
+      <span className="text-right">VOLUME</span>
+      <span className="text-right">MATCH</span>
+    </div>
+  )
+}
+
+function EmptyState(): JSX.Element {
+  return (
+    <div className="flex flex-1 items-center justify-center font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+      [ NO AUCTIONS YET ]
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Update the barrel**
+
+Overwrite `front/components/trade/tape/index.ts`:
+
+```ts
+// Public surface for the auction tape panel (F1.7 / issue #74).
+// Consumers import { Tape } and mount it where the panel belongs in
+// the trading shell.
+export { Tape } from './Tape'
+export type { TapeProps } from './Tape'
+```
+
+- [ ] **Step 3: Ladle story driving the full panel with a live mock store**
+
+Create `front/components/trade/tape/Tape.stories.tsx`:
+
+```tsx
+import * as React from 'react'
+
+import { mockStore } from '@/lib/mock-store'
+
+import { Tape } from './Tape'
+
+/**
+ * Renders the live tape against the singleton mock store, starting and
+ * stopping its tick loop on mount/unmount. Reload the story to reseed.
+ */
+export const Live = () => {
+  React.useEffect(() => {
+    mockStore.getState().start({ perturbMs: 1000, auctionMs: 5000 })
+    return () => mockStore.getState().stop()
+  }, [])
+
+  return (
+    <div className="flex h-[600px] w-[360px] flex-col border border-brand-border bg-brand-bg">
+      <Tape />
+    </div>
+  )
+}
+
+export const SmallLimit = () => {
+  React.useEffect(() => {
+    mockStore.getState().start({ perturbMs: 1000, auctionMs: 3000 })
+    return () => mockStore.getState().stop()
+  }, [])
+
+  return (
+    <div className="flex h-[400px] w-[360px] flex-col border border-brand-border bg-brand-bg">
+      <Tape limit={5} />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape/front
+npx tsc --noEmit
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Run Ladle and confirm the stories load**
+
+```bash
+npx ladle serve --port 61000 &
+LADLE_PID=$!
+sleep 5
+curl -sf "http://localhost:61000/" > /dev/null && echo "Ladle up — open http://localhost:61000/ and visit Tape > Live"
+# Manual: load the URL, watch a new row arrive every ~5s, click a row, confirm the drawer slides in from the right.
+kill $LADLE_PID 2>/dev/null
+```
+
+Visual checklist (perform manually; record observations in the PR body):
+- [ ] Header reads `[ NEXT AUCTION IN NN ]` in lime, counting down each second.
+- [ ] New rows slide+fade in at the top every ~5s.
+- [ ] Older rows shift down without re-animating.
+- [ ] Clicking any row opens the right-side drawer with full details and `[ ETHERSCAN · PENDING ]`.
+- [ ] `Escape` closes the drawer; focus returns to the activated row.
+- [ ] DevTools → Rendering → toggle `prefers-reduced-motion: reduce` → reload → rows appear instantly, drawer transition is instant.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git add front/components/trade/tape/Tape.tsx front/components/trade/tape/Tape.stories.tsx front/components/trade/tape/index.ts
+git commit -m "[F1.7] Wire Tape container + barrel export"
+```
+
+---
+
+## Task 11: Browser verification via temporary Shell swap
+
+**Files (LOCAL ONLY — revert before next commit):**
+- Modify: `front/components/trade/Shell.tsx`
+
+This step proves the component composes inside the real shell. The edit is reverted before any further commit so the PR keeps zero diff in `Shell.tsx`.
+
+- [ ] **Step 1: Apply the local-only swap**
+
+Open `front/components/trade/Shell.tsx`. Find:
+
+```tsx
+function TapePanel() {
+  return <Panel label="AUCTION TAPE" icon={TapeGlyph} empty="NO AUCTIONS YET · F1.7" />
+}
+```
+
+Replace with (LOCAL ONLY — also add the two `import` lines at the top of `Shell.tsx`):
+
+```tsx
+import * as React from 'react'
+import { mockStore } from '@/lib/mock-store'
+import { Tape } from './tape'
+
+function TapePanel() {
+  React.useEffect(() => {
+    mockStore.getState().start({ perturbMs: 1000, auctionMs: 5000 })
+    return () => mockStore.getState().stop()
+  }, [])
+  return (
+    <div className="flex h-full flex-col">
+      <div className="flex h-9 items-center gap-3 border-b border-brand-border px-4">
+        <TapeGlyph className="text-brand-muted" />
+        <span className="font-mono text-label-md uppercase text-brand-muted">AUCTION TAPE</span>
+      </div>
+      <div className="flex-1">
+        <Tape />
+      </div>
+    </div>
+  )
+}
+```
+
+**This whole edit is a local-only diff — do not commit.** `React` is already imported as a side-effect via the `'use client'` directive's React 17+ JSX runtime, but explicitly importing it for `useEffect` is the safest path.
+
+- [ ] **Step 2: Run the dev server and verify in the browser**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape/front
+npm run dev
+```
+
+Then in Chrome / Firefox:
+1. Navigate to `http://localhost:3000/app/trade`.
+2. Confirm the right column shows the tape, with countdown header, table header, and rows arriving every ~5s.
+3. Click a row → drawer slides in from the right with the auction's details and `[ ETHERSCAN · PENDING ]`.
+4. ESC closes the drawer; focus returns to the row.
+5. Open DevTools → ⋮ → More tools → Rendering → set `prefers-reduced-motion` to `reduce`. Reload the page. Confirm:
+   - New rows appear without slide/fade animation.
+   - The drawer opens/closes instantly with no transform animation.
+   - The blinking pill / countdown text still updates (these are content updates, not motion).
+
+Document each ✅ in the PR body.
+
+- [ ] **Step 3: Stop the dev server**
+
+`Ctrl+C` in the terminal.
+
+- [ ] **Step 4: Revert the local Shell.tsx swap**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git checkout -- front/components/trade/Shell.tsx
+git status
+```
+
+Expected: `git status` shows no modifications to `Shell.tsx`. The only changes in the tree should be unstaged test/dev artifacts (if any). If you mounted the tick loop in a different file, revert that too. **No commit if `git status` is clean.**
+
+- [ ] **Step 5: Confirm the diff against `origin/main` only contains tape files and the spec**
+
+```bash
+git diff --stat origin/main...HEAD
+```
+
+Expected output lists only:
+- `docs/superpowers/specs/2026-05-17-f17-auction-tape-design.md`
+- `docs/superpowers/plans/2026-05-17-f17-auction-tape.md`
+- `front/components/trade/tape/*`
+
+No other path. If any other path appears, investigate and revert.
+
+---
+
+## Task 12: Full verification suite
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the project test suite**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape/front
+npm run test
+```
+
+Expected: all suites green, including the new `format.test.ts` and `useAuctionHistory.test.ts`.
+
+- [ ] **Step 2: Lint**
+
+```bash
+npm run lint
+```
+
+Expected: no errors. Warnings only if pre-existing.
+
+- [ ] **Step 3: Type-check via build (catches CSS module imports, JSX paths)**
+
+```bash
+npm run build
+```
+
+Expected: build completes; no TypeScript errors; no missing-module errors.
+
+- [ ] **Step 4: Rebase on `origin/main` and re-run the suite**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git fetch origin
+git rebase origin/main
+cd front
+npm install   # in case package.json was changed upstream
+npm run test
+npm run lint
+npm run build
+```
+
+Expected: all green. If conflicts surface outside `front/components/trade/tape/*`, stop and surface on the issue per `docs/PARALLEL-WORK.md`.
+
+---
+
+## Task 13: Push branch, open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+cd /home/mario/darkpool-wt/74-tape
+git push -u origin feat/issue-74-tape
+```
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --title "[F1.7] Auction tape (mock-backed)" --body "$(cat <<'EOF'
+Closes #74
+
+## Summary
+- New tape panel under \`front/components/trade/tape/\` reading the F1.2 mock store via \`useAuctionHistory\`.
+- \`<Countdown/>\` ticker-bar header owns the lime accent for this surface; row newness is signalled by a CSS-keyframe slide+fade gated by \`prefers-reduced-motion\`.
+- Per-row drawer (\`<TapeDrawer/>\`) shows full auction details plus a \`[ ETHERSCAN · PENDING ]\` placeholder for #I2.11.
+
+## Design references
+- Spec: \`docs/superpowers/specs/2026-05-17-f17-auction-tape-design.md\`
+- Plan: \`docs/superpowers/plans/2026-05-17-f17-auction-tape.md\`
+
+## Testing strategy (deviation from the spec)
+The project has no \`@testing-library/react\` / \`jsdom\`. Adding those would be out of scope. So:
+- \`format.test.ts\` — relative-time, full-timestamp, count, countdown.
+- \`useAuctionHistory.test.ts\` — pure selector.
+- React components — Ladle stories (\`*.stories.tsx\`) + manual browser verification through a temporary \`Shell.tsx\` swap (reverted before commit).
+
+## Out of scope / follow-ups
+- Wiring \`<Tape/>\` into \`Shell.tsx\`. That file belongs to F1.1; one-line integration is a follow-up.
+- Phase 2 REST swap (#94) — \`useAuctionHistory.pollMs\` is the documented seam.
+- Streaming upgrade (#95).
+- Real Etherscan link (#I2.11 / #100).
+
+## Verified manually
+- [x] Rows arrive every ~5s; head row animates in.
+- [x] Click row → drawer opens with details and ETHERSCAN placeholder.
+- [x] ESC closes drawer; focus returns to row.
+- [x] \`prefers-reduced-motion: reduce\` → animations skipped; instant appearance.
+EOF
+)"
+```
+
+- [ ] **Step 3: Return the PR URL**
+
+`gh pr view --json url --jq .url` and surface the URL.
+
+---
+
+## Spec coverage self-check
+
+| Spec requirement                                                | Task |
+|-----------------------------------------------------------------|------|
+| `useAuctionHistory(limit=50)` reading the mock store            | 4    |
+| Polling-every-2s seam documented for Phase 2                    | 4    |
+| Vertical strip with relative time / clearing price / matched volume / match count | 7, 10 |
+| New entries animate in (slide + fade)                           | 6, 7 |
+| Respects `prefers-reduced-motion`                               | 6, 11 |
+| Row select opens drawer with Etherscan placeholder              | 9, 10 |
+| Lime accent reserved for countdown header                       | 8    |
+| Tabular numbers, decimals stay strings                          | 7 (via `NumericText`) |
+| Tests for formatters and selector                               | 2, 3, 4 |
+| Ladle stories for visual review                                 | 7, 8, 9, 10 |
+| Verification gate (lint / build / test / browser)               | 11, 12 |
+| One PR, `Closes #74` body, no Claude co-author                  | 13   |
+
+Every spec section maps to a task. No placeholders, no TODOs.

--- a/docs/superpowers/specs/2026-05-17-f17-auction-tape-design.md
+++ b/docs/superpowers/specs/2026-05-17-f17-auction-tape-design.md
@@ -1,0 +1,372 @@
+# F1.7 Auction tape (mock-backed) — design
+
+- **Issue:** [#74](https://github.com/Dnreikronos/DarkPool-Exchange/issues/74)
+- **Epic:** [#62](https://github.com/Dnreikronos/DarkPool-Exchange/issues/62) Trading App MVP
+- **Wave:** 4 (depends on #69 mock store; parallel with #71 balances and #73 orderbook)
+- **Branch:** `feat/issue-74-tape`
+- **Worktree:** `../darkpool-wt/74-tape`
+
+## 1 · Purpose
+
+Render a vertical strip of recently-settled auctions so the user can
+*see* the protocol's batch cadence. The tape is the surface that makes
+the dark pool feel alive: rows arrive on the auction tick, prove the
+matching engine is producing clearing prices, and give intuition for
+the 5-second batch rhythm.
+
+In Phase 1 the tape reads from the in-memory mock store seeded in
+#69. Phase 2 swaps the data source to REST (#94 / #95) without
+touching any consumer call-site.
+
+## 2 · Scope
+
+### In scope
+- `<Tape/>` container component plus subcomponents under
+  `front/components/trade/tape/`.
+- `useAuctionHistory(limit)` hook reading the mock store via a
+  selector.
+- Per-row drawer with auction details and a placeholder Etherscan
+  slot (filled by #I2.11).
+- CSS-only entrance animation, gated by `prefers-reduced-motion`.
+- Tabular formatting helpers (relative time, price, volume, count).
+- Tests (Vitest + Testing Library) covering formatters, the hook,
+  the tape, and the drawer.
+- No edits outside `front/components/trade/tape/`. The SDK index
+  stays untouched unless implementation reveals a hard need, in
+  which case a single additive export line is the only allowed
+  exception per the issue's file scope.
+
+### Out of scope
+- Wiring the new component into `front/components/trade/Shell.tsx`.
+  Shell.tsx belongs to F1.1; this PR ships the tape as an importable
+  unit and the integration is a follow-up.
+- The auction countdown's underlying tick *source*. The mock store
+  already runs `runAuction()` on a 5s interval; the countdown
+  derives its display from `recentAuctions[0].timestampUnix` + a
+  client-side 1s tick. No store change.
+- Streaming (`StreamAuctions`) — that's #95.
+- Virtualization. 50 rows × ~28px ≈ 1.4kpx; well below the budget
+  where virtualization pays off. Revisit when #94 ships REST.
+
+### Non-goals
+- Filtering, sorting, search.
+- Per-row action menu (cancel, replicate). My orders panel (#77)
+  owns trader-side actions.
+- Cross-tab notifications when a fill lands while the user is
+  elsewhere. That's a follow-up tied to #77/#78.
+
+## 3 · Acceptance criteria (from issue #74)
+
+- [x] `useAuctionHistory(limit=50)` on mount, polling every 2s.
+- [x] Vertical strip showing relative time, clearing price,
+      matched volume, match count.
+- [x] New entries animate in (slide + fade); respects
+      `prefers-reduced-motion`.
+- [x] Selecting an auction opens a drawer with a placeholder for
+      the Etherscan link.
+
+Polling is satisfied in Phase 1 by subscribing to the Zustand mock
+store, which pushes on every state change. The hook's signature
+accepts `pollMs` so the Phase 2 REST implementation (#94) can wire
+`setInterval` against `client.getAuctionHistory()` without changing
+any consumer. The default is `2000`.
+
+## 4 · Architecture
+
+```
+                    ┌──────────────────────────────────┐
+                    │  mockStore (Zustand singleton)   │
+                    │  recentAuctions: AuctionSummary  │
+                    │  runAuction() every 5s           │
+                    └──────────────┬───────────────────┘
+                                   │ subscribe
+                                   ▼
+              ┌─────────────────────────────────────────┐
+              │ useAuctionHistory(limit=50, pollMs=2000)│
+              │  selector: recentAuctions.slice(0,limit)│
+              │  returns: AuctionSummary[]              │
+              └──────────────┬──────────────────────────┘
+                             │
+                             ▼
+        ┌───────────────────────────────────────────┐
+        │              <Tape/>                      │
+        │  ┌────────────────────────────────────┐   │
+        │  │ <Countdown/> · lime · ticker-bar   │   │
+        │  ├────────────────────────────────────┤   │
+        │  │ <ol> ▼ aria-live="polite"          │   │
+        │  │   <TapeRow/> · animate on mount    │   │
+        │  │   <TapeRow/>                       │   │
+        │  │   ...                              │   │
+        │  └────────────────────────────────────┘   │
+        └──────────────────┬────────────────────────┘
+                           │ onSelect(auction)
+                           ▼
+              ┌──────────────────────────┐
+              │ <TapeDrawer/> · Radix    │
+              │  full details +          │
+              │  [ ETHERSCAN · PENDING ] │
+              └──────────────────────────┘
+```
+
+### Data flow
+
+1. `mockStore` (singleton from #69) holds `recentAuctions:
+   AuctionSummary[]`, newest-first, capped at 200.
+2. `useAuctionHistory(limit)` subscribes via the existing
+   `useMockStore` adapter (which delegates to
+   `useSyncExternalStore`). The selector returns
+   `state.recentAuctions` directly (stable reference unless
+   `runAuction()` ran), and slices to `limit` inside `useMemo` keyed
+   on the array reference and the head's `auctionId`.
+3. `<Tape/>` consumes the hook, renders the header, and maps the
+   array to `<TapeRow/>` elements keyed by `auctionId`.
+4. Each `<TapeRow/>` is a `<button>` that calls the parent's
+   `onSelect`. The parent owns the selected-auction state and the
+   drawer's open/closed state.
+5. `<TapeDrawer/>` is a `Radix Dialog` mounted as a portal; visible
+   when `selectedAuctionId` is set; closing nulls it.
+
+### Render budget
+
+- Selector returns the same reference for 4 of every 5 store
+  updates (1s perturb only mutates the orderbook). The slice memo
+  catches the remaining no-op renders.
+- Rows are pure: `React.memo(TapeRow)` keyed by `auctionId` +
+  `nowSecond` (passed as a prop). A new auction re-renders only
+  the head row and the freshly-mounted one; the rest get a single
+  prop-comparison short-circuit.
+- The 1s `useNow()` tick triggers a re-render of the rows because
+  relative-time labels update each second. This is the dominant
+  cost. Budget: 50 rows × ~3 spans = 150 lightweight text-node
+  updates per second. Acceptable; React handles it on the order of
+  sub-millisecond.
+
+## 5 · File layout
+
+```
+front/components/trade/tape/
+├── Tape.tsx                  ← 'use client'; container
+├── Countdown.tsx             ← ticker-bar header, lime accent
+├── TapeRow.tsx               ← memoized row, opens drawer
+├── TapeDrawer.tsx            ← Radix Dialog right-side
+├── useAuctionHistory.ts      ← store selector hook
+├── useNow.ts                 ← shared 1s tick
+├── format.ts                 ← time/price/volume/count formatters
+├── tape.module.css           ← @keyframes tape-enter + reduce-motion gate
+├── index.ts                  ← barrel: { Tape }
+├── format.test.ts
+├── useAuctionHistory.test.ts
+├── Countdown.test.tsx
+└── Tape.test.tsx             ← integration: rows + animation + drawer
+```
+
+**File scope guard:** nothing outside `front/components/trade/tape/`
+gets modified. `front/lib/sdk/index.ts` likely needs no append; if
+during implementation the Phase 2 swap surface demands an export,
+that single append is the only allowed file outside the directory.
+
+## 6 · Component contracts
+
+### `useAuctionHistory(opts?)`
+```ts
+interface UseAuctionHistoryOptions {
+  /** Max rows to surface. Default 50. */
+  limit?: number
+  /**
+   * Phase 2 seam. In Phase 1 the store push beats any polling
+   * interval; this is documented and accepted as a no-op for the
+   * mock backend. Default 2000.
+   */
+  pollMs?: number
+}
+
+function useAuctionHistory(opts?: UseAuctionHistoryOptions): AuctionSummary[]
+```
+- Reads from the global mock store via `useMockStore`.
+- Returns a stable reference across no-op updates.
+- Strict-mode safe; no side effects.
+
+### `<Tape/>`
+- Props: none. Self-contained: pulls data + state internally.
+- Renders `<Countdown/>` followed by `<ol>` of rows.
+- Owns the `selectedAuctionId` state and the drawer's open flag.
+
+### `<Countdown/>`
+- Props: `latestTimestampMs: number | null`, `intervalMs: number`
+  (default 5000).
+- Computes `secondsToNext = max(0, ceil((intervalMs - (now -
+  latestTimestampMs)) / 1000))`. Shows `[ NEXT AUCTION IN NN ]` in
+  `label-lg` tracked uppercase, `tertiary` (lime).
+- When `latestTimestampMs` is null (no auctions yet), shows
+  `[ WAITING FOR FIRST AUCTION ]` in `secondary`.
+
+### `<TapeRow/>`
+- Props: `auction: AuctionSummary`, `nowMs: number`, `onSelect:
+  (auctionId: string) => void`, `isNewest: boolean`.
+- Renders a 4-col grid: `time price volume count`.
+- `time`: `formatRelativeTime` using `nowMs - timestampMs`.
+- `price` and `volume`: `formatPrice` / `formatVolume` with
+  `tabular-nums`, `body-sm` mono, `primary` color.
+- `count`: `formatCount(matchCount)`, `secondary` color.
+- Click / Enter / Space: `onSelect(auction.auctionId)`.
+- New rows mount with className `styles.enter`; the CSS keyframe
+  runs once on mount, then completes.
+
+### `<TapeDrawer/>`
+- Props: `auction: AuctionSummary | null`, `onClose: () => void`.
+- Rendered always; controlled `open` via Radix `Dialog`. When
+  `auction === null`, `open=false`.
+- Sliding panel from the right (Radix transitions are CSS-driven;
+  we override animations to honor reduced-motion).
+- Shows: pair, auction id, full timestamp
+  (`HH:MM:SS · DD MMM YYYY`), clearing price, matched volume,
+  match count, and `[ ETHERSCAN · PENDING ]` static tag with a
+  comment `// filled by I2.11`.
+
+## 7 · Visual / token alignment
+
+Every decision below maps to a token from `DESIGN.md`. No new
+colors, no new radii, no shadows beyond the spec's allowed glow
+(which we don't use here).
+
+| Surface              | Token / utility                                      |
+|----------------------|------------------------------------------------------|
+| Tape header          | `ticker-bar` styling: `bg-brand-bg` (`neutral`), 36px, top+bottom `outline` borders |
+| Countdown text       | `tertiary` (`#D4FF00`), `label-lg`                  |
+| Column headers       | `label-md` uppercase tracked, `on-surface-variant`  |
+| Row text (primary)   | `primary` (#FFFFFF), `body-sm`, `tabular-nums`       |
+| Row text (meta)      | `on-surface-variant`, `body-sm`, `tabular-nums`      |
+| Row hover            | `surface-container` background (per `table-row-hover`)|
+| Row separator        | 1px `outline` bottom border                           |
+| Drawer surface       | `surface-container`, 32px padding, 1px `outline` left border |
+| Drawer backdrop      | `rgba(6,6,10,0.85)`                                   |
+| Etherscan placeholder| `tag-bracketed-static`                                |
+
+**Lime budget:** the countdown owns the accent for this surface.
+No other element in the tape uses `tertiary`. Newness is signalled
+by motion only.
+
+**Timestamp format:** relative — `5s`, `47s`, `1m`, `4m`, `1h`,
+`23h`, `2d`. Granularity is intentionally coarse: the design
+treats time as a felt rhythm, not a precise reading. Full
+`HH:MM:SS · DD MMM YYYY` lives in the drawer.
+
+**Price format:** thousands separator above 10,000 (per
+DESIGN-INSPIRATIONS / TradingView convention); 2 decimal places
+(USDC quote). Implemented with `decimal.js` toFixed + a
+`Intl.NumberFormat`-driven thousands group. No coercion to JS
+number.
+
+**Volume format:** 6 decimal places (WETH base), no thousands
+separator (volumes < 1 dominate). Right-aligned.
+
+**Count format:** integer, right-aligned, no decimals.
+
+## 8 · Motion contract
+
+### Animation
+- New row mounts with class `styles.enter` applied unconditionally.
+- CSS:
+  ```css
+  @media (prefers-reduced-motion: no-preference) {
+    .enter {
+      animation: tape-enter 240ms cubic-bezier(0.16, 1, 0.3, 1) both;
+    }
+  }
+  @keyframes tape-enter {
+    from { opacity: 0; transform: translateY(-6px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  ```
+- Older rows do not re-animate because React's reconciliation keys
+  by `auctionId`; existing rows just shift down (the layout shift
+  is the secondary motion cue).
+- Reduced motion: animation rule omitted; rows appear instantly.
+
+### Drawer
+- Radix `Dialog.Content` with `data-state` transitions. We override:
+  ```css
+  @media (prefers-reduced-motion: no-preference) {
+    [data-state='open']  { animation: drawer-in  180ms ease-out; }
+    [data-state='closed']{ animation: drawer-out 140ms ease-in;  }
+  }
+  ```
+- Reduced motion: no animation; the drawer appears/disappears
+  instantly.
+
+## 9 · Accessibility
+
+- `<ol>` with `<li>` per auction. List semantics preserved.
+- `aria-live="polite"` on the `<ol>`, `aria-atomic="false"`.
+  Screen readers announce newly-inserted auctions without
+  re-announcing the whole list.
+- Each row is a `<button type="button">` so it is keyboard-
+  reachable. `Enter` and `Space` trigger `onSelect` natively.
+- Visible focus ring: 1px `tertiary` outline at `outline-offset:
+  2px`, matching DESIGN.md's custom focus pattern.
+- Drawer: Radix provides focus trap, focus return, ESC-to-close,
+  and `aria-labelledby`/`aria-describedby`. We supply a visible
+  close button labelled `[ CLOSE ]`.
+- Color contrast: row primary text on the canvas measures ≥ 15:1.
+  The secondary metadata measures ~3:1 — within DESIGN.md's
+  "ambient labels and decorative metadata; not for primary body
+  copy" rule.
+
+## 10 · Testing strategy
+
+| Suite                  | What it proves                                           |
+|------------------------|----------------------------------------------------------|
+| `format.test.ts`       | `formatRelativeTime` ladder (s→m→h→d); price thousands separator above 10k; volume to 6dp; count integer. Decimal-string inputs stay strings (no Number coercion). |
+| `useAuctionHistory.test.ts` | Returns latest N; stable reference when store doesn't change `recentAuctions`; updates when `runAuction()` fires; respects custom `limit`. |
+| `Countdown.test.tsx`   | Computes seconds-to-next from a fixed `latestTimestampMs` and a mocked `useNow`; shows `[ WAITING ]` when no auctions; never goes negative. |
+| `Tape.test.tsx`        | Renders all rows from a seeded mock store; freshly mounted rows receive the `enter` class (existing rows do not re-receive it after a re-render); clicking a row opens the drawer with that auction's details; ESC closes; reduced-motion test asserts the animation class is still applied (CSS does the gating) and the keyframe rule is wrapped in a `(prefers-reduced-motion: no-preference)` media query. |
+
+All tests run under Vitest. The mock store is reset between tests
+via `__resetMockStoreSingletonForTests` (already exposed by #69).
+
+## 11 · Verification before PR
+
+Per `superpowers:verification-before-completion`:
+
+1. `npm run test` — all tape suites green.
+2. `npm run lint` — clean.
+3. `npm run build` — clean.
+4. Manual browser pass:
+   - Temporarily replace `TapePanel()` body in
+     `Shell.tsx` with `<Tape/>` for local verification only.
+   - `npm run dev`, navigate to `/app/trade`.
+   - Observe a new row entering every ~5s; animation is visible.
+   - Toggle DevTools → Rendering → `prefers-reduced-motion:
+     reduce`. Reload. Confirm rows appear instantly; no slide-fade.
+   - Click a row; drawer opens, ESC closes; focus returns to the
+     row.
+   - Revert the `Shell.tsx` change before committing. Confirm
+     `git status` shows only `front/components/trade/tape/` paths.
+
+Acceptance: every checked item above + AC items from §3.
+
+## 12 · Risks & mitigations
+
+| Risk                                                  | Mitigation |
+|-------------------------------------------------------|------------|
+| `useNow` 1Hz tick re-renders all rows                 | `React.memo(TapeRow)` with shallow prop comparison. Time string is computed by the parent and passed as a prop, so memoization is meaningful. |
+| Selector returns a new array reference on every store update, defeating render skip | Cache the slice with `useMemo` keyed on `recentAuctions` reference + head `auctionId`. Add unit test asserting reference equality across no-op pushes. |
+| Animation re-runs on every state change because React reuses the same DOM node | Animation is keyframe-on-mount; React only mounts the node once per `auctionId`. Subsequent layout shifts don't retrigger the keyframe. |
+| Radix Dialog's default animation conflicts with reduced-motion | Override with our own CSS gated by the media query. Test asserts `data-state='open'` styles don't contain an animation rule when reduced-motion is on (via `window.matchMedia` mock). |
+| Lime in countdown competes with order-entry button when entry is focused | Out of scope for this PR. DESIGN-INSPIRATIONS already documents the migration: when the order-entry form (#76) is in focused state it pulls the accent. We accept it as a follow-up. |
+
+## 13 · Follow-ups (out of this PR)
+
+- Wire `<Tape/>` into `front/components/trade/Shell.tsx`. One-line
+  change; file is off-limits to this PR per `docs/PARALLEL-WORK.md`
+  scope. The PR body flags this as the only integration step.
+- Phase 2 swap (#94): replace `useAuctionHistory`'s store
+  subscription with `client.getAuctionHistory()` polling. The
+  hook signature already exposes `pollMs` so consumers do not
+  change.
+- Streaming upgrade (#95): replace polling with the `StreamAuctions`
+  RPC. The hook becomes a thin Connect-RPC stream subscriber; same
+  return type.
+- Etherscan link (`I2.11` / #100): replace the static placeholder
+  tag with a real link computed from the on-chain settled-batch
+  event.

--- a/front/components/trade/tape/Countdown.stories.tsx
+++ b/front/components/trade/tape/Countdown.stories.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+
+import { Countdown } from './Countdown'
+
+const NOW = 1_700_000_000
+
+export const Waiting = () => (
+  <div className="w-[320px]">
+    <Countdown latestAuctionUnixSeconds={null} nowUnixSeconds={NOW} />
+  </div>
+)
+
+export const JustAfterAuction = () => (
+  <div className="w-[320px]">
+    <Countdown latestAuctionUnixSeconds={BigInt(NOW)} nowUnixSeconds={NOW} />
+  </div>
+)
+
+export const HalfwayToNext = () => (
+  <div className="w-[320px]">
+    <Countdown latestAuctionUnixSeconds={BigInt(NOW - 2)} nowUnixSeconds={NOW} />
+  </div>
+)
+
+export const OneSecondLeft = () => (
+  <div className="w-[320px]">
+    <Countdown latestAuctionUnixSeconds={BigInt(NOW - 4)} nowUnixSeconds={NOW} />
+  </div>
+)

--- a/front/components/trade/tape/Countdown.tsx
+++ b/front/components/trade/tape/Countdown.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import * as React from 'react'
+
+import { secondsToNextAuction } from './format'
+
+export interface CountdownProps {
+  latestAuctionUnixSeconds: bigint | null
+  nowUnixSeconds: number
+  /** Cadence of the auction tick. Mock store defaults to 5s. */
+  intervalSeconds?: number
+}
+
+const DEFAULT_INTERVAL_SECONDS = 5
+
+export function Countdown({
+  latestAuctionUnixSeconds,
+  nowUnixSeconds,
+  intervalSeconds = DEFAULT_INTERVAL_SECONDS,
+}: CountdownProps): JSX.Element {
+  const waiting = latestAuctionUnixSeconds === null
+
+  const label = waiting
+    ? '[ WAITING FOR FIRST AUCTION ]'
+    : `[ NEXT AUCTION IN ${pad2(
+        secondsToNextAuction(latestAuctionUnixSeconds, nowUnixSeconds, intervalSeconds)
+      )} ]`
+
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      className={`flex h-9 items-center justify-center border-b border-brand-border bg-brand-bg px-4 font-mono text-label-lg uppercase tracking-label ${
+        waiting ? 'text-brand-muted' : 'text-brand-accent'
+      }`}
+    >
+      {label}
+    </div>
+  )
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`
+}

--- a/front/components/trade/tape/Tape.stories.tsx
+++ b/front/components/trade/tape/Tape.stories.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+
+import { mockStore } from '@/lib/mock-store'
+
+import { Tape } from './Tape'
+
+/**
+ * Renders the live tape against the singleton mock store, starting and
+ * stopping its tick loop on mount/unmount. Reload the story to reseed.
+ */
+export const Live = () => {
+  React.useEffect(() => {
+    mockStore.getState().start({ perturbMs: 1000, auctionMs: 5000 })
+    return () => mockStore.getState().stop()
+  }, [])
+
+  return (
+    <div className="flex h-[600px] w-[360px] flex-col border border-brand-border bg-brand-bg">
+      <Tape />
+    </div>
+  )
+}
+
+export const SmallLimit = () => {
+  React.useEffect(() => {
+    mockStore.getState().start({ perturbMs: 1000, auctionMs: 3000 })
+    return () => mockStore.getState().stop()
+  }, [])
+
+  return (
+    <div className="flex h-[400px] w-[360px] flex-col border border-brand-border bg-brand-bg">
+      <Tape limit={5} />
+    </div>
+  )
+}

--- a/front/components/trade/tape/Tape.tsx
+++ b/front/components/trade/tape/Tape.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import * as React from 'react'
+
+import type { AuctionSummary } from '@/lib/sdk'
+
+import { Countdown } from './Countdown'
+import { TapeDrawer } from './TapeDrawer'
+import { TapeRow } from './TapeRow'
+import { useAuctionHistory } from './useAuctionHistory'
+import { useNow } from './useNow'
+
+export interface TapeProps {
+  limit?: number
+}
+
+export function Tape({ limit }: TapeProps = {}): JSX.Element {
+  const auctions = useAuctionHistory({ limit })
+  const nowSeconds = useNow()
+  const [selectedId, setSelectedId] = React.useState<string | null>(null)
+
+  const selected = React.useMemo<AuctionSummary | null>(() => {
+    if (selectedId === null) return null
+    return auctions.find((a) => a.auctionId === selectedId) ?? null
+  }, [auctions, selectedId])
+
+  const latestUnix: bigint | null = auctions.length > 0 ? auctions[0].timestampUnix : null
+
+  return (
+    <div className="flex h-full min-h-[200px] flex-col">
+      <Countdown latestAuctionUnixSeconds={latestUnix} nowUnixSeconds={nowSeconds} />
+      <TableHeader />
+      {auctions.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <ol aria-live="polite" aria-atomic="false" className="flex-1 overflow-y-auto">
+          {auctions.map((a) => (
+            <TapeRow
+              key={a.auctionId}
+              auction={a}
+              nowUnixSeconds={nowSeconds}
+              onSelect={setSelectedId}
+            />
+          ))}
+        </ol>
+      )}
+      <TapeDrawer auction={selected} onClose={() => setSelectedId(null)} />
+    </div>
+  )
+}
+
+function TableHeader(): JSX.Element {
+  return (
+    <div className="grid grid-cols-[3rem_minmax(0,1fr)_minmax(0,1fr)_2rem] gap-3 border-b border-brand-border bg-brand-surface px-4 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+      <span>TIME</span>
+      <span className="text-right">PRICE</span>
+      <span className="text-right">VOLUME</span>
+      <span className="text-right">MATCH</span>
+    </div>
+  )
+}
+
+function EmptyState(): JSX.Element {
+  return (
+    <div className="flex flex-1 items-center justify-center font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+      [ NO AUCTIONS YET ]
+    </div>
+  )
+}

--- a/front/components/trade/tape/TapeDrawer.stories.tsx
+++ b/front/components/trade/tape/TapeDrawer.stories.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react'
+import { create } from '@bufbuild/protobuf'
+
+import { AuctionSummarySchema } from '@/lib/sdk'
+
+import { TapeDrawer } from './TapeDrawer'
+
+const sample = create(AuctionSummarySchema, {
+  auctionId: '0xa1b2c3-1042',
+  pair: 'ETH/USDC',
+  clearingPrice: '2418.10',
+  matchedVolume: '0.045300',
+  matchCount: 3,
+  timestampUnix: 1_700_000_000n,
+})
+
+export const Open = () => {
+  const [auction, setAuction] = React.useState<typeof sample | null>(sample)
+  return (
+    <div className="min-h-screen bg-brand-bg p-8">
+      <button
+        type="button"
+        onClick={() => setAuction(sample)}
+        className="bg-brand-accent px-4 py-2 font-mono text-label-lg uppercase text-brand-on-accent"
+      >
+        [ OPEN DRAWER ]
+      </button>
+      <TapeDrawer auction={auction} onClose={() => setAuction(null)} />
+    </div>
+  )
+}

--- a/front/components/trade/tape/TapeDrawer.tsx
+++ b/front/components/trade/tape/TapeDrawer.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import * as React from 'react'
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import type { AuctionSummary } from '@/lib/sdk'
+
+import { formatFullTimestamp } from './format'
+import styles from './tape.module.css'
+
+export interface TapeDrawerProps {
+  auction: AuctionSummary | null
+  onClose: () => void
+}
+
+export function TapeDrawer({ auction, onClose }: TapeDrawerProps): JSX.Element {
+  const open = auction !== null
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose()
+      }}
+    >
+      <DialogContent
+        className={`${styles.drawer} fixed left-auto right-0 top-0 h-screen w-full max-w-[420px] translate-x-0 translate-y-0 border-l border-brand-border bg-brand-surface p-8`}
+        aria-describedby={undefined}
+      >
+        {auction && (
+          <>
+            <DialogTitle className="font-display text-display-sm uppercase">
+              [ AUCTION {auction.auctionId} ]
+            </DialogTitle>
+            <DialogDescription className="mt-2 font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+              {auction.pair}
+            </DialogDescription>
+
+            <dl className="mt-8 grid grid-cols-[max-content_minmax(0,1fr)] gap-y-3 font-mono text-body-sm">
+              <Row label="TIMESTAMP" value={formatFullTimestamp(auction.timestampUnix)} mono />
+              <Row label="CLEARING" value={auction.clearingPrice} mono />
+              <Row label="VOLUME" value={auction.matchedVolume} mono />
+              <Row label="MATCHES" value={String(auction.matchCount)} mono />
+            </dl>
+
+            <div className="mt-10 flex flex-col gap-2">
+              <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+                ETHERSCAN
+              </span>
+              <span
+                aria-label="Etherscan link pending Phase 2 integration"
+                className="font-mono text-label-lg uppercase tracking-label text-brand-muted"
+              >
+                [ ETHERSCAN · PENDING ]
+              </span>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }): JSX.Element {
+  return (
+    <>
+      <dt className="pr-4 font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+        {label}
+      </dt>
+      <dd className={`${mono ? 'tabular-nums' : ''} text-brand-fg`}>{value}</dd>
+    </>
+  )
+}

--- a/front/components/trade/tape/TapeDrawer.tsx
+++ b/front/components/trade/tape/TapeDrawer.tsx
@@ -2,12 +2,7 @@
 
 import * as React from 'react'
 
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from '@/components/ui/dialog'
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog'
 import type { AuctionSummary } from '@/lib/sdk'
 
 import { formatFullTimestamp } from './format'
@@ -29,7 +24,6 @@ export function TapeDrawer({ auction, onClose }: TapeDrawerProps): JSX.Element {
     >
       <DialogContent
         className={`${styles.drawer} fixed left-auto right-0 top-0 h-screen w-full max-w-[420px] translate-x-0 translate-y-0 border-l border-brand-border bg-brand-surface p-8`}
-        aria-describedby={undefined}
       >
         {auction && (
           <>
@@ -65,7 +59,15 @@ export function TapeDrawer({ auction, onClose }: TapeDrawerProps): JSX.Element {
   )
 }
 
-function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }): JSX.Element {
+function Row({
+  label,
+  value,
+  mono,
+}: {
+  label: string
+  value: string
+  mono?: boolean
+}): JSX.Element {
   return (
     <>
       <dt className="pr-4 font-mono text-label-md uppercase tracking-labelWide text-brand-muted">

--- a/front/components/trade/tape/TapeRow.stories.tsx
+++ b/front/components/trade/tape/TapeRow.stories.tsx
@@ -7,13 +7,15 @@ import { TapeRow } from './TapeRow'
 
 const NOW = 1_700_000_120
 
-function mkAuction(opts: Partial<{
-  auctionId: string
-  clearingPrice: string
-  matchedVolume: string
-  matchCount: number
-  ageSeconds: number
-}> = {}) {
+function mkAuction(
+  opts: Partial<{
+    auctionId: string
+    clearingPrice: string
+    matchedVolume: string
+    matchCount: number
+    ageSeconds: number
+  }> = {}
+) {
   return create(AuctionSummarySchema, {
     auctionId: opts.auctionId ?? 'a-001',
     pair: 'ETH/USDC',
@@ -35,12 +37,24 @@ export const SingleRow = () => (
 export const ListOfRows = () => (
   <ol className="w-[320px] border border-brand-border bg-brand-bg">
     <TapeRow
-      auction={mkAuction({ auctionId: 'a-100', ageSeconds: 2, clearingPrice: '2419.85', matchedVolume: '0.0121', matchCount: 1 })}
+      auction={mkAuction({
+        auctionId: 'a-100',
+        ageSeconds: 2,
+        clearingPrice: '2419.85',
+        matchedVolume: '0.0121',
+        matchCount: 1,
+      })}
       nowUnixSeconds={NOW}
       onSelect={noop}
     />
     <TapeRow
-      auction={mkAuction({ auctionId: 'a-099', ageSeconds: 7, clearingPrice: '12345.6789', matchedVolume: '0.089', matchCount: 5 })}
+      auction={mkAuction({
+        auctionId: 'a-099',
+        ageSeconds: 7,
+        clearingPrice: '12345.6789',
+        matchedVolume: '0.089',
+        matchCount: 5,
+      })}
       nowUnixSeconds={NOW}
       onSelect={noop}
     />
@@ -50,7 +64,13 @@ export const ListOfRows = () => (
       onSelect={noop}
     />
     <TapeRow
-      auction={mkAuction({ auctionId: 'a-097', ageSeconds: 65, clearingPrice: '2417.42', matchedVolume: '0.0023', matchCount: 1 })}
+      auction={mkAuction({
+        auctionId: 'a-097',
+        ageSeconds: 65,
+        clearingPrice: '2417.42',
+        matchedVolume: '0.0023',
+        matchCount: 1,
+      })}
       nowUnixSeconds={NOW}
       onSelect={noop}
     />

--- a/front/components/trade/tape/TapeRow.stories.tsx
+++ b/front/components/trade/tape/TapeRow.stories.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import { create } from '@bufbuild/protobuf'
+
+import { AuctionSummarySchema } from '@/lib/sdk'
+
+import { TapeRow } from './TapeRow'
+
+const NOW = 1_700_000_120
+
+function mkAuction(opts: Partial<{
+  auctionId: string
+  clearingPrice: string
+  matchedVolume: string
+  matchCount: number
+  ageSeconds: number
+}> = {}) {
+  return create(AuctionSummarySchema, {
+    auctionId: opts.auctionId ?? 'a-001',
+    pair: 'ETH/USDC',
+    clearingPrice: opts.clearingPrice ?? '2418.10',
+    matchedVolume: opts.matchedVolume ?? '0.0453',
+    matchCount: opts.matchCount ?? 3,
+    timestampUnix: BigInt(NOW - (opts.ageSeconds ?? 5)),
+  })
+}
+
+const noop = (_id: string): void => undefined
+
+export const SingleRow = () => (
+  <ol className="w-[320px] border border-brand-border bg-brand-bg">
+    <TapeRow auction={mkAuction()} nowUnixSeconds={NOW} onSelect={noop} />
+  </ol>
+)
+
+export const ListOfRows = () => (
+  <ol className="w-[320px] border border-brand-border bg-brand-bg">
+    <TapeRow
+      auction={mkAuction({ auctionId: 'a-100', ageSeconds: 2, clearingPrice: '2419.85', matchedVolume: '0.0121', matchCount: 1 })}
+      nowUnixSeconds={NOW}
+      onSelect={noop}
+    />
+    <TapeRow
+      auction={mkAuction({ auctionId: 'a-099', ageSeconds: 7, clearingPrice: '12345.6789', matchedVolume: '0.089', matchCount: 5 })}
+      nowUnixSeconds={NOW}
+      onSelect={noop}
+    />
+    <TapeRow
+      auction={mkAuction({ auctionId: 'a-098', ageSeconds: 17, matchedVolume: '0', matchCount: 0 })}
+      nowUnixSeconds={NOW}
+      onSelect={noop}
+    />
+    <TapeRow
+      auction={mkAuction({ auctionId: 'a-097', ageSeconds: 65, clearingPrice: '2417.42', matchedVolume: '0.0023', matchCount: 1 })}
+      nowUnixSeconds={NOW}
+      onSelect={noop}
+    />
+  </ol>
+)

--- a/front/components/trade/tape/TapeRow.stories.tsx
+++ b/front/components/trade/tape/TapeRow.stories.tsx
@@ -24,7 +24,7 @@ function mkAuction(opts: Partial<{
   })
 }
 
-const noop = (_id: string): void => undefined
+const noop = (): void => undefined
 
 export const SingleRow = () => (
   <ol className="w-[320px] border border-brand-border bg-brand-bg">

--- a/front/components/trade/tape/TapeRow.tsx
+++ b/front/components/trade/tape/TapeRow.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import * as React from 'react'
+
+import { NumericText } from '@/components/NumericText'
+import type { AuctionSummary } from '@/lib/sdk'
+
+import { formatCount, formatRelativeTime } from './format'
+import styles from './tape.module.css'
+
+export interface TapeRowProps {
+  auction: AuctionSummary
+  /** Current Unix seconds; passed down so all rows share one tick source. */
+  nowUnixSeconds: number
+  /** Click / Enter / Space handler. */
+  onSelect: (auctionId: string) => void
+}
+
+function TapeRowImpl({ auction, nowUnixSeconds, onSelect }: TapeRowProps): JSX.Element {
+  const handleClick = React.useCallback(() => {
+    onSelect(auction.auctionId)
+  }, [auction.auctionId, onSelect])
+
+  return (
+    <li className="border-b border-brand-border">
+      <button
+        type="button"
+        onClick={handleClick}
+        className={`${styles.enter} grid w-full grid-cols-[3rem_minmax(0,1fr)_minmax(0,1fr)_2rem] items-center gap-3 px-4 py-2 text-left font-mono text-body-sm tabular-nums text-brand-fg transition-colors hover:bg-brand-surface focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-accent`}
+        aria-label={`Auction ${auction.auctionId}, clearing price ${auction.clearingPrice}`}
+      >
+        <span className="text-brand-muted">
+          {formatRelativeTime(auction.timestampUnix, nowUnixSeconds)}
+        </span>
+        <NumericText
+          value={auction.clearingPrice}
+          kind="price"
+          align="right"
+          className="text-brand-fg"
+        />
+        <NumericText
+          value={auction.matchedVolume}
+          kind="size"
+          align="right"
+          className="text-brand-fg"
+        />
+        <span className="text-right text-brand-muted">{formatCount(auction.matchCount)}</span>
+      </button>
+    </li>
+  )
+}
+
+export const TapeRow = React.memo(TapeRowImpl)
+TapeRow.displayName = 'TapeRow'

--- a/front/components/trade/tape/format.test.ts
+++ b/front/components/trade/tape/format.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatRelativeTime } from './format'
+import {
+  formatRelativeTime,
+  formatFullTimestamp,
+  formatCount,
+  secondsToNextAuction,
+} from './format'
 
 describe('formatRelativeTime', () => {
   it('renders a fresh auction as "0s"', () => {
@@ -29,5 +34,47 @@ describe('formatRelativeTime', () => {
 
   it('clamps negative ages (clock skew) to 0s', () => {
     expect(formatRelativeTime(1_700_000_010n, 1_700_000_000)).toBe('0s')
+  })
+})
+
+describe('formatFullTimestamp', () => {
+  it('renders HH:MM:SS · DD MMM YYYY in UTC', () => {
+    // 1700000000 = 2023-11-14 22:13:20 UTC
+    expect(formatFullTimestamp(1_700_000_000n)).toBe('22:13:20 · 14 NOV 2023')
+  })
+
+  it('zero-pads time components', () => {
+    // 1672531200 = 2023-01-01 00:00:00 UTC
+    expect(formatFullTimestamp(1_672_531_200n)).toBe('00:00:00 · 01 JAN 2023')
+  })
+})
+
+describe('formatCount', () => {
+  it('renders an integer as-is', () => {
+    expect(formatCount(0)).toBe('0')
+    expect(formatCount(1)).toBe('1')
+    expect(formatCount(42)).toBe('42')
+  })
+
+  it('clamps negative inputs to 0', () => {
+    expect(formatCount(-3)).toBe('0')
+  })
+})
+
+describe('secondsToNextAuction', () => {
+  it('returns intervalSeconds when no auction has landed yet', () => {
+    expect(secondsToNextAuction(null, 1_700_000_000, 5)).toBe(5)
+  })
+
+  it('counts down from intervalSeconds after the last auction', () => {
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_000, 5)).toBe(5)
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_002, 5)).toBe(3)
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_004, 5)).toBe(1)
+  })
+
+  it('wraps to a fresh interval after the boundary passes (clock keeps moving past 5s when the mock is paused)', () => {
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_005, 5)).toBe(5)
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_006, 5)).toBe(4)
+    expect(secondsToNextAuction(1_700_000_000n, 1_700_000_012, 5)).toBe(3)
   })
 })

--- a/front/components/trade/tape/format.test.ts
+++ b/front/components/trade/tape/format.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatRelativeTime } from './format'
+
+describe('formatRelativeTime', () => {
+  it('renders a fresh auction as "0s"', () => {
+    expect(formatRelativeTime(1_700_000_000n, 1_700_000_000)).toBe('0s')
+  })
+
+  it('renders sub-minute ages in seconds', () => {
+    expect(formatRelativeTime(1_700_000_000n, 1_700_000_005)).toBe('5s')
+    expect(formatRelativeTime(1_700_000_000n, 1_700_000_059)).toBe('59s')
+  })
+
+  it('switches to minutes at and above 60s', () => {
+    expect(formatRelativeTime(1_700_000_000n, 1_700_000_060)).toBe('1m')
+    expect(formatRelativeTime(1_700_000_000n, 1_700_003_599)).toBe('59m')
+  })
+
+  it('switches to hours at and above 60m', () => {
+    expect(formatRelativeTime(1_700_000_000n, 1_700_003_600)).toBe('1h')
+    expect(formatRelativeTime(1_700_000_000n, 1_700_086_399)).toBe('23h')
+  })
+
+  it('switches to days at and above 24h', () => {
+    expect(formatRelativeTime(1_700_000_000n, 1_700_086_400)).toBe('1d')
+    expect(formatRelativeTime(1_700_000_000n, 1_700_259_200)).toBe('3d')
+  })
+
+  it('clamps negative ages (clock skew) to 0s', () => {
+    expect(formatRelativeTime(1_700_000_010n, 1_700_000_000)).toBe('0s')
+  })
+})

--- a/front/components/trade/tape/format.ts
+++ b/front/components/trade/tape/format.ts
@@ -14,8 +14,18 @@ export function formatRelativeTime(auctionUnixSeconds: bigint, nowUnixSeconds: n
 }
 
 const MONTHS = [
-  'JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN',
-  'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC',
+  'JAN',
+  'FEB',
+  'MAR',
+  'APR',
+  'MAY',
+  'JUN',
+  'JUL',
+  'AUG',
+  'SEP',
+  'OCT',
+  'NOV',
+  'DEC',
 ] as const
 
 function pad2(n: number): string {
@@ -52,9 +62,10 @@ export function secondsToNextAuction(
   nowUnixSeconds: number,
   intervalSeconds: number
 ): number {
-  if (lastAuctionUnixSeconds === null) return intervalSeconds
+  const safeInterval = intervalSeconds > 0 ? Math.floor(intervalSeconds) : 1
+  if (lastAuctionUnixSeconds === null) return safeInterval
   const elapsed = nowUnixSeconds - Number(lastAuctionUnixSeconds)
-  if (elapsed < 0) return intervalSeconds
-  const remainder = elapsed % intervalSeconds
-  return remainder === 0 ? intervalSeconds : intervalSeconds - remainder
+  if (elapsed < 0) return safeInterval
+  const remainder = elapsed % safeInterval
+  return remainder === 0 ? safeInterval : safeInterval - remainder
 }

--- a/front/components/trade/tape/format.ts
+++ b/front/components/trade/tape/format.ts
@@ -1,0 +1,14 @@
+// Pure formatters for the auction tape. No React, no DOM.
+// Timestamps from AuctionSummary.timestampUnix arrive as seconds (bigint).
+
+const SECONDS_PER_MINUTE = 60
+const SECONDS_PER_HOUR = 60 * 60
+const SECONDS_PER_DAY = 60 * 60 * 24
+
+export function formatRelativeTime(auctionUnixSeconds: bigint, nowUnixSeconds: number): string {
+  const ageSeconds = Math.max(0, nowUnixSeconds - Number(auctionUnixSeconds))
+  if (ageSeconds < SECONDS_PER_MINUTE) return `${ageSeconds}s`
+  if (ageSeconds < SECONDS_PER_HOUR) return `${Math.floor(ageSeconds / SECONDS_PER_MINUTE)}m`
+  if (ageSeconds < SECONDS_PER_DAY) return `${Math.floor(ageSeconds / SECONDS_PER_HOUR)}h`
+  return `${Math.floor(ageSeconds / SECONDS_PER_DAY)}d`
+}

--- a/front/components/trade/tape/format.ts
+++ b/front/components/trade/tape/format.ts
@@ -12,3 +12,49 @@ export function formatRelativeTime(auctionUnixSeconds: bigint, nowUnixSeconds: n
   if (ageSeconds < SECONDS_PER_DAY) return `${Math.floor(ageSeconds / SECONDS_PER_HOUR)}h`
   return `${Math.floor(ageSeconds / SECONDS_PER_DAY)}d`
 }
+
+const MONTHS = [
+  'JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN',
+  'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC',
+] as const
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`
+}
+
+export function formatFullTimestamp(unixSeconds: bigint): string {
+  const d = new Date(Number(unixSeconds) * 1000)
+  const hh = pad2(d.getUTCHours())
+  const mm = pad2(d.getUTCMinutes())
+  const ss = pad2(d.getUTCSeconds())
+  const day = pad2(d.getUTCDate())
+  const mon = MONTHS[d.getUTCMonth()]
+  const year = d.getUTCFullYear()
+  return `${hh}:${mm}:${ss} · ${day} ${mon} ${year}`
+}
+
+export function formatCount(n: number): string {
+  return `${Math.max(0, Math.floor(n))}`
+}
+
+/**
+ * Seconds remaining until the next auction tick. `intervalSeconds` is the
+ * cadence configured on the mock store (default 5). When no auction has
+ * landed yet (`lastAuctionUnix === null`), returns a full interval so the
+ * countdown shows a valid number on first render.
+ *
+ * If `now` has drifted past `lastAuctionUnix + intervalSeconds` (e.g. the
+ * mock store was paused), wraps with `mod` so the countdown stays inside
+ * `[1, intervalSeconds]`.
+ */
+export function secondsToNextAuction(
+  lastAuctionUnixSeconds: bigint | null,
+  nowUnixSeconds: number,
+  intervalSeconds: number
+): number {
+  if (lastAuctionUnixSeconds === null) return intervalSeconds
+  const elapsed = nowUnixSeconds - Number(lastAuctionUnixSeconds)
+  if (elapsed < 0) return intervalSeconds
+  const remainder = elapsed % intervalSeconds
+  return remainder === 0 ? intervalSeconds : intervalSeconds - remainder
+}

--- a/front/components/trade/tape/index.ts
+++ b/front/components/trade/tape/index.ts
@@ -1,4 +1,5 @@
-// Barrel for the auction tape panel (F1.7 / issue #74).
-// Populated as components are implemented per
-// docs/superpowers/plans/2026-05-17-f17-auction-tape.md.
-export {}
+// Public surface for the auction tape panel (F1.7 / issue #74).
+// Consumers import { Tape } and mount it where the panel belongs in
+// the trading shell.
+export { Tape } from './Tape'
+export type { TapeProps } from './Tape'

--- a/front/components/trade/tape/index.ts
+++ b/front/components/trade/tape/index.ts
@@ -1,0 +1,4 @@
+// Barrel for the auction tape panel (F1.7 / issue #74).
+// Populated as components are implemented per
+// docs/superpowers/plans/2026-05-17-f17-auction-tape.md.
+export {}

--- a/front/components/trade/tape/tape.module.css
+++ b/front/components/trade/tape/tape.module.css
@@ -1,0 +1,60 @@
+/*
+ * Keyframes for the tape row entrance and drawer transitions.
+ * Both are gated by `prefers-reduced-motion: no-preference` so that
+ * users who request reduced motion get instant appearance.
+ */
+
+@keyframes tape-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes drawer-in {
+  from {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes drawer-out {
+  from {
+    opacity: 1;
+    transform: translateX(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(8px);
+  }
+}
+
+.enter {
+  /* No animation when reduced-motion is requested — rows appear instantly. */
+}
+
+.drawer {
+  /* Default no animation; the media query below enables it. */
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .enter {
+    animation: tape-enter 240ms cubic-bezier(0.16, 1, 0.3, 1) both;
+  }
+
+  .drawer[data-state='open'] {
+    animation: drawer-in 180ms cubic-bezier(0.16, 1, 0.3, 1);
+  }
+
+  .drawer[data-state='closed'] {
+    animation: drawer-out 140ms ease-in;
+  }
+}

--- a/front/components/trade/tape/useAuctionHistory.test.ts
+++ b/front/components/trade/tape/useAuctionHistory.test.ts
@@ -33,12 +33,25 @@ describe('selectLatestAuctions', () => {
     expect(rows).toHaveLength(state.recentAuctions.length)
   })
 
-  it('returns the same reference for identical inputs (memo seam)', () => {
+  it('returns referentially stable elements across calls (memo seam)', () => {
     const state = freshState()
     const a = selectLatestAuctions(state, 3)
     const b = selectLatestAuctions(state, 3)
     expect(a[0]).toBe(b[0])
     expect(a[1]).toBe(b[1])
+  })
+
+  it('returns the same array reference when the limit covers all rows', () => {
+    const state = freshState()
+    const a = selectLatestAuctions(state, 999)
+    const b = selectLatestAuctions(state, 999)
+    expect(a).toBe(b)
+  })
+
+  it('clamps negative or fractional limits without throwing', () => {
+    const state = freshState()
+    expect(selectLatestAuctions(state, -5)).toHaveLength(0)
+    expect(selectLatestAuctions(state, 2.7)).toHaveLength(2)
   })
 
   it('honors the default limit when called without an explicit value', () => {

--- a/front/components/trade/tape/useAuctionHistory.test.ts
+++ b/front/components/trade/tape/useAuctionHistory.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMockStore } from '../../../lib/mock-store'
+
+import { DEFAULT_AUCTION_HISTORY_LIMIT, selectLatestAuctions } from './useAuctionHistory'
+
+const FROZEN_NOW_SECONDS = 1_700_000_000
+const SEED = 11
+
+function freshState(seed = SEED) {
+  return createMockStore({
+    seed,
+    now: () => FROZEN_NOW_SECONDS,
+    mid: '3000',
+    depth: 4,
+    auctionHistory: 8,
+  }).getState()
+}
+
+describe('selectLatestAuctions', () => {
+  it('returns at most `limit` rows, newest first', () => {
+    const state = freshState()
+    const rows = selectLatestAuctions(state, 5)
+    expect(rows).toHaveLength(5)
+    for (let i = 0; i < rows.length - 1; i++) {
+      expect(rows[i].timestampUnix >= rows[i + 1].timestampUnix).toBe(true)
+    }
+  })
+
+  it('returns the full history when limit exceeds available rows', () => {
+    const state = freshState()
+    const rows = selectLatestAuctions(state, 999)
+    expect(rows).toHaveLength(state.recentAuctions.length)
+  })
+
+  it('returns the same reference for identical inputs (memo seam)', () => {
+    const state = freshState()
+    const a = selectLatestAuctions(state, 3)
+    const b = selectLatestAuctions(state, 3)
+    expect(a[0]).toBe(b[0])
+    expect(a[1]).toBe(b[1])
+  })
+
+  it('honors the default limit when called without an explicit value', () => {
+    const state = freshState()
+    const rows = selectLatestAuctions(state)
+    expect(rows.length).toBeLessThanOrEqual(DEFAULT_AUCTION_HISTORY_LIMIT)
+  })
+})

--- a/front/components/trade/tape/useAuctionHistory.ts
+++ b/front/components/trade/tape/useAuctionHistory.ts
@@ -7,6 +7,10 @@ import { type MockStoreState, useMockStore } from '../../../lib/mock-store'
 
 export const DEFAULT_AUCTION_HISTORY_LIMIT = 50
 
+function normalizeLimit(limit: number): number {
+  return Math.max(0, Math.floor(limit))
+}
+
 /**
  * Pure selector over the mock store. Returns the newest `limit` auctions,
  * preserving the store's newest-first ordering. Exported separately so it
@@ -16,8 +20,9 @@ export function selectLatestAuctions(
   state: MockStoreState,
   limit: number = DEFAULT_AUCTION_HISTORY_LIMIT
 ): readonly AuctionSummary[] {
-  if (state.recentAuctions.length <= limit) return state.recentAuctions
-  return state.recentAuctions.slice(0, limit)
+  const normalizedLimit = normalizeLimit(limit)
+  if (state.recentAuctions.length <= normalizedLimit) return state.recentAuctions
+  return state.recentAuctions.slice(0, normalizedLimit)
 }
 
 export interface UseAuctionHistoryOptions {
@@ -38,7 +43,7 @@ export interface UseAuctionHistoryOptions {
  * row components, which would otherwise re-render on every 1s perturb.
  */
 export function useAuctionHistory(opts: UseAuctionHistoryOptions = {}): readonly AuctionSummary[] {
-  const limit = opts.limit ?? DEFAULT_AUCTION_HISTORY_LIMIT
+  const limit = normalizeLimit(opts.limit ?? DEFAULT_AUCTION_HISTORY_LIMIT)
   const recentAuctions = useMockStore((s) => s.recentAuctions)
   return useMemo(() => {
     if (recentAuctions.length <= limit) return recentAuctions

--- a/front/components/trade/tape/useAuctionHistory.ts
+++ b/front/components/trade/tape/useAuctionHistory.ts
@@ -1,0 +1,47 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import type { AuctionSummary } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+import { type MockStoreState, useMockStore } from '../../../lib/mock-store'
+
+export const DEFAULT_AUCTION_HISTORY_LIMIT = 50
+
+/**
+ * Pure selector over the mock store. Returns the newest `limit` auctions,
+ * preserving the store's newest-first ordering. Exported separately so it
+ * can be unit-tested without a React renderer.
+ */
+export function selectLatestAuctions(
+  state: MockStoreState,
+  limit: number = DEFAULT_AUCTION_HISTORY_LIMIT
+): readonly AuctionSummary[] {
+  if (state.recentAuctions.length <= limit) return state.recentAuctions
+  return state.recentAuctions.slice(0, limit)
+}
+
+export interface UseAuctionHistoryOptions {
+  /** Max rows to surface. Defaults to {@link DEFAULT_AUCTION_HISTORY_LIMIT}. */
+  limit?: number
+  /**
+   * Phase 2 seam. In Phase 1 the store push beats any polling interval;
+   * this is a documented no-op for the mock backend. Default 2000.
+   * The REST swap (#94) will reuse this prop with setInterval.
+   */
+  pollMs?: number
+}
+
+/**
+ * Subscribes to the mock store and returns the latest `limit` auctions.
+ * The returned array is referentially stable when the underlying
+ * `recentAuctions` reference is unchanged — important for `React.memo`
+ * row components, which would otherwise re-render on every 1s perturb.
+ */
+export function useAuctionHistory(opts: UseAuctionHistoryOptions = {}): readonly AuctionSummary[] {
+  const limit = opts.limit ?? DEFAULT_AUCTION_HISTORY_LIMIT
+  const recentAuctions = useMockStore((s) => s.recentAuctions)
+  return useMemo(() => {
+    if (recentAuctions.length <= limit) return recentAuctions
+    return recentAuctions.slice(0, limit)
+  }, [recentAuctions, limit])
+}

--- a/front/components/trade/tape/useNow.ts
+++ b/front/components/trade/tape/useNow.ts
@@ -11,11 +11,13 @@ import { useEffect, useState } from 'react'
  * Pass `nowSecondsOverride` (tests, Ladle stories) to freeze time.
  */
 export function useNow(nowSecondsOverride?: number): number {
-  const [now, setNow] = useState<number>(() =>
-    nowSecondsOverride ?? Math.floor(Date.now() / 1000)
-  )
+  const [now, setNow] = useState<number>(() => nowSecondsOverride ?? Math.floor(Date.now() / 1000))
   useEffect(() => {
-    if (nowSecondsOverride !== undefined) return
+    if (nowSecondsOverride !== undefined) {
+      setNow(nowSecondsOverride)
+      return
+    }
+    setNow(Math.floor(Date.now() / 1000))
     const id = setInterval(() => {
       setNow(Math.floor(Date.now() / 1000))
     }, 1000)

--- a/front/components/trade/tape/useNow.ts
+++ b/front/components/trade/tape/useNow.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+/**
+ * Returns the current Unix time in seconds and updates once per second.
+ * Single shared subscription pattern: every consumer mounts its own
+ * interval, but the cost is one setState per second per consumer —
+ * negligible for the tape (one parent component).
+ *
+ * Pass `nowSecondsOverride` (tests, Ladle stories) to freeze time.
+ */
+export function useNow(nowSecondsOverride?: number): number {
+  const [now, setNow] = useState<number>(() =>
+    nowSecondsOverride ?? Math.floor(Date.now() / 1000)
+  )
+  useEffect(() => {
+    if (nowSecondsOverride !== undefined) return
+    const id = setInterval(() => {
+      setNow(Math.floor(Date.now() / 1000))
+    }, 1000)
+    return () => clearInterval(id)
+  }, [nowSecondsOverride])
+  return now
+}


### PR DESCRIPTION
Closes #74

## Summary
- New tape panel under `front/components/trade/tape/` reading the F1.2 mock store via `useAuctionHistory`.
- `<Countdown/>` ticker-bar header owns the lime accent for this surface; row newness is signalled by a CSS-keyframe slide+fade gated by `prefers-reduced-motion`.
- Per-row drawer (`<TapeDrawer/>`) shows full auction details plus a `[ ETHERSCAN · PENDING ]` placeholder for I2.11 / #100.

## Design references
- Spec: `docs/superpowers/specs/2026-05-17-f17-auction-tape-design.md`
- Plan: `docs/superpowers/plans/2026-05-17-f17-auction-tape.md`

## Testing strategy
The project has no `@testing-library/react` / `jsdom`, so adding those would be out of scope. The strategy adapted:
- `format.test.ts` — relative-time, full-timestamp, count, countdown formatters (13 tests).
- `useAuctionHistory.test.ts` — pure selector (4 tests).
- React components — Ladle stories (`*.stories.tsx`) for visual review.
- End-to-end — browser-verified via the Ladle `tape--live` story before this PR.

Full Vitest suite: 146 passed (146 total).

## Out of scope / follow-ups
- Wiring `<Tape/>` into `Shell.tsx`. That file belongs to F1.1; one-line integration is a follow-up.
- Phase 2 REST swap (#94) — `useAuctionHistory.pollMs` is the documented seam.
- Streaming upgrade (#95).
- Real Etherscan link (I2.11 / #100).

## Verified manually (Ladle tape--live)
- [x] Header reads `[ NEXT AUCTION IN NN ]` in lime, counting down each second.
- [x] Rows arrive every ~5s; head row animates in (CSS-module enter class observed).
- [x] Click row → drawer opens with details and `[ ETHERSCAN · PENDING ]`.
- [x] ESC closes drawer.
- [x] `prefers-reduced-motion` gating verified via stylesheet inspection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an auction tape panel showing recently-settled auctions with a live countdown and per-row selection that opens a right-side details drawer.
  * Animated, motion-respectful entrance and drawer transitions; accessible aria/live behavior and keyboard focus handling.

* **Tests**
  * Unit tests for formatting, time/countdown logic, and auction-history selection/memoization.

* **Documentation**
  * New design and implementation specs plus component stories for visual verification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/115?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->