### PR TITLE
[F1.9] Order entry form (mock)

### DIFF
--- a/front/components/trade/entry/BuySellTabs.tsx
+++ b/front/components/trade/entry/BuySellTabs.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+// Segmented control that picks the order side. Both options are styled
+// as `button-ghost` per DESIGN-INSPIRATIONS.md; the active option lifts
+// its text to `primary` and its border to `outline-variant`. No semantic
+// hue — BUY/SELL are differentiated by position and weight only.
+
+import * as React from 'react'
+
+import { cn } from '../../ui/cn'
+
+import type { OrderSide } from './validate'
+
+export interface BuySellTabsProps {
+  value: OrderSide
+  onChange: (next: OrderSide) => void
+  disabled?: boolean
+}
+
+interface OptionProps {
+  side: OrderSide
+  label: string
+  active: boolean
+  disabled?: boolean
+  onClick: () => void
+}
+
+function Option({ side, label, active, disabled, onClick }: OptionProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      aria-controls="order-entry-form"
+      data-side={side}
+      data-state={active ? 'active' : 'inactive'}
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        'flex h-10 flex-1 items-center justify-center',
+        'font-mono uppercase tracking-[0.15em] text-[11px] font-medium leading-none',
+        'transition-colors duration-150 ease-out',
+        'border border-brand-border',
+        'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-brand-accent',
+        active
+          ? 'text-brand-fg border-brand-border2 bg-brand-surface'
+          : 'text-brand-muted hover:text-brand-fg hover:border-brand-muted',
+        'disabled:cursor-not-allowed disabled:opacity-60'
+      )}
+    >
+      {label}
+    </button>
+  )
+}
+
+export function BuySellTabs({ value, onChange, disabled }: BuySellTabsProps) {
+  return (
+    <div role="tablist" aria-label="Order side" className="flex gap-px">
+      <Option
+        side="buy"
+        label="[ BUY ]"
+        active={value === 'buy'}
+        disabled={disabled}
+        onClick={() => onChange('buy')}
+      />
+      <Option
+        side="sell"
+        label="[ SELL ]"
+        active={value === 'sell'}
+        disabled={disabled}
+        onClick={() => onChange('sell')}
+      />
+    </div>
+  )
+}

--- a/front/components/trade/entry/OrderEntry.stories.tsx
+++ b/front/components/trade/entry/OrderEntry.stories.tsx
@@ -1,0 +1,210 @@
+import * as React from 'react'
+
+import { walletStore } from '../../../lib/wallet/mock-store'
+import { Toaster } from '../../ui/toaster'
+
+import { OrderEntry, type OrderEntryHandle } from './OrderEntry'
+import { PlaceButton } from './ProveSubmitStages'
+import { BuySellTabs } from './BuySellTabs'
+import { DecimalInput } from './inputs'
+import { TotalRow } from './TotalRow'
+import {
+  STAGE_DURATIONS_MS,
+  STAGE_LABELS,
+  STAGE_ORDER,
+  STAGE_TOTAL_MS,
+  type SubmitStageId,
+} from './policy'
+import type { SubmissionPhase } from './useSubmitStages'
+
+// Ladle is the project's visual-verification surface (the JSX test
+// transform is node-only). Each story imperatively positions the wallet
+// mock store before render; Ladle renders stories in their own iframe so
+// per-story side effects don't leak.
+//
+// Note: the wallet mock (#70) has no balance-mutation API — F1.5 (#72)
+// adds deposit/withdraw. Until then `connect()` lands the trader on
+// zero internal balances, which the form correctly flags as
+// `Insufficient balance.` The `InstantSubmit` story uses a stub
+// placeOrder so the SUCCESS path is reviewable; the live mock-store
+// path runs once balances are populated by F1.5 in a follow-up.
+
+function useWalletInitialState(initial: 'connected' | 'disconnected') {
+  React.useEffect(() => {
+    walletStore.disconnect()
+    if (initial === 'connected') walletStore.connect()
+    return () => walletStore.disconnect()
+  }, [initial])
+}
+
+function Frame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex w-[360px] flex-col gap-4">
+      {children}
+      <Toaster />
+    </div>
+  )
+}
+
+// ─── OrderEntry: states ───────────────────────────────────────────────
+
+export const Disconnected = () => {
+  useWalletInitialState('disconnected')
+  return (
+    <Frame>
+      <OrderEntry />
+    </Frame>
+  )
+}
+
+export const Connected = () => {
+  useWalletInitialState('connected')
+  return (
+    <Frame>
+      <OrderEntry />
+    </Frame>
+  )
+}
+
+export const ClickToFill = () => {
+  useWalletInitialState('connected')
+  const ref = React.useRef<OrderEntryHandle>(null)
+  return (
+    <Frame>
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => ref.current?.fill('3000.50', 'buy')}
+          className="font-mono text-[10px] uppercase tracking-[0.2em] text-brand-muted hover:text-brand-fg border border-brand-border px-3 py-2"
+        >
+          [ FILL BID 3000.50 ]
+        </button>
+        <button
+          type="button"
+          onClick={() => ref.current?.fill('3010.25', 'sell')}
+          className="font-mono text-[10px] uppercase tracking-[0.2em] text-brand-muted hover:text-brand-fg border border-brand-border px-3 py-2"
+        >
+          [ FILL ASK 3010.25 ]
+        </button>
+      </div>
+      <OrderEntry ref={ref} />
+    </Frame>
+  )
+}
+
+export const InstantSubmit = () => {
+  // Demonstrates the successful submission path without the staged
+  // delays. `placeOrder` is stubbed so the test isn't gated on the
+  // wallet store's internal balance (which is zero in Phase 1; F1.5
+  // populates it after deposit/withdraw lands). Type a price and a
+  // size, then submit — the staged labels still play (delay is a no-op
+  // wait but the React state still cycles).
+  useWalletInitialState('connected')
+  const placed = React.useRef<unknown[]>([])
+  return (
+    <Frame>
+      <OrderEntry placeOrder={(p) => placed.current.push(p)} delay={async () => {}} />
+      <p className="font-mono text-[10px] uppercase tracking-[0.2em] text-brand-muted">
+        [ STUBBED PLACEORDER ]
+      </p>
+    </Frame>
+  )
+}
+
+// ─── Primitive variants ───────────────────────────────────────────────
+
+export const SidesTab = () => {
+  const [side, setSide] = React.useState<'buy' | 'sell'>('buy')
+  return (
+    <div className="w-[360px]">
+      <BuySellTabs value={side} onChange={setSide} />
+      <p className="mt-3 font-mono text-[10px] uppercase tracking-[0.2em] text-brand-muted">
+        SIDE: {side}
+      </p>
+    </div>
+  )
+}
+
+export const PriceAndSizeInputs = () => {
+  const [price, setPrice] = React.useState('3000')
+  const [size, setSize] = React.useState('0.5')
+  return (
+    <div className="flex w-[360px] flex-col gap-4">
+      <DecimalInput
+        id="story-price"
+        label="[ PRICE · USDC ]"
+        unit="USDC"
+        value={price}
+        onChange={setPrice}
+        placeholder="0.00"
+      />
+      <DecimalInput
+        id="story-size"
+        label="[ SIZE · WETH ]"
+        unit="WETH"
+        value={size}
+        onChange={setSize}
+        placeholder="0.0000"
+        rightSlot={
+          <button
+            type="button"
+            onClick={() => setSize('10')}
+            className="font-mono text-[10px] font-medium uppercase tracking-[0.2em] text-brand-muted hover:text-brand-fg transition-colors"
+          >
+            [ MAX ]
+          </button>
+        }
+      />
+      <TotalRow price={price} size={size} />
+    </div>
+  )
+}
+
+export const PlaceButtonStages = () => {
+  // Static gallery of the place button across every submission state.
+  // Useful for visually confirming the label mutations and the progress
+  // bar position without driving a live timer.
+  const states: Array<{ name: string; phase: SubmissionPhase }> = [
+    { name: 'idle', phase: { kind: 'idle' } },
+    ...STAGE_ORDER.map((stage) => ({
+      name: STAGE_LABELS[stage].toLowerCase(),
+      phase: {
+        kind: 'running' as const,
+        stage: stage as SubmitStageId,
+        progress: progressMidpoint(stage),
+      },
+    })),
+    { name: 'success', phase: { kind: 'success' } },
+    { name: 'error', phase: { kind: 'error', message: 'rejected by engine' } },
+  ]
+  return (
+    <div className="flex w-[360px] flex-col gap-6">
+      {states.map(({ name, phase }) => (
+        <div key={name} className="flex flex-col gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.2em] text-brand-muted">
+            [ {name.toUpperCase()} ]
+          </span>
+          <PlaceButton
+            idleLabel="[ BUY · WETH ]"
+            phase={phase}
+            accent={phase.kind === 'idle'}
+            disabled={phase.kind === 'error'}
+            onClick={() => {}}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function progressMidpoint(stage: SubmitStageId): number {
+  let elapsed = 0
+  for (const id of STAGE_ORDER) {
+    if (id === stage) {
+      elapsed += STAGE_DURATIONS_MS[id] / 2
+      break
+    }
+    elapsed += STAGE_DURATIONS_MS[id]
+  }
+  return elapsed / STAGE_TOTAL_MS
+}

--- a/front/components/trade/entry/OrderEntry.test.tsx
+++ b/front/components/trade/entry/OrderEntry.test.tsx
@@ -1,0 +1,87 @@
+// Smoke tests for the panel composition. We render to static markup
+// (no DOM needed) because the project's vitest setup is node-only — the
+// existing pattern is pure unit tests + Ladle stories for visual review.
+//
+// These lock the wallet/balance/store contracts end-to-end at the
+// composition layer; the inner state machine and validation logic have
+// their own dedicated tests.
+
+import * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { walletStore } from '../../../lib/wallet/mock-store'
+
+import { OrderEntry } from './OrderEntry'
+
+function renderPanel(): string {
+  return renderToStaticMarkup(<OrderEntry />)
+}
+
+describe('OrderEntry composition', () => {
+  beforeEach(() => {
+    walletStore.disconnect()
+  })
+
+  afterEach(() => {
+    walletStore.disconnect()
+  })
+
+  it('renders the bracketed-tag header in every state', () => {
+    expect(renderPanel()).toContain('[ ORDER ENTRY ]')
+  })
+
+  it('renders the BUY/SELL tabs and price/size labels', () => {
+    const html = renderPanel()
+    expect(html).toContain('[ BUY ]')
+    expect(html).toContain('[ SELL ]')
+    expect(html).toContain('[ PRICE · USDC ]')
+    expect(html).toContain('[ SIZE · WETH ]')
+  })
+
+  it('renders the wallet-disconnected error when disconnected', () => {
+    const html = renderPanel()
+    expect(html).toContain('Connect a wallet')
+  })
+
+  it('drops the disconnected error when the wallet connects', () => {
+    walletStore.connect()
+    const html = renderPanel()
+    expect(html).not.toContain('Connect a wallet')
+  })
+
+  it('shows a balance error when connected with zero balances and price/size are valid', () => {
+    walletStore.connect()
+    // The form starts with empty inputs — no balance check fires.
+    // We can't drive the field state from static markup, so we trust the
+    // separate validate.test.ts unit tests for balance-error coverage and
+    // just lock the wired surface: the panel renders without the
+    // disconnected error and without crashing.
+    expect(() => renderPanel()).not.toThrow()
+  })
+
+  it('idle button reads "[ BUY · WETH ]" by default', () => {
+    walletStore.connect()
+    const html = renderPanel()
+    expect(html).toContain('[ BUY · WETH ]')
+  })
+
+  it('the fee-row carries the protocol fee bps', () => {
+    const html = renderPanel()
+    expect(html).toContain('FEE · 5 BPS')
+  })
+
+  it('does not introduce a lime accent until the form is valid', () => {
+    // Idle / empty form ⇒ no lime accent on the place button surface.
+    walletStore.connect()
+    const html = renderPanel()
+    // The accent is migrated to the place button only when validation is
+    // green. With empty inputs the place button must NOT be the bg-brand-accent
+    // surface — but the [ MAX ] shortcut can still focus-ring to lime,
+    // and the toast viewport may reference brand-accent for the accent
+    // variant. So we narrow the assertion to the place-button surface
+    // class which would only set bg-brand-accent if `accentActive` were
+    // true.
+    expect(html).not.toMatch(/class="[^"]*bg-brand-accent[^"]*"[^>]*>\s*<span[^>]*>\s*\[ BUY/)
+  })
+})

--- a/front/components/trade/entry/OrderEntry.test.tsx
+++ b/front/components/trade/entry/OrderEntry.test.tsx
@@ -50,16 +50,6 @@ describe('OrderEntry composition', () => {
     expect(html).not.toContain('Connect a wallet')
   })
 
-  it('shows a balance error when connected with zero balances and price/size are valid', () => {
-    walletStore.connect()
-    // The form starts with empty inputs — no balance check fires.
-    // We can't drive the field state from static markup, so we trust the
-    // separate validate.test.ts unit tests for balance-error coverage and
-    // just lock the wired surface: the panel renders without the
-    // disconnected error and without crashing.
-    expect(() => renderPanel()).not.toThrow()
-  })
-
   it('idle button reads "[ BUY · WETH ]" by default', () => {
     walletStore.connect()
     const html = renderPanel()

--- a/front/components/trade/entry/OrderEntry.tsx
+++ b/front/components/trade/entry/OrderEntry.tsx
@@ -81,6 +81,8 @@ export const OrderEntry = React.forwardRef<OrderEntryHandle, OrderEntryProps>(fu
     baseBalance: balances.weth,
     quoteBalance: balances.usdc,
   })
+  const formStateRef = React.useRef(form)
+  formStateRef.current = form
 
   const effectivePlaceOrder = React.useCallback(
     (payload: SubmitPayload) => {
@@ -120,10 +122,10 @@ export const OrderEntry = React.forwardRef<OrderEntryHandle, OrderEntryProps>(fu
     ref,
     () => ({
       fill: (price: string, nextSide?: OrderSide) => {
-        form.fillFromLevel(price, nextSide)
+        formStateRef.current.fillFromLevel(price, nextSide)
       },
     }),
-    [form]
+    []
   )
 
   const handleSubmit = (event: React.FormEvent) => {
@@ -176,7 +178,9 @@ export const OrderEntry = React.forwardRef<OrderEntryHandle, OrderEntryProps>(fu
       </header>
       <form
         ref={formRef}
+        id="order-entry-form"
         onSubmit={handleSubmit}
+        aria-describedby={formError ? formErrorId : undefined}
         className="flex flex-1 flex-col gap-4 p-4"
         noValidate
       >

--- a/front/components/trade/entry/OrderEntry.tsx
+++ b/front/components/trade/entry/OrderEntry.tsx
@@ -1,0 +1,248 @@
+'use client'
+
+// Order entry composition root.
+//
+// Phase 1 wiring:
+//   - reads internal balances via the mock wallet store (F1.3 / #70)
+//   - pushes new orders into the mock store (F1.2 / #69) where they
+//     immediately surface in the orderbook (F1.6 / #73) and the
+//     my-orders panel (F1.10 / #77).
+//   - surfaces the staged mock UX (ENCRYPT → PROVE → SUBMIT → ACK) so
+//     the WASM prover delay (5–30s in Phase 2) has a UX rehearsed before
+//     the real flow lands at #99.
+//
+// Click-to-fill: the orderbook (#73) calls `onPriceSelect(price, side)`.
+// `OrderEntry` exposes an imperative `fill(price, side?)` via forwardRef
+// so a parent composing the trade layout can pipe that callback in:
+//
+//   const ref = React.useRef<OrderEntryHandle>(null)
+//   <OrderBook onPriceSelect={(p, s) => ref.current?.fill(p, ...)} />
+//   <OrderEntry ref={ref} />
+//
+// Shell.tsx (F1.1) is out of this issue's file scope — the wiring lands
+// in a follow-up that owns Shell.
+
+import * as React from 'react'
+
+import { mockStore } from '../../../lib/mock-store'
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+import { Decimal } from '../../../lib/units'
+import { useInternalBalances, useWallet } from '../../../lib/wallet/hooks'
+
+import { useToast } from '../../ui/use-toast'
+
+import { BuySellTabs } from './BuySellTabs'
+import { errorMessage } from './errors'
+import { DecimalInput } from './inputs'
+import { BASE_TOKEN, FEE_BPS, QUOTE_TOKEN } from './policy'
+import { PlaceButton } from './ProveSubmitStages'
+import { TotalRow } from './TotalRow'
+import { useOrderForm } from './useOrderForm'
+import { useSubmitStages, type SubmitPayload } from './useSubmitStages'
+import type { OrderSide } from './validate'
+
+export interface OrderEntryHandle {
+  /** Fill the form from an external source (orderbook click-to-fill). */
+  fill: (price: string, side?: OrderSide) => void
+}
+
+export interface OrderEntryProps {
+  /**
+   * Injectable side-effect: where to push the placed order. Defaults to
+   * the singleton mock store. Tests and Storybook variants override
+   * this to stub the mutation.
+   */
+  placeOrder?: (payload: SubmitPayload) => void
+  /**
+   * Injectable wait function for the staged submission. Defaults to
+   * setTimeout-based sleep. Storybook variants pass `() => Promise.resolve()`
+   * to step through stages without the real timings.
+   */
+  delay?: (ms: number) => Promise<void>
+}
+
+const FEE_FACTOR = new Decimal(1).plus(new Decimal(FEE_BPS).div(10_000))
+
+export const OrderEntry = React.forwardRef<OrderEntryHandle, OrderEntryProps>(function OrderEntry(
+  { placeOrder, delay },
+  ref
+) {
+  const { isConnected } = useWallet()
+  const balances = useInternalBalances()
+  const { toast } = useToast()
+  const formRef = React.useRef<HTMLFormElement>(null)
+  const headerId = React.useId()
+  const priceErrorId = React.useId()
+  const sizeErrorId = React.useId()
+  const formErrorId = React.useId()
+
+  const form = useOrderForm({
+    isConnected,
+    baseBalance: balances.weth,
+    quoteBalance: balances.usdc,
+  })
+
+  const effectivePlaceOrder = React.useCallback(
+    (payload: SubmitPayload) => {
+      if (placeOrder) {
+        placeOrder(payload)
+        return
+      }
+      mockStore.getState().placeOrder({
+        side: payload.side === 'buy' ? Side.BUY : Side.SELL,
+        price: payload.price,
+        size: payload.size,
+      })
+    },
+    [placeOrder]
+  )
+
+  const submit = useSubmitStages({
+    placeOrder: effectivePlaceOrder,
+    delay,
+    onSuccess: () => {
+      toast({
+        title: 'Order placed',
+        description: 'Pending next auction.',
+        variant: 'accent',
+      })
+      form.reset()
+    },
+    onError: (error) => {
+      toast({
+        title: 'Order rejected',
+        description: error.message,
+      })
+    },
+  })
+
+  React.useImperativeHandle(
+    ref,
+    () => ({
+      fill: (price: string, nextSide?: OrderSide) => {
+        form.fillFromLevel(price, nextSide)
+      },
+    }),
+    [form]
+  )
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!form.validation.ok || submit.isRunning) return
+    void submit.submit({ side: form.side, price: form.price, size: form.size })
+  }
+
+  const handleMax = () => {
+    // Sell: cap size at the available WETH balance.
+    // Buy: derive size = quoteBalance / (price * (1 + fee_bps/10000)),
+    // snap down to 4dp so the displayed value matches the size column.
+    // If price isn't set we leave the field alone — populating it from
+    // a stale or zero price would mislead the user.
+    try {
+      if (form.side === 'sell') {
+        form.setSize(balances.weth)
+        return
+      }
+      if (form.price.trim() === '') return
+      const priceD = new Decimal(form.price)
+      if (priceD.lte(0)) return
+      const quoteD = new Decimal(balances.usdc)
+      const maxSize = quoteD.div(FEE_FACTOR).div(priceD)
+      form.setSize(maxSize.toDecimalPlaces(4, Decimal.ROUND_DOWN).toFixed())
+    } catch {
+      /* invalid input — leave the size field as-is */
+    }
+  }
+
+  const priceError = form.validation.errors.price
+  const sizeError = form.validation.errors.size
+  const formError = form.validation.errors.form
+
+  const idleLabel = `${form.side === 'buy' ? '[ BUY' : '[ SELL'} · ${BASE_TOKEN} ]`
+  const accentActive = form.validation.ok && submit.phase.kind !== 'running'
+
+  return (
+    <section
+      aria-labelledby={headerId}
+      className="flex h-full flex-col border border-brand-border bg-brand-surface"
+    >
+      <header className="flex h-9 items-center border-b border-brand-border px-4">
+        <span
+          id={headerId}
+          className="font-mono text-[10px] font-medium uppercase tracking-[0.2em] text-brand-muted"
+        >
+          [ ORDER ENTRY ]
+        </span>
+      </header>
+      <form
+        ref={formRef}
+        onSubmit={handleSubmit}
+        className="flex flex-1 flex-col gap-4 p-4"
+        noValidate
+      >
+        <BuySellTabs value={form.side} onChange={form.setSide} disabled={submit.isRunning} />
+
+        <DecimalInput
+          id="order-entry-price"
+          label={`[ PRICE · ${QUOTE_TOKEN} ]`}
+          unit={QUOTE_TOKEN}
+          value={form.price}
+          onChange={form.setPrice}
+          placeholder="0.00"
+          disabled={submit.isRunning}
+          invalid={!!priceError}
+          errorId={priceError ? priceErrorId : undefined}
+        />
+        {priceError && (
+          <p id={priceErrorId} role="alert" className="font-mono text-body-sm text-brand-muted">
+            {errorMessage(priceError)}
+          </p>
+        )}
+
+        <DecimalInput
+          id="order-entry-size"
+          label={`[ SIZE · ${BASE_TOKEN} ]`}
+          unit={BASE_TOKEN}
+          value={form.size}
+          onChange={form.setSize}
+          placeholder="0.0000"
+          disabled={submit.isRunning}
+          invalid={!!sizeError}
+          errorId={sizeError ? sizeErrorId : undefined}
+          rightSlot={
+            <button
+              type="button"
+              onClick={handleMax}
+              disabled={submit.isRunning || !isConnected}
+              className="font-mono text-[10px] font-medium uppercase tracking-[0.2em] text-brand-muted hover:text-brand-fg transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Set size to maximum"
+            >
+              [ MAX ]
+            </button>
+          }
+        />
+        {sizeError && (
+          <p id={sizeErrorId} role="alert" className="font-mono text-body-sm text-brand-muted">
+            {errorMessage(sizeError)}
+          </p>
+        )}
+
+        <TotalRow price={form.price} size={form.size} />
+
+        {formError && (
+          <p id={formErrorId} role="alert" className="font-mono text-body-sm text-brand-muted">
+            {errorMessage(formError)}
+          </p>
+        )}
+
+        <PlaceButton
+          idleLabel={idleLabel}
+          phase={submit.phase}
+          disabled={!form.validation.ok}
+          accent={accentActive}
+          onClick={() => formRef.current?.requestSubmit()}
+        />
+      </form>
+    </section>
+  )
+})

--- a/front/components/trade/entry/ProveSubmitStages.tsx
+++ b/front/components/trade/entry/ProveSubmitStages.tsx
@@ -49,7 +49,10 @@ export function PlaceButton({ idleLabel, phase, disabled, onClick, accent }: Pla
         className={cn(
           'relative flex h-12 items-center justify-center px-8',
           'font-mono uppercase tracking-[0.15em] text-[11px] font-medium leading-none',
-          'transition-colors transition-shadow duration-150 ease-out',
+          // Custom transition-property so colors AND shadow both animate —
+          // chaining `transition-colors transition-shadow` lets the second
+          // class win and only shadow tweens.
+          'transition-[color,background-color,box-shadow] duration-150 ease-out',
           'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-brand-accent',
           accent
             ? 'bg-brand-accent text-brand-on-accent hover:shadow-accent-glow'

--- a/front/components/trade/entry/ProveSubmitStages.tsx
+++ b/front/components/trade/entry/ProveSubmitStages.tsx
@@ -1,0 +1,121 @@
+'use client'
+
+// Visual layer for the multi-stage submission. Renders the place-button
+// label (which mutates through the stages) and the thin progress bar
+// directly underneath the button — no modal stacking, per the
+// DESIGN-INSPIRATIONS pattern "Submission: button label mutates through
+// the 4 stages, with a thin tertiary progress bar underneath the button
+// (height 2px, filling left to right). No modals."
+//
+// The component is presentational only. The state machine and the
+// progress numbers come from useSubmitStages.ts; this file just maps
+// them to DOM. F1.12 (#79) reuses the same stage labels so renaming is
+// a coordinated change.
+
+import * as React from 'react'
+
+import { cn } from '../../ui/cn'
+
+import { STAGE_LABELS, type SubmitStageId } from './policy'
+import type { SubmissionPhase } from './useSubmitStages'
+
+export interface PlaceButtonProps {
+  /** What the button reads when idle (e.g. "BUY · WETH"). */
+  idleLabel: string
+  phase: SubmissionPhase
+  disabled?: boolean
+  onClick: () => void
+  /**
+   * When true, the button is rendered as the accent surface (lime).
+   * The accent migrates here from the auction countdown when the form
+   * is valid and not submitting — see DESIGN-INSPIRATIONS.md.
+   */
+  accent: boolean
+}
+
+export function PlaceButton({ idleLabel, phase, disabled, onClick, accent }: PlaceButtonProps) {
+  const label = labelFor(phase, idleLabel)
+  const isRunning = phase.kind === 'running'
+  const showSuccess = phase.kind === 'success'
+
+  return (
+    <div className="flex flex-col">
+      <button
+        type="button"
+        onClick={onClick}
+        disabled={disabled || isRunning}
+        aria-busy={isRunning || undefined}
+        aria-live="polite"
+        className={cn(
+          'relative flex h-12 items-center justify-center px-8',
+          'font-mono uppercase tracking-[0.15em] text-[11px] font-medium leading-none',
+          'transition-colors transition-shadow duration-150 ease-out',
+          'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-brand-accent',
+          accent
+            ? 'bg-brand-accent text-brand-on-accent hover:shadow-accent-glow'
+            : 'bg-transparent text-brand-muted border border-brand-border shadow-[inset_0_0_0_1px_#0C0C12]',
+          // Hold ground on hover when not eligible — the form is the
+          // signal of validity; the button itself shouldn't flicker.
+          'disabled:cursor-not-allowed',
+          accent
+            ? 'disabled:bg-brand-border disabled:text-brand-muted disabled:shadow-none'
+            : 'disabled:text-brand-muted'
+        )}
+      >
+        <span className="block">{label}</span>
+      </button>
+      <ProgressBar phase={phase} success={showSuccess} />
+    </div>
+  )
+}
+
+function labelFor(phase: SubmissionPhase, idleLabel: string): string {
+  switch (phase.kind) {
+    case 'idle':
+      return idleLabel
+    case 'running':
+      return `${STAGE_LABELS[phase.stage]} …`
+    case 'success':
+      return 'ORDER PLACED'
+    case 'error':
+      return 'TRY AGAIN'
+  }
+}
+
+function ProgressBar({ phase, success }: { phase: SubmissionPhase; success: boolean }) {
+  const width = progressWidth(phase, success)
+  const visible = phase.kind === 'running' || success
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'h-[2px] w-full overflow-hidden bg-brand-border/0',
+        'transition-opacity duration-150',
+        visible ? 'opacity-100' : 'opacity-0'
+      )}
+    >
+      <div
+        data-testid="place-progress"
+        className="h-full bg-brand-accent transition-[width] duration-150 ease-out"
+        style={{ width: `${(width * 100).toFixed(2)}%` }}
+      />
+    </div>
+  )
+}
+
+function progressWidth(phase: SubmissionPhase, success: boolean): number {
+  if (success) return 1
+  if (phase.kind === 'running') return phase.progress
+  return 0
+}
+
+export function StageReadout({ phase }: { phase: SubmissionPhase }) {
+  // Optional out-of-band readout for cases that want the textual stage
+  // label outside the button (Storybook variants, debugging surfaces).
+  if (phase.kind !== 'running') return null
+  return (
+    <span className="font-mono text-[10px] font-medium uppercase tracking-[0.2em] text-brand-muted">
+      {STAGE_LABELS[phase.stage as SubmitStageId]} …
+    </span>
+  )
+}

--- a/front/components/trade/entry/TotalRow.tsx
+++ b/front/components/trade/entry/TotalRow.tsx
@@ -1,0 +1,88 @@
+'use client'
+
+// Total + fee preview. Sits directly above the place button. The fee
+// line carries the protocol fee in basis points so users see what
+// they're paying (5 bps = 0.05% per DarkPool.sol PROTOCOL_FEE_BPS) and
+// the grand total reads as a single tabular number so callers stacked
+// in a column align on the decimal.
+
+import * as React from 'react'
+
+import { NumericText } from '../../NumericText'
+import { displayDecimalsFor } from '../balances/format-balance'
+
+import { computeFee, computeTotal } from './derive'
+import { FEE_BPS, QUOTE_TOKEN } from './policy'
+
+export interface TotalRowProps {
+  price: string
+  size: string
+}
+
+const FEE_DECIMALS = displayDecimalsFor(QUOTE_TOKEN)
+const TOTAL_DECIMALS = displayDecimalsFor(QUOTE_TOKEN)
+
+export function TotalRow({ price, size }: TotalRowProps) {
+  const total = computeTotal(price, size)
+  const totalStr = total?.toFixed() ?? ''
+  const feeStr = total ? computeFee(total).toFixed() : ''
+
+  return (
+    <dl
+      aria-label="Order preview"
+      className="flex flex-col gap-1 border border-brand-border bg-brand-surface px-3 py-2"
+    >
+      <Row
+        label={`FEE · ${FEE_BPS} BPS`}
+        valueNode={
+          <NumericText
+            value={feeStr}
+            decimals={FEE_DECIMALS}
+            kind="usd"
+            className="text-body-sm text-brand-fg"
+          />
+        }
+        unit={QUOTE_TOKEN}
+      />
+      <Row
+        label={`TOTAL`}
+        valueNode={
+          <NumericText
+            value={totalStr}
+            decimals={TOTAL_DECIMALS}
+            kind="usd"
+            className="text-body-sm text-brand-fg"
+          />
+        }
+        unit={QUOTE_TOKEN}
+      />
+    </dl>
+  )
+}
+
+function Row({
+  label,
+  valueNode,
+  unit,
+}: {
+  label: string
+  valueNode: React.ReactNode
+  unit: string
+}) {
+  return (
+    <div className="flex items-baseline justify-between gap-3">
+      <dt className="font-mono text-[10px] font-medium uppercase tracking-[0.2em] text-brand-muted">
+        {label}
+      </dt>
+      <dd className="flex items-baseline gap-2">
+        {valueNode}
+        <span
+          aria-hidden
+          className="font-mono text-[10px] font-medium uppercase tracking-[0.2em] text-brand-muted"
+        >
+          {unit}
+        </span>
+      </dd>
+    </div>
+  )
+}

--- a/front/components/trade/entry/TotalRow.tsx
+++ b/front/components/trade/entry/TotalRow.tsx
@@ -19,8 +19,12 @@ export interface TotalRowProps {
   size: string
 }
 
-const FEE_DECIMALS = displayDecimalsFor(QUOTE_TOKEN)
+// Total renders at the quote-token's display precision (USDC=2dp). Fee
+// renders at +2 extra dp so a 5-bps charge on a small trade like
+// $5 doesn't round visibly to "0.00" — at $5 the fee is $0.0025, which
+// surfaces as `0.0025 USDC`.
 const TOTAL_DECIMALS = displayDecimalsFor(QUOTE_TOKEN)
+const FEE_DECIMALS = TOTAL_DECIMALS + 2
 
 export function TotalRow({ price, size }: TotalRowProps) {
   const total = computeTotal(price, size)

--- a/front/components/trade/entry/derive.test.ts
+++ b/front/components/trade/entry/derive.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { computeFee, computeGrandTotal, computeTotal } from './derive'
+import { FEE_BPS } from './policy'
+
+describe('computeTotal', () => {
+  it('multiplies price * size as Decimal', () => {
+    const total = computeTotal('3000', '0.5')
+    expect(total).not.toBeNull()
+    expect(total!.toFixed()).toBe('1500')
+  })
+
+  it('preserves precision past JS float (0.1 * 0.2)', () => {
+    const total = computeTotal('0.1', '0.2')
+    expect(total!.toFixed()).toBe('0.02')
+  })
+
+  it('returns null for empty inputs', () => {
+    expect(computeTotal('', '1')).toBeNull()
+    expect(computeTotal('1', '')).toBeNull()
+    expect(computeTotal('  ', '1')).toBeNull()
+  })
+
+  it('returns null for non-numeric inputs', () => {
+    expect(computeTotal('abc', '1')).toBeNull()
+    expect(computeTotal('1', 'xyz')).toBeNull()
+  })
+
+  it('returns null when either side is negative', () => {
+    expect(computeTotal('-1', '1')).toBeNull()
+    expect(computeTotal('1', '-1')).toBeNull()
+  })
+})
+
+describe('computeFee', () => {
+  it('applies FEE_BPS = 5 (0.05%)', () => {
+    expect(FEE_BPS).toBe(5)
+    expect(computeFee('1000').toFixed()).toBe('0.5')
+    expect(computeFee('2000').toFixed()).toBe('1')
+  })
+
+  it('survives small totals without rounding to zero', () => {
+    // 5 bps of 0.01 = 0.000005 — keeps precision instead of clamping.
+    expect(computeFee('0.01').toFixed(8)).toBe('0.00000500')
+  })
+})
+
+describe('computeGrandTotal', () => {
+  it('returns total + fee', () => {
+    // price 3000 * size 0.5 = 1500; fee = 0.75; grand = 1500.75.
+    expect(computeGrandTotal('3000', '0.5')!.toFixed()).toBe('1500.75')
+  })
+
+  it('returns null when inputs are unparseable', () => {
+    expect(computeGrandTotal('', '0.5')).toBeNull()
+    expect(computeGrandTotal('3000', '')).toBeNull()
+    expect(computeGrandTotal('abc', '0.5')).toBeNull()
+  })
+})

--- a/front/components/trade/entry/derive.ts
+++ b/front/components/trade/entry/derive.ts
@@ -1,0 +1,45 @@
+// Pure decimal arithmetic for the order-entry preview. Everything passes
+// through Decimal so the wire-string contract from docs/adr/0002-decimals.md
+// is preserved end-to-end. Never use Number() or parseFloat here.
+
+import { Decimal, toDecimal, type DecimalInput } from '../../../lib/units'
+
+import { FEE_BPS } from './policy'
+
+const BPS_DIVISOR = new Decimal(10_000)
+
+/**
+ * Total in quote-token units: `price * size`. Returns null if either
+ * input is empty or non-numeric so the preview row can render a dash.
+ */
+export function computeTotal(price: string, size: string): Decimal | null {
+  if (!isParseable(price) || !isParseable(size)) return null
+  try {
+    const p = toDecimal(price)
+    const s = toDecimal(size)
+    if (p.isNegative() || s.isNegative()) return null
+    return p.times(s)
+  } catch {
+    return null
+  }
+}
+
+/** Protocol fee on a given total, charged at FEE_BPS. */
+export function computeFee(total: DecimalInput): Decimal {
+  return toDecimal(total).times(FEE_BPS).div(BPS_DIVISOR)
+}
+
+/**
+ * Grand total = total + fee. The trader pays this many quote tokens on a
+ * BUY and receives `total - fee` quote tokens on a SELL. The balance
+ * check (in validate.ts) consults the relevant side.
+ */
+export function computeGrandTotal(price: string, size: string): Decimal | null {
+  const total = computeTotal(price, size)
+  if (total === null) return null
+  return total.plus(computeFee(total))
+}
+
+function isParseable(value: string): boolean {
+  return typeof value === 'string' && value.trim() !== ''
+}

--- a/front/components/trade/entry/errors.ts
+++ b/front/components/trade/entry/errors.ts
@@ -1,0 +1,27 @@
+// Single source of truth for the inline error copy. Codes come from
+// validate.ts; the messages here follow the DESIGN-INSPIRATIONS tone:
+// informative, no apology, no exclamation.
+
+import { MIN_PRICE, MIN_SIZE, QUOTE_TOKEN } from './policy'
+import type { ValidationCode } from './validate'
+
+export function errorMessage(code: ValidationCode): string {
+  switch (code) {
+    case 'price-required':
+      return 'Enter a price.'
+    case 'price-invalid':
+      return 'Price must be a positive number.'
+    case 'price-below-min':
+      return `Price must be at least ${MIN_PRICE} ${QUOTE_TOKEN}.`
+    case 'size-required':
+      return 'Enter a size.'
+    case 'size-invalid':
+      return 'Size must be a positive number.'
+    case 'size-below-min':
+      return `Size must be at least ${MIN_SIZE}.`
+    case 'insufficient-balance':
+      return 'Insufficient balance.'
+    case 'wallet-disconnected':
+      return 'Connect a wallet to place orders.'
+  }
+}

--- a/front/components/trade/entry/index.ts
+++ b/front/components/trade/entry/index.ts
@@ -1,0 +1,33 @@
+export { OrderEntry, type OrderEntryHandle, type OrderEntryProps } from './OrderEntry'
+export { BuySellTabs } from './BuySellTabs'
+export { DecimalInput } from './inputs'
+export { TotalRow } from './TotalRow'
+export { PlaceButton } from './ProveSubmitStages'
+export { useOrderForm } from './useOrderForm'
+export {
+  useSubmitStages,
+  runSubmission,
+  type SubmissionPhase,
+  type SubmitPayload,
+} from './useSubmitStages'
+export {
+  validateOrder,
+  type OrderSide,
+  type ValidationCode,
+  type ValidationResult,
+} from './validate'
+export {
+  FEE_BPS,
+  MIN_PRICE,
+  MIN_SIZE,
+  BASE_TOKEN,
+  QUOTE_TOKEN,
+  STAGE_DURATIONS_MS,
+  STAGE_LABELS,
+  STAGE_ORDER,
+  STAGE_TOTAL_MS,
+  SUCCESS_HOLD_MS,
+  type SubmitStageId,
+} from './policy'
+export { errorMessage } from './errors'
+export { computeFee, computeGrandTotal, computeTotal } from './derive'

--- a/front/components/trade/entry/inputs.tsx
+++ b/front/components/trade/entry/inputs.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+// Labeled decimal inputs for price and size. The label sits above the
+// field (uppercase tracked) per the `input-text` + `input-label` pattern
+// in DESIGN.md. The suffix tag (`USDC`, `WETH`) sits inside the field on
+// the right, rendered in `label-md` muted so it reads as metadata.
+//
+// Values are strings the whole way through — never coerce to JS number.
+// `inputMode="decimal"` opens the right keypad on mobile without forcing
+// a numeric input (which would round / coerce).
+
+import * as React from 'react'
+
+import { cn } from '../../ui/cn'
+
+const DECIMAL_PATTERN = /^\d*\.?\d*$/
+
+export interface DecimalInputProps {
+  id: string
+  label: string
+  /** Suffix tag rendered inside the field (e.g. "USDC"). */
+  unit?: string
+  value: string
+  onChange: (next: string) => void
+  placeholder?: string
+  disabled?: boolean
+  errorId?: string
+  invalid?: boolean
+  /**
+   * Optional control rendered inside the right end of the field. Used
+   * for the SizeInput MAX shortcut.
+   */
+  rightSlot?: React.ReactNode
+}
+
+export const DecimalInput = React.forwardRef<HTMLInputElement, DecimalInputProps>(
+  function DecimalInput(
+    { id, label, unit, value, onChange, placeholder, disabled, errorId, invalid, rightSlot },
+    ref
+  ) {
+    const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+      const next = event.target.value
+      // Reject anything that isn't a partial decimal so we don't push
+      // mangled strings down to Decimal.js on every keystroke.
+      if (next === '' || DECIMAL_PATTERN.test(next)) onChange(next)
+    }
+
+    return (
+      <div className="flex flex-col gap-1">
+        <label
+          htmlFor={id}
+          className="font-mono text-[10px] font-medium uppercase tracking-[0.2em] text-brand-muted"
+        >
+          {label}
+        </label>
+        <div
+          className={cn(
+            'relative flex h-10 items-stretch border bg-brand-surface',
+            invalid ? 'border-brand-border2' : 'border-brand-border',
+            'focus-within:border-brand-accent',
+            disabled && 'opacity-60'
+          )}
+        >
+          <input
+            ref={ref}
+            id={id}
+            type="text"
+            inputMode="decimal"
+            autoComplete="off"
+            spellCheck={false}
+            value={value}
+            onChange={handleChange}
+            disabled={disabled}
+            placeholder={placeholder}
+            aria-invalid={invalid || undefined}
+            aria-describedby={errorId}
+            className={cn(
+              'flex-1 bg-transparent px-3 font-mono tabular-nums text-[12px] leading-[1.8] text-brand-fg',
+              'placeholder:text-brand-muted',
+              'focus:outline-none',
+              'disabled:cursor-not-allowed'
+            )}
+          />
+          {(rightSlot || unit) && (
+            <div className="flex shrink-0 items-center gap-2 pr-3">
+              {rightSlot}
+              {unit && (
+                <span
+                  aria-hidden
+                  className="font-mono text-[10px] font-medium uppercase tracking-[0.2em] text-brand-muted"
+                >
+                  {unit}
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+  }
+)

--- a/front/components/trade/entry/policy.ts
+++ b/front/components/trade/entry/policy.ts
@@ -1,0 +1,69 @@
+// Policy constants for the order-entry form.
+//
+// The values here are Phase 1 defaults that future issues (#83 pair
+// registry, #99 real placement) will replace by reading the live policy
+// off the pair-registry RPC. Keep this file the single import point for
+// every constant the form references so the swap stays a one-line change.
+
+import type { TokenSymbol } from '../../../lib/wallet/types'
+
+/**
+ * Protocol fee, in basis points. Mirrors `DarkPool.sol::PROTOCOL_FEE_BPS`
+ * (5 bps = 0.05%). Quoted on the trader-paid side of the trade.
+ */
+export const FEE_BPS = 5
+
+/** Lowest accepted limit price, in quote-token units (USDC). */
+export const MIN_PRICE = '0.01'
+
+/** Lowest accepted size, in base-token units (WETH). */
+export const MIN_SIZE = '0.0001'
+
+/**
+ * Default ETH/USDC pair the form trades. Multi-pair is gated on backend
+ * issue #29 — until then this is constant.
+ */
+export const BASE_TOKEN: TokenSymbol = 'WETH'
+export const QUOTE_TOKEN: TokenSymbol = 'USDC'
+
+/**
+ * Stage durations for the mock submission pipeline. F1.12 (#79) reuses
+ * the same stage IDs for onboarding copy, so renaming is a coordinated
+ * change across both panels.
+ */
+export const STAGE_DURATIONS_MS = {
+  preparing: 500,
+  proving: 2000,
+  encrypting: 200,
+  submitting: 300,
+} as const
+
+export type SubmitStageId = keyof typeof STAGE_DURATIONS_MS
+
+/**
+ * Stage IDs in execution order. The progress bar weights each stage by
+ * its duration so the bar moves at a constant pixel rate.
+ */
+export const STAGE_ORDER: readonly SubmitStageId[] = [
+  'preparing',
+  'proving',
+  'encrypting',
+  'submitting',
+] as const
+
+/** Total stage duration. Used by the progress bar normalisation. */
+export const STAGE_TOTAL_MS = STAGE_ORDER.reduce((sum, id) => sum + STAGE_DURATIONS_MS[id], 0)
+
+/**
+ * Uppercase tracked labels for each stage. Matches the DESIGN.md tone:
+ * informative, no exclamation, no marketing voice.
+ */
+export const STAGE_LABELS: Record<SubmitStageId, string> = {
+  preparing: 'PREPARING WITNESS',
+  proving: 'GENERATING PROOF',
+  encrypting: 'ENCRYPTING',
+  submitting: 'SUBMITTING',
+}
+
+/** Brief flash after a successful submission before the form resets. */
+export const SUCCESS_HOLD_MS = 800

--- a/front/components/trade/entry/useOrderForm.ts
+++ b/front/components/trade/entry/useOrderForm.ts
@@ -1,0 +1,81 @@
+'use client'
+
+// Form state for the order-entry panel. Holds the controlled side /
+// price / size strings and exposes a `setPrice(price, side?)` setter
+// the orderbook's click-to-fill flow can call from outside.
+//
+// Validation is derived (not stored) so it stays in sync with whatever
+// the latest balances are without an extra effect. Balance changes
+// triggered by the mock store (auctions clearing, deposits) re-render
+// the panel and the derived `errors` follow.
+
+import { useCallback, useMemo, useState } from 'react'
+
+import { validateOrder, type OrderSide, type ValidationResult } from './validate'
+
+export interface OrderFormState {
+  side: OrderSide
+  price: string
+  size: string
+}
+
+export interface UseOrderFormParams {
+  /** Internal WETH balance (decimal string). */
+  baseBalance: string
+  /** Internal USDC balance (decimal string). */
+  quoteBalance: string
+  isConnected: boolean
+  initial?: Partial<OrderFormState>
+}
+
+export interface UseOrderFormResult extends OrderFormState {
+  setSide: (next: OrderSide) => void
+  setPrice: (next: string) => void
+  setSize: (next: string) => void
+  /** Set price and (optionally) side in one go. Used by click-to-fill. */
+  fillFromLevel: (price: string, side?: OrderSide) => void
+  reset: () => void
+  validation: ValidationResult
+}
+
+export function useOrderForm(params: UseOrderFormParams): UseOrderFormResult {
+  const [side, setSide] = useState<OrderSide>(params.initial?.side ?? 'buy')
+  const [price, setPrice] = useState(params.initial?.price ?? '')
+  const [size, setSize] = useState(params.initial?.size ?? '')
+
+  const fillFromLevel = useCallback((nextPrice: string, nextSide?: OrderSide) => {
+    setPrice(nextPrice)
+    if (nextSide) setSide(nextSide)
+  }, [])
+
+  const reset = useCallback(() => {
+    setSize('')
+    // Keep `price` and `side` — the user usually places a series of orders
+    // around the same level, and clearing them every time wastes input.
+  }, [])
+
+  const validation = useMemo(
+    () =>
+      validateOrder({
+        side,
+        price,
+        size,
+        baseBalance: params.baseBalance,
+        quoteBalance: params.quoteBalance,
+        isConnected: params.isConnected,
+      }),
+    [side, price, size, params.baseBalance, params.quoteBalance, params.isConnected]
+  )
+
+  return {
+    side,
+    price,
+    size,
+    setSide,
+    setPrice,
+    setSize,
+    fillFromLevel,
+    reset,
+    validation,
+  }
+}

--- a/front/components/trade/entry/useSubmitStages.test.ts
+++ b/front/components/trade/entry/useSubmitStages.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { STAGE_DURATIONS_MS, STAGE_ORDER, STAGE_TOTAL_MS, SUCCESS_HOLD_MS } from './policy'
+import {
+  progressAtEndOfStage,
+  progressAtStartOfStage,
+  runSubmission,
+  type SubmissionPhase,
+  type SubmitPayload,
+} from './useSubmitStages'
+
+const PAYLOAD: SubmitPayload = { side: 'buy', price: '3000', size: '0.5' }
+
+function instant(): (ms: number) => Promise<void> {
+  return async () => {}
+}
+
+function record(phases: SubmissionPhase[]) {
+  return (phase: SubmissionPhase) => {
+    phases.push(phase)
+  }
+}
+
+describe('progress helpers', () => {
+  it('progressAtStartOfStage returns 0 for the first stage and a value < 1 for the rest', () => {
+    expect(progressAtStartOfStage('preparing')).toBe(0)
+    for (const stage of STAGE_ORDER) {
+      expect(progressAtStartOfStage(stage)).toBeGreaterThanOrEqual(0)
+      expect(progressAtStartOfStage(stage)).toBeLessThan(1)
+    }
+  })
+
+  it('progressAtEndOfStage returns 1 for the last stage', () => {
+    expect(progressAtEndOfStage('submitting')).toBe(1)
+  })
+
+  it('progress is monotonically non-decreasing across stage order', () => {
+    let last = -1
+    for (const stage of STAGE_ORDER) {
+      const start = progressAtStartOfStage(stage)
+      const end = progressAtEndOfStage(stage)
+      expect(start).toBeGreaterThanOrEqual(last)
+      expect(end).toBeGreaterThanOrEqual(start)
+      last = end
+    }
+  })
+
+  it('stage durations sum to STAGE_TOTAL_MS', () => {
+    const total = STAGE_ORDER.reduce((sum, id) => sum + STAGE_DURATIONS_MS[id], 0)
+    expect(total).toBe(STAGE_TOTAL_MS)
+  })
+})
+
+describe('runSubmission', () => {
+  it('emits each stage transition in order, then success, then idle', async () => {
+    const phases: SubmissionPhase[] = []
+    const placeOrder = vi.fn()
+
+    await runSubmission(PAYLOAD, {
+      placeOrder,
+      delay: instant(),
+      onPhase: record(phases),
+    })
+
+    // Two `running` emissions per stage (start + end), then success, then idle.
+    const running = phases.filter((p) => p.kind === 'running') as Extract<
+      SubmissionPhase,
+      { kind: 'running' }
+    >[]
+    expect(running.map((p) => p.stage)).toEqual([
+      'preparing',
+      'preparing',
+      'proving',
+      'proving',
+      'encrypting',
+      'encrypting',
+      'submitting',
+      'submitting',
+    ])
+
+    const terminal = phases.slice(-2)
+    expect(terminal[0].kind).toBe('success')
+    expect(terminal[1].kind).toBe('idle')
+  })
+
+  it('calls placeOrder exactly once, during the submitting stage', async () => {
+    const placeOrder = vi.fn()
+    let placeOrderCallOrder = -1
+    let nextOrder = 0
+    const onPhase = vi.fn((phase: SubmissionPhase) => {
+      nextOrder += 1
+      if (phase.kind === 'running' && phase.stage === 'submitting' && placeOrderCallOrder === -1) {
+        // First entry into submitting — placeOrder should already have been
+        // recorded against the next call (the orchestrator awaits placeOrder
+        // before the stage-duration delay).
+      }
+    })
+
+    placeOrder.mockImplementation(() => {
+      placeOrderCallOrder = nextOrder
+    })
+
+    await runSubmission(PAYLOAD, {
+      placeOrder,
+      delay: instant(),
+      onPhase,
+    })
+
+    expect(placeOrder).toHaveBeenCalledTimes(1)
+    expect(placeOrder).toHaveBeenCalledWith(PAYLOAD)
+  })
+
+  it('emits an error phase when placeOrder throws', async () => {
+    const phases: SubmissionPhase[] = []
+    const placeOrder = vi.fn(() => {
+      throw new Error('insufficient liquidity')
+    })
+
+    await runSubmission(PAYLOAD, {
+      placeOrder,
+      delay: instant(),
+      onPhase: record(phases),
+    })
+
+    const terminal = phases[phases.length - 1]
+    expect(terminal.kind).toBe('error')
+    if (terminal.kind === 'error') {
+      expect(terminal.message).toBe('insufficient liquidity')
+    }
+    // No success/idle should follow an error.
+    expect(phases.filter((p) => p.kind === 'success')).toHaveLength(0)
+  })
+
+  it('emits an error phase when placeOrder rejects asynchronously', async () => {
+    const phases: SubmissionPhase[] = []
+    const placeOrder = vi.fn(async () => {
+      throw new Error('rejected by engine')
+    })
+
+    await runSubmission(PAYLOAD, {
+      placeOrder,
+      delay: instant(),
+      onPhase: record(phases),
+    })
+
+    const terminal = phases[phases.length - 1]
+    expect(terminal.kind).toBe('error')
+  })
+
+  it('aborts before the next emission when shouldAbort returns true', async () => {
+    const phases: SubmissionPhase[] = []
+    const placeOrder = vi.fn()
+    let count = 0
+
+    await runSubmission(PAYLOAD, {
+      placeOrder,
+      delay: instant(),
+      shouldAbort: () => {
+        // Abort after the first running phase has been emitted.
+        count += 1
+        return count > 1
+      },
+      onPhase: record(phases),
+    })
+
+    // The run aborts before reaching the submitting stage, so placeOrder is
+    // never called.
+    expect(placeOrder).not.toHaveBeenCalled()
+    // No terminal phase (success / error) is emitted on abort.
+    expect(phases.some((p) => p.kind === 'success' || p.kind === 'error')).toBe(false)
+  })
+
+  it('delays each stage by STAGE_DURATIONS_MS[stage]', async () => {
+    const phases: SubmissionPhase[] = []
+    const placeOrder = vi.fn()
+    const delays: number[] = []
+    const delay = async (ms: number) => {
+      delays.push(ms)
+    }
+
+    await runSubmission(PAYLOAD, {
+      placeOrder,
+      delay,
+      onPhase: record(phases),
+    })
+
+    // One delay per stage + SUCCESS_HOLD_MS.
+    expect(delays).toEqual([
+      STAGE_DURATIONS_MS.preparing,
+      STAGE_DURATIONS_MS.proving,
+      STAGE_DURATIONS_MS.encrypting,
+      STAGE_DURATIONS_MS.submitting,
+      SUCCESS_HOLD_MS,
+    ])
+  })
+})

--- a/front/components/trade/entry/useSubmitStages.ts
+++ b/front/components/trade/entry/useSubmitStages.ts
@@ -17,7 +17,7 @@
 //   - `delay`:      defaults to setTimeout-based sleep; tests pass a
 //                   manually-pumped scheduler.
 
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 import {
   STAGE_DURATIONS_MS,
@@ -132,7 +132,10 @@ export function useSubmitStages(params: UseSubmitStagesParams): UseSubmitStagesR
   const [phase, setPhase] = useState<SubmissionPhase>({ kind: 'idle' })
   const runIdRef = useRef(0)
   const paramsRef = useRef(params)
-  useEffect(() => {
+  // useLayoutEffect over useEffect so paramsRef is current before any
+  // post-commit click handler can call submit() — useEffect would leave
+  // a one-render window where stale params are visible.
+  useLayoutEffect(() => {
     paramsRef.current = params
   })
 

--- a/front/components/trade/entry/useSubmitStages.ts
+++ b/front/components/trade/entry/useSubmitStages.ts
@@ -1,0 +1,167 @@
+'use client'
+
+// Drives the multi-stage mock submission (PREPARING WITNESS → GENERATING
+// PROOF → ENCRYPTING → SUBMITTING → success/error). The same state shape
+// will be reused by F1.12 (#79) onboarding so the stage IDs are stable.
+//
+// The orchestration runs inside `runSubmission` — a pure async function
+// that emits each phase transition to an `onPhase` callback. The hook
+// itself is a thin wrapper that pipes those emissions into React state.
+// That split lets unit tests drive the state machine without a DOM and
+// without React Testing Library (the project's vitest setup is
+// node-only).
+//
+// Two dependencies are injected so tests can run synchronously and the
+// real submission path can be swapped in Phase 2:
+//   - `placeOrder`: mock-store mutation today, real RPC after #99.
+//   - `delay`:      defaults to setTimeout-based sleep; tests pass a
+//                   manually-pumped scheduler.
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import {
+  STAGE_DURATIONS_MS,
+  STAGE_ORDER,
+  STAGE_TOTAL_MS,
+  SUCCESS_HOLD_MS,
+  type SubmitStageId,
+} from './policy'
+
+export type SubmissionPhase =
+  | { kind: 'idle' }
+  | { kind: 'running'; stage: SubmitStageId; progress: number }
+  | { kind: 'success' }
+  | { kind: 'error'; message: string }
+
+export interface SubmitPayload {
+  side: 'buy' | 'sell'
+  price: string
+  size: string
+}
+
+export interface SubmissionDeps {
+  placeOrder: (payload: SubmitPayload) => void | Promise<void>
+  /** Returns a promise that resolves after `ms`. Defaults to setTimeout. */
+  delay?: (ms: number) => Promise<void>
+}
+
+export interface RunSubmissionOptions extends SubmissionDeps {
+  onPhase: (phase: SubmissionPhase) => void
+  /**
+   * `true` aborts the run between awaits. Used by the hook to drop
+   * stale runs when `submit` fires while another run is still in flight.
+   */
+  shouldAbort?: () => boolean
+}
+
+export function progressAtStartOfStage(stage: SubmitStageId): number {
+  let elapsed = 0
+  for (const id of STAGE_ORDER) {
+    if (id === stage) break
+    elapsed += STAGE_DURATIONS_MS[id]
+  }
+  return elapsed / STAGE_TOTAL_MS
+}
+
+export function progressAtEndOfStage(stage: SubmitStageId): number {
+  let elapsed = 0
+  for (const id of STAGE_ORDER) {
+    elapsed += STAGE_DURATIONS_MS[id]
+    if (id === stage) break
+  }
+  return elapsed / STAGE_TOTAL_MS
+}
+
+const defaultDelay = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
+
+/**
+ * Pure orchestrator. Emits each phase change through `onPhase` and
+ * resolves once the run lands on a terminal state (success / error) and
+ * the post-success hold has elapsed.
+ */
+export async function runSubmission(
+  payload: SubmitPayload,
+  opts: RunSubmissionOptions
+): Promise<void> {
+  const delay = opts.delay ?? defaultDelay
+  const aborted = () => (opts.shouldAbort ? opts.shouldAbort() : false)
+
+  try {
+    for (const stage of STAGE_ORDER) {
+      if (aborted()) return
+      opts.onPhase({ kind: 'running', stage, progress: progressAtStartOfStage(stage) })
+
+      // placeOrder runs at the start of the SUBMIT stage so the
+      // mock-store mutation lands while the user still sees the
+      // "SUBMITTING" label. A synchronous throw surfaces here.
+      if (stage === 'submitting') {
+        await Promise.resolve(opts.placeOrder(payload))
+      }
+
+      await delay(STAGE_DURATIONS_MS[stage])
+      if (aborted()) return
+      opts.onPhase({ kind: 'running', stage, progress: progressAtEndOfStage(stage) })
+    }
+
+    if (aborted()) return
+    opts.onPhase({ kind: 'success' })
+
+    await delay(SUCCESS_HOLD_MS)
+    if (aborted()) return
+    opts.onPhase({ kind: 'idle' })
+  } catch (err) {
+    if (aborted()) return
+    const message = err instanceof Error ? err.message : String(err)
+    opts.onPhase({ kind: 'error', message })
+  }
+}
+
+export interface UseSubmitStagesParams extends SubmissionDeps {
+  onSuccess?: (payload: SubmitPayload) => void
+  onError?: (error: Error) => void
+}
+
+export interface UseSubmitStagesResult {
+  phase: SubmissionPhase
+  isRunning: boolean
+  submit: (payload: SubmitPayload) => Promise<void>
+  reset: () => void
+}
+
+export function useSubmitStages(params: UseSubmitStagesParams): UseSubmitStagesResult {
+  const [phase, setPhase] = useState<SubmissionPhase>({ kind: 'idle' })
+  const runIdRef = useRef(0)
+  const paramsRef = useRef(params)
+  useEffect(() => {
+    paramsRef.current = params
+  })
+
+  const reset = useCallback(() => {
+    runIdRef.current += 1
+    setPhase({ kind: 'idle' })
+  }, [])
+
+  const submit = useCallback(async (payload: SubmitPayload) => {
+    const myRunId = ++runIdRef.current
+    const isStale = () => runIdRef.current !== myRunId
+
+    await runSubmission(payload, {
+      placeOrder: paramsRef.current.placeOrder,
+      delay: paramsRef.current.delay,
+      shouldAbort: isStale,
+      onPhase: (next) => {
+        if (isStale()) return
+        setPhase(next)
+        if (next.kind === 'success') paramsRef.current.onSuccess?.(payload)
+        if (next.kind === 'error') paramsRef.current.onError?.(new Error(next.message))
+      },
+    })
+  }, [])
+
+  return {
+    phase,
+    isRunning: phase.kind === 'running',
+    submit,
+    reset,
+  }
+}

--- a/front/components/trade/entry/validate.test.ts
+++ b/front/components/trade/entry/validate.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateOrder, type ValidationInput } from './validate'
+
+const baseInput: ValidationInput = {
+  side: 'buy',
+  price: '3000',
+  size: '0.5',
+  baseBalance: '10',
+  quoteBalance: '25000',
+  isConnected: true,
+}
+
+describe('validateOrder', () => {
+  it('reports ok for a valid buy with sufficient quote balance', () => {
+    const result = validateOrder(baseInput)
+    expect(result.ok).toBe(true)
+    expect(result.errors).toEqual({})
+  })
+
+  it('reports ok for a valid sell with sufficient base balance', () => {
+    const result = validateOrder({ ...baseInput, side: 'sell' })
+    expect(result.ok).toBe(true)
+  })
+
+  it('flags wallet-disconnected before anything else', () => {
+    const result = validateOrder({ ...baseInput, isConnected: false })
+    expect(result.ok).toBe(false)
+    expect(result.errors.form).toBe('wallet-disconnected')
+  })
+
+  it('flags missing price as price-required (not invalid)', () => {
+    const result = validateOrder({ ...baseInput, price: '' })
+    expect(result.ok).toBe(false)
+    expect(result.errors.price).toBe('price-required')
+  })
+
+  it('flags missing size as size-required', () => {
+    const result = validateOrder({ ...baseInput, size: '   ' })
+    expect(result.ok).toBe(false)
+    expect(result.errors.size).toBe('size-required')
+  })
+
+  it('flags non-numeric price as price-invalid', () => {
+    const result = validateOrder({ ...baseInput, price: 'abc' })
+    expect(result.errors.price).toBe('price-invalid')
+  })
+
+  it('flags zero/negative size as size-invalid', () => {
+    expect(validateOrder({ ...baseInput, size: '0' }).errors.size).toBe('size-invalid')
+    expect(validateOrder({ ...baseInput, size: '-1' }).errors.size).toBe('size-invalid')
+  })
+
+  it('flags price below MIN_PRICE', () => {
+    const result = validateOrder({ ...baseInput, price: '0.0001' })
+    expect(result.errors.price).toBe('price-below-min')
+  })
+
+  it('flags size below MIN_SIZE', () => {
+    const result = validateOrder({ ...baseInput, size: '0.00001' })
+    expect(result.errors.size).toBe('size-below-min')
+  })
+
+  it('flags insufficient quote balance on BUY (fee included)', () => {
+    // price 3000 * size 8 = 24000; fee 12; grand 24012 > balance 24000.
+    const result = validateOrder({
+      ...baseInput,
+      price: '3000',
+      size: '8',
+      quoteBalance: '24000',
+    })
+    expect(result.ok).toBe(false)
+    expect(result.errors.form).toBe('insufficient-balance')
+  })
+
+  it('allows BUY when grand total equals balance exactly', () => {
+    // price 100 * size 10 = 1000; fee 0.5; grand 1000.5.
+    const result = validateOrder({
+      ...baseInput,
+      price: '100',
+      size: '10',
+      quoteBalance: '1000.5',
+    })
+    expect(result.ok).toBe(true)
+  })
+
+  it('flags insufficient base balance on SELL (size > base balance)', () => {
+    const result = validateOrder({
+      ...baseInput,
+      side: 'sell',
+      size: '20',
+      baseBalance: '10',
+    })
+    expect(result.ok).toBe(false)
+    expect(result.errors.form).toBe('insufficient-balance')
+  })
+
+  it('does not double-stack insufficient-balance on top of wallet-disconnected', () => {
+    const result = validateOrder({
+      ...baseInput,
+      isConnected: false,
+      quoteBalance: '0',
+    })
+    expect(result.errors.form).toBe('wallet-disconnected')
+  })
+
+  it('does not run balance check while a field error is still pending', () => {
+    // Empty size — no balance check should run, no insufficient-balance.
+    const result = validateOrder({ ...baseInput, size: '', quoteBalance: '0' })
+    expect(result.errors.size).toBe('size-required')
+    expect(result.errors.form).toBeUndefined()
+  })
+})

--- a/front/components/trade/entry/validate.ts
+++ b/front/components/trade/entry/validate.ts
@@ -1,0 +1,139 @@
+// Pure validation for the order-entry form. Returns a discriminated
+// result so the UI can pick which inline error to surface and the
+// PlaceButton can decide whether to enable.
+//
+// Validation runs on every keystroke (cheap — no async, no allocations
+// past a couple of Decimals) and re-runs at submit time so a stale form
+// can't slip through. Errors are coded so copy lives in one place.
+
+import { Decimal, toDecimal } from '../../../lib/units'
+
+import { computeGrandTotal } from './derive'
+import { MIN_PRICE, MIN_SIZE } from './policy'
+
+export type OrderSide = 'buy' | 'sell'
+
+export type ValidationCode =
+  | 'price-required'
+  | 'price-invalid'
+  | 'price-below-min'
+  | 'size-required'
+  | 'size-invalid'
+  | 'size-below-min'
+  | 'insufficient-balance'
+  | 'wallet-disconnected'
+
+export interface ValidationErrors {
+  price?: ValidationCode
+  size?: ValidationCode
+  /** Cross-cutting issues that aren't bound to a single field. */
+  form?: ValidationCode
+}
+
+export interface ValidationInput {
+  side: OrderSide
+  price: string
+  size: string
+  /** Internal (DarkPool) balance of WETH. Decimal string. */
+  baseBalance: string
+  /** Internal (DarkPool) balance of USDC. Decimal string. */
+  quoteBalance: string
+  isConnected: boolean
+}
+
+export interface ValidationResult {
+  ok: boolean
+  errors: ValidationErrors
+}
+
+const MIN_PRICE_DEC = new Decimal(MIN_PRICE)
+const MIN_SIZE_DEC = new Decimal(MIN_SIZE)
+
+/**
+ * Validate a form snapshot. Empty strings yield required errors (not
+ * `invalid`) so the user gets a stable placeholder while typing.
+ *
+ * Balance check semantics:
+ *   - BUY  costs `price * size * (1 + fee)` in quote (USDC). The user
+ *     must hold that much USDC inside the pool.
+ *   - SELL costs `size` in base (WETH). The user must hold that much
+ *     WETH inside the pool. The fee is collected from the quote
+ *     proceeds, not from base — so the base check is purely on size.
+ */
+export function validateOrder(input: ValidationInput): ValidationResult {
+  const errors: ValidationErrors = {}
+
+  if (!input.isConnected) {
+    errors.form = 'wallet-disconnected'
+  }
+
+  const priceCode = validateField(input.price, MIN_PRICE_DEC, {
+    required: 'price-required',
+    invalid: 'price-invalid',
+    belowMin: 'price-below-min',
+  })
+  if (priceCode) errors.price = priceCode
+
+  const sizeCode = validateField(input.size, MIN_SIZE_DEC, {
+    required: 'size-required',
+    invalid: 'size-invalid',
+    belowMin: 'size-below-min',
+  })
+  if (sizeCode) errors.size = sizeCode
+
+  if (!errors.price && !errors.size) {
+    if (!checkBalance(input)) {
+      errors.form = errors.form ?? 'insufficient-balance'
+    }
+  }
+
+  return { ok: Object.keys(errors).length === 0, errors }
+}
+
+function validateField(
+  raw: string,
+  min: Decimal,
+  codes: { required: ValidationCode; invalid: ValidationCode; belowMin: ValidationCode }
+): ValidationCode | undefined {
+  if (typeof raw !== 'string' || raw.trim() === '') return codes.required
+  let d: Decimal
+  try {
+    d = toDecimal(raw)
+  } catch {
+    return codes.invalid
+  }
+  if (!d.isFinite() || d.isNegative() || d.isZero()) return codes.invalid
+  if (d.lt(min)) return codes.belowMin
+  return undefined
+}
+
+function checkBalance(input: ValidationInput): boolean {
+  // Skip the balance check when the wallet is disconnected — that case
+  // is already represented by `wallet-disconnected` and we don't want
+  // a misleading "insufficient balance" error stacking on top.
+  if (!input.isConnected) return true
+
+  if (input.side === 'buy') {
+    const grand = computeGrandTotal(input.price, input.size)
+    if (grand === null) return true
+    return safeLte(grand, input.quoteBalance)
+  }
+  // sell
+  let size: Decimal
+  try {
+    size = toDecimal(input.size)
+  } catch {
+    return true
+  }
+  return safeLte(size, input.baseBalance)
+}
+
+function safeLte(value: Decimal, balanceRaw: string): boolean {
+  let balance: Decimal
+  try {
+    balance = toDecimal(balanceRaw)
+  } catch {
+    return false
+  }
+  return value.lte(balance)
+}


### PR DESCRIPTION
Closes #76

## Summary

Adds the order-entry panel inside `front/components/trade/entry/`:

- **`OrderEntry.tsx`** — composition root. Wires the panel against the
  mock wallet store (#70) for `isConnected` + internal balances, and
  pushes placed orders into the mock store (#69) where they immediately
  appear in the orderbook (#73) and my-orders (#77, when it lands).
- **`BuySellTabs.tsx`** — segmented control. No semantic hue; the
  active option lifts text to `primary` and border to `outline-variant`.
- **`inputs.tsx`** — labeled decimal input (`PriceInput` / `SizeInput`
  share a primitive). Inputs only accept partial-decimal strings and
  never coerce through `Number(...)` — math runs end-to-end through
  `decimal.js` per ADR 0002.
- **`TotalRow.tsx`** — total + 5-bps fee preview, matching
  `DarkPool.sol::PROTOCOL_FEE_BPS`.
- **`ProveSubmitStages.tsx`** — `PlaceButton` whose label mutates
  through the 4 stages with a 2px lime progress bar underneath. No
  modal stacking (per DESIGN-INSPIRATIONS).
- **`useOrderForm.ts`** — controlled form state + derived validation.
- **`useSubmitStages.ts`** — pure `runSubmission(...)` orchestrator
  emitting phase transitions, plus the React hook on top. Stage IDs
  are stable so F1.12 (#79) onboarding can reuse them.
- **`validate.ts`** / **`derive.ts`** / **`policy.ts`** / **`errors.ts`**
  — pure helpers; constants live in one place so swapping mock policy
  for the real pair-registry feed (#83) is a one-line change.
- **`OrderEntry.stories.tsx`** — Ladle coverage: `Disconnected`,
  `Connected`, `ClickToFill`, `InstantSubmit` (stubbed `placeOrder`),
  plus primitive variants for the tabs / inputs / and a static gallery
  of the `PlaceButton` across all submission phases.

### Stage timings

| Stage      | Duration | Label                |
|------------|---------:|----------------------|
| preparing  |    500ms | `PREPARING WITNESS`  |
| proving    |  2,000ms | `GENERATING PROOF`   |
| encrypting |    200ms | `ENCRYPTING`         |
| submitting |    300ms | `SUBMITTING`         |

`placeOrder` runs at the start of the SUBMIT stage so the mock-store
mutation lands while the user still sees the `SUBMITTING` label. A
sync or async throw inside `placeOrder` surfaces as the `error` phase.

### Click-to-fill

The orderbook (#73) already exposes `onPriceSelect(price, side)`.
`OrderEntry` exposes an imperative `fill(price, side?)` handle via
`forwardRef`:

```tsx
const ref = React.useRef<OrderEntryHandle>(null)
<OrderBook onPriceSelect={(p, s) => ref.current?.fill(p, sideOf(s))} />
<OrderEntry ref={ref} />
```

The wiring lives wherever Shell.tsx renders both. Shell.tsx is out of
this issue's file scope, so the integration is a tiny follow-up.

### Out of scope (intentional)

- **Shell.tsx wiring.** The `MobileOrderEntryDock` placeholder and the
  desktop `OrderEntryPanel` slot still read their `F1.9` stubs. A
  follow-up PR owns Shell.
- **Funded internal balance demo.** The wallet mock (#70) has no
  balance-mutation API in Phase 1; F1.5 (#72) ships deposit/withdraw.
  Until that lands `connect()` keeps internal balances at zero, which
  the form correctly flags as `Insufficient balance.` Ladle's
  `InstantSubmit` story stubs `placeOrder` so the success path is
  reviewable today.

## Verification

- `npm test` → 214 passed (41 new under `components/trade/entry/`)
- `npm run typecheck` → no errors
- `npm run lint` → no issues
- `npm run format:check` → clean
- `npm run build` → succeeds
- `npx ladle build` → succeeds; all stories compile

## Test plan

- [ ] `npm test` clean
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean
- [ ] `npm run build` clean
- [ ] Ladle visual review of `OrderEntry / Disconnected | Connected |
      ClickToFill | InstantSubmit` and `PlaceButtonStages`
- [ ] After merge, follow-up wires `OrderEntry` into `Shell.tsx`
      (out of this issue's file scope)