### PR TITLE
[F1.5] Deposit/withdraw modals (mock)

### DIFF
--- a/front/components/trade/deposit/DepositForm.stories.tsx
+++ b/front/components/trade/deposit/DepositForm.stories.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react'
+
+import { walletStore } from '../../../lib/wallet/mock-store'
+
+import { DepositForm } from './DepositForm'
+
+// Stories render the form body in isolation. Modals are exercised in
+// the dedicated DepositModal / WithdrawModal / DepositTriggers stories
+// so reviewers can scrub through every interaction state without
+// the modal chrome stealing focus.
+
+function useWalletScenario({
+  connected,
+  paused,
+  allowance,
+  internal,
+}: {
+  connected: boolean
+  paused?: boolean
+  allowance?: { weth?: string; usdc?: string }
+  internal?: { weth?: string; usdc?: string }
+}) {
+  React.useEffect(() => {
+    walletStore.resetTxState()
+    if (connected) walletStore.connect()
+    else walletStore.disconnect()
+    if (allowance?.weth) walletStore.approve('WETH', allowance.weth)
+    if (allowance?.usdc) walletStore.approve('USDC', allowance.usdc)
+    // Seed a fake internal balance through the public mutators for the
+    // "ready to withdraw" stories — we deposit and immediately drain
+    // the allowance so the user sees a non-zero darkpool balance.
+    if (internal?.weth) {
+      walletStore.approve('WETH', internal.weth)
+      walletStore.deposit('WETH', internal.weth)
+    }
+    if (internal?.usdc) {
+      walletStore.approve('USDC', internal.usdc)
+      walletStore.deposit('USDC', internal.usdc)
+    }
+    if (paused) walletStore.setPaused(true)
+    return () => {
+      walletStore.disconnect()
+      walletStore.resetTxState()
+    }
+  }, [connected, paused, allowance?.weth, allowance?.usdc, internal?.weth, internal?.usdc])
+}
+
+function StoryFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto w-full max-w-md border border-brand-border bg-brand-surface p-8">
+      {children}
+    </div>
+  )
+}
+
+export const Disconnected = () => {
+  useWalletScenario({ connected: false })
+  return (
+    <StoryFrame>
+      <DepositForm initialToken="USDC" />
+    </StoryFrame>
+  )
+}
+
+export const ConnectedNoAllowance = () => {
+  useWalletScenario({ connected: true })
+  return (
+    <StoryFrame>
+      <DepositForm initialToken="USDC" />
+    </StoryFrame>
+  )
+}
+
+export const ConnectedWithAllowance = () => {
+  useWalletScenario({ connected: true, allowance: { usdc: '1000' } })
+  return (
+    <StoryFrame>
+      <DepositForm initialToken="USDC" />
+    </StoryFrame>
+  )
+}
+
+export const Paused = () => {
+  useWalletScenario({ connected: true, paused: true })
+  return (
+    <StoryFrame>
+      <DepositForm initialToken="USDC" />
+    </StoryFrame>
+  )
+}
+
+export const WETHPath = () => {
+  useWalletScenario({ connected: true })
+  return (
+    <StoryFrame>
+      <DepositForm initialToken="WETH" />
+    </StoryFrame>
+  )
+}

--- a/front/components/trade/deposit/DepositForm.tsx
+++ b/front/components/trade/deposit/DepositForm.tsx
@@ -1,0 +1,333 @@
+'use client'
+
+import * as React from 'react'
+
+import { Button } from '../../ui/button'
+import { cn } from '../../ui/cn'
+import { Input } from '../../ui/input'
+import { NumericText } from '../../NumericText'
+import { useWallet, useWalletBalances } from '../../../lib/wallet/hooks'
+import type { TokenSymbol } from '../../../lib/wallet/types'
+
+import { displayDecimalsFor } from '../balances/format-balance'
+
+import { useDepositController, useTxState, type DepositRevertReason } from './hooks'
+import { StepIndicator, type Step } from './StepIndicator'
+import { TokenToggle } from './TokenToggle'
+import { needsApproval, validateDeposit } from './validation'
+
+const DEPOSIT_STEPS: readonly Step[] = [
+  { index: '01', label: 'Approve' },
+  { index: '02', label: 'Deposit' },
+]
+
+const IS_DEV =
+  typeof process !== 'undefined' &&
+  (process.env?.NODE_ENV === 'development' || process.env?.NODE_ENV === 'test')
+
+interface DepositFormProps {
+  initialToken?: TokenSymbol
+  /**
+   * Called when the controller reaches the `confirmed` terminal stage
+   * (after a brief flash so the user sees the success state). The modal
+   * uses this to auto-close itself.
+   */
+  onConfirmed?: () => void
+  /** Header copy override; defaults to a brutalist `[ DEPOSIT — <TOKEN> ]`. */
+  titleId?: string
+}
+
+function tokenKey(token: TokenSymbol): 'weth' | 'usdc' {
+  return token === 'WETH' ? 'weth' : 'usdc'
+}
+
+export function DepositForm({ initialToken = 'USDC', onConfirmed, titleId }: DepositFormProps) {
+  const [token, setToken] = React.useState<TokenSymbol>(initialToken)
+  const [amount, setAmount] = React.useState('')
+  const { isConnected } = useWallet()
+  const wallet = useWalletBalances()
+  const tx = useTxState()
+  const controller = useDepositController()
+
+  React.useEffect(() => {
+    if (controller.stage.kind !== 'confirmed') return
+    const t = setTimeout(() => onConfirmed?.(), 800)
+    return () => clearTimeout(t)
+  }, [controller.stage.kind, onConfirmed])
+
+  const tokenWalletBalance = wallet[tokenKey(token)]
+  const tokenAllowance = tx.allowances[tokenKey(token)]
+  const validation = validateDeposit({ amount, walletBalance: tokenWalletBalance })
+  const requiresApproval = validation.ok ? needsApproval(amount, tokenAllowance) : true
+  const isInFlight = controller.stage.kind === 'approving' || controller.stage.kind === 'submitting'
+  const isPaused = controller.isPaused
+
+  const canStart = isConnected && !isInFlight && !isPaused && validation.ok
+  const formDisabled = isInFlight || controller.stage.kind === 'confirmed'
+
+  const onMax = () => {
+    if (formDisabled) return
+    setAmount(tokenWalletBalance)
+  }
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canStart) return
+    controller.start({ token, amount })
+  }
+
+  const onTokenChange = (next: TokenSymbol) => {
+    setToken(next)
+    setAmount('')
+    if (controller.stage.kind === 'error') controller.reset()
+  }
+
+  return (
+    <div className="flex flex-col gap-5" data-testid="deposit-form">
+      <header className="flex flex-col gap-2">
+        <h2 id={titleId} className="font-display text-[24px] leading-none uppercase text-brand-fg">
+          DEPOSIT&nbsp;—&nbsp;{token}
+        </h2>
+        <p className="font-mono text-body-md leading-[1.8] text-brand-muted">
+          Move {token} from your wallet into the DarkPool engine. The engine holds deposited balance
+          off-chain until it is matched in a batch auction.
+        </p>
+      </header>
+
+      <form onSubmit={onSubmit} className="flex flex-col gap-5">
+        <FieldGroup label="TOKEN">
+          <TokenToggle
+            value={token}
+            onChange={onTokenChange}
+            disabled={formDisabled}
+            label="Deposit token"
+          />
+        </FieldGroup>
+
+        <FieldGroup label="AMOUNT">
+          <div className="flex gap-2">
+            <Input
+              inputMode="decimal"
+              autoComplete="off"
+              placeholder="0.00"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              disabled={formDisabled}
+              aria-invalid={!validation.ok && amount !== ''}
+              aria-describedby={
+                !validation.ok && validation.reason !== 'empty' ? 'deposit-error' : undefined
+              }
+              className="flex-1"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onMax}
+              disabled={formDisabled || !isConnected}
+              className="h-10"
+            >
+              [ MAX ]
+            </Button>
+          </div>
+          {!validation.ok && validation.reason !== 'empty' && amount !== '' ? (
+            <p
+              id="deposit-error"
+              className="font-mono text-label-md uppercase tracking-label text-brand-fg"
+            >
+              {validation.message}
+            </p>
+          ) : null}
+        </FieldGroup>
+
+        <BalanceRow label="WALLET BALANCE" token={token} value={tokenWalletBalance} />
+        <BalanceRow
+          label="CURRENT ALLOWANCE"
+          token={token}
+          value={tokenAllowance}
+          helper={requiresApproval ? '[ APPROVE REQUIRED ]' : '[ APPROVED ]'}
+        />
+
+        <StepIndicator
+          steps={DEPOSIT_STEPS}
+          stage={controller.stage}
+          currentIndex={
+            controller.stage.kind === 'submitting' || controller.stage.kind === 'confirmed' ? 1 : 0
+          }
+        />
+
+        {isPaused ? (
+          <PausedNotice />
+        ) : controller.stage.kind === 'error' ? (
+          <ErrorNotice message={controller.stage.errorMessage ?? 'Transaction reverted.'} />
+        ) : null}
+
+        <Button type="submit" variant="primary" disabled={!canStart} aria-busy={isInFlight}>
+          {primaryLabel({
+            stage: controller.stage.kind,
+            requiresApproval,
+            paused: isPaused,
+            connected: isConnected,
+          })}
+        </Button>
+
+        {IS_DEV && !isPaused ? (
+          <DevRevertControls
+            disabled={isInFlight || controller.stage.kind === 'confirmed'}
+            onPick={(reason) => controller.simulateRevert(reason)}
+          />
+        ) : null}
+      </form>
+    </div>
+  )
+}
+
+function FieldGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-2">
+      <span className="font-mono text-label-md uppercase tracking-label text-brand-muted">
+        [ {label} ]
+      </span>
+      {children}
+    </label>
+  )
+}
+
+function BalanceRow({
+  label,
+  token,
+  value,
+  helper,
+}: {
+  label: string
+  token: TokenSymbol
+  value: string
+  helper?: string
+}) {
+  const dp = displayDecimalsFor(token)
+  return (
+    <div className="flex items-baseline justify-between border-t border-brand-border pt-3">
+      <span className="font-mono text-label-md uppercase tracking-label text-brand-muted">
+        [ {label} ]
+      </span>
+      <span className="flex items-baseline gap-2">
+        {helper ? (
+          <span className="font-mono text-label-sm uppercase tracking-label text-brand-muted">
+            {helper}
+          </span>
+        ) : null}
+        <NumericText
+          value={value}
+          decimals={dp}
+          kind="size"
+          aria-label={`${label} ${token}`}
+          className="text-body-md"
+        />
+        <span className="font-mono text-label-md uppercase tracking-label text-brand-muted">
+          {token}
+        </span>
+      </span>
+    </div>
+  )
+}
+
+function PausedNotice() {
+  return (
+    <div
+      role="status"
+      className={cn(
+        'border border-brand-border p-3',
+        'font-mono text-body-sm leading-[1.75] text-brand-fg'
+      )}
+    >
+      <p className="font-mono text-label-md uppercase tracking-label text-brand-muted">
+        [ CONTRACT PAUSED ]
+      </p>
+      <p className="mt-2">
+        Deposits are suspended while the operator pauses the contract. The pause is used during
+        emergency upgrades; balances are not affected. Try again once the pause is lifted.
+      </p>
+    </div>
+  )
+}
+
+function ErrorNotice({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="border border-brand-border p-3 font-mono text-body-sm leading-[1.75] text-brand-fg"
+    >
+      <p className="font-mono text-label-md uppercase tracking-label text-brand-muted">
+        [ REVERT ]
+      </p>
+      <p className="mt-2">{message}</p>
+    </div>
+  )
+}
+
+function DevRevertControls({
+  disabled,
+  onPick,
+}: {
+  disabled: boolean
+  onPick: (reason: DepositRevertReason) => void
+}) {
+  return (
+    <fieldset
+      className="border border-dashed border-brand-border p-3"
+      aria-label="Developer: simulate revert"
+    >
+      <legend className="px-1 font-mono text-label-sm uppercase tracking-label text-brand-muted">
+        [ DEV · SIMULATE REVERT ]
+      </legend>
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => onPick('approve')}
+          disabled={disabled}
+        >
+          [ ON APPROVE ]
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => onPick('deposit')}
+          disabled={disabled}
+        >
+          [ ON DEPOSIT ]
+        </Button>
+      </div>
+    </fieldset>
+  )
+}
+
+function primaryLabel({
+  stage,
+  requiresApproval,
+  paused,
+  connected,
+}: {
+  stage: 'idle' | 'approving' | 'submitting' | 'confirmed' | 'error'
+  requiresApproval: boolean
+  paused: boolean
+  connected: boolean
+}): string {
+  if (paused) return 'PAUSED'
+  if (!connected) return 'CONNECT WALLET'
+  switch (stage) {
+    case 'approving':
+      return 'APPROVING…'
+    case 'submitting':
+      return 'DEPOSITING…'
+    case 'confirmed':
+      return 'CONFIRMED'
+    case 'error':
+      return 'RETRY'
+    case 'idle':
+    default:
+      return requiresApproval ? 'APPROVE & DEPOSIT' : 'DEPOSIT'
+  }
+}

--- a/front/components/trade/deposit/DepositModal.test.tsx
+++ b/front/components/trade/deposit/DepositModal.test.tsx
@@ -1,0 +1,154 @@
+// Smoke tests for the deposit form composition. We render to static
+// markup (no DOM, no RTL) because the project's vitest setup is
+// node-only — mirroring the pattern set by `BalancesPanel.test.tsx`.
+//
+// Why test the form, not the modal: Radix's Dialog primitive renders
+// its content through a client-only Portal that emits no markup in
+// SSR. The modal is a thin wrapper that just routes the open/close
+// state; the user-visible behavior lives in `DepositForm`. The pure
+// stage machine + validation + wallet store tests cover the in-flight
+// transitions; Ladle stories cover the visual states end-to-end.
+
+import * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { walletStore } from '../../../lib/wallet/mock-store'
+
+import { DepositForm } from './DepositForm'
+import { DepositTriggers } from './DepositTriggers'
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+describe('DepositForm', () => {
+  beforeEach(() => {
+    walletStore.disconnect()
+    walletStore.resetTxState()
+  })
+
+  afterEach(() => {
+    walletStore.disconnect()
+    walletStore.resetTxState()
+  })
+
+  it('renders the bracketed header, field labels, and step indicator when connected', () => {
+    walletStore.connect()
+    const html = render(<DepositForm initialToken="USDC" />)
+    expect(html).toContain('DEPOSIT')
+    expect(html).toContain('USDC')
+    expect(html).toContain('[ TOKEN ]')
+    expect(html).toContain('[ AMOUNT ]')
+    expect(html).toContain('[ WALLET BALANCE ]')
+    expect(html).toContain('[ CURRENT ALLOWANCE ]')
+    expect(html).toContain('01')
+    expect(html).toContain('Approve')
+    expect(html).toContain('02')
+    expect(html).toContain('Deposit')
+  })
+
+  it('shows the paused notice + PAUSED primary label when tx state is paused', () => {
+    walletStore.connect()
+    walletStore.setPaused(true)
+    const html = render(<DepositForm initialToken="USDC" />)
+    expect(html).toContain('[ CONTRACT PAUSED ]')
+    expect(html).toMatch(/Deposits are suspended/i)
+    expect(html).toContain('PAUSED')
+  })
+
+  it('surfaces CONNECT WALLET when the wallet is disconnected', () => {
+    const html = render(<DepositForm initialToken="USDC" />)
+    expect(html).toContain('CONNECT WALLET')
+  })
+
+  it('reflects the seeded wallet balance for the selected token', () => {
+    walletStore.connect()
+    const html = render(<DepositForm initialToken="USDC" />)
+    // F1.3 seeds wallet USDC at 1000 — 2dp display (no comma below 10,000).
+    expect(html).toContain('1000.00')
+  })
+
+  it('reflects the seeded wallet balance for WETH at 4dp', () => {
+    walletStore.connect()
+    const html = render(<DepositForm initialToken="WETH" />)
+    expect(html).toContain('1.0000')
+  })
+
+  it('flags an approve requirement when allowance < amount (default 0 allowance)', () => {
+    walletStore.connect()
+    const html = render(<DepositForm initialToken="USDC" />)
+    expect(html).toContain('[ APPROVE REQUIRED ]')
+  })
+
+  it('switches to [ APPROVED ] when allowance is already covered', () => {
+    walletStore.connect()
+    walletStore.approve('USDC', '1000')
+    const html = render(<DepositForm initialToken="USDC" />)
+    // Initial amount field is empty, so requiresApproval is computed on
+    // the live amount. With amount blank, validation is `empty` and
+    // requiresApproval falls back to true. Bump the amount via a
+    // controlled test: render with the form's initial state and rely
+    // on the user typing in Ladle. Here we just sanity-check the
+    // allowance row surfaces the configured 1000 alongside the badge.
+    expect(html).toMatch(/CURRENT ALLOWANCE/)
+    // The allowance numeric value renders at the panel's 2dp for USDC.
+    expect(html).toContain('1000.00')
+  })
+
+  it('exposes the dev simulate-revert affordance in test/dev builds', () => {
+    walletStore.connect()
+    const html = render(<DepositForm initialToken="USDC" />)
+    expect(html).toContain('[ DEV · SIMULATE REVERT ]')
+    expect(html).toContain('[ ON APPROVE ]')
+    expect(html).toContain('[ ON DEPOSIT ]')
+  })
+
+  it('keeps brand-accent scoped to the single CTA (no accent spread)', () => {
+    walletStore.connect()
+    const html = render(<DepositForm initialToken="USDC" />)
+    // The primary button uses `bg-brand-accent` + `outline-brand-accent`.
+    // Inputs and ghost buttons embed `outline-brand-accent` as an inert
+    // focus token. Anything beyond that ceiling means a second visible
+    // accent landed on the surface.
+    const matches = html.match(/brand-accent/g) ?? []
+    expect(matches.length).toBeLessThanOrEqual(10)
+  })
+})
+
+describe('DepositTriggers', () => {
+  beforeEach(() => {
+    walletStore.disconnect()
+    walletStore.resetTxState()
+  })
+
+  afterEach(() => {
+    walletStore.disconnect()
+    walletStore.resetTxState()
+  })
+
+  it('renders both trigger buttons disabled when disconnected', () => {
+    const html = render(<DepositTriggers />)
+    expect(html).toContain('[ DEPOSIT ]')
+    expect(html).toContain('[ WITHDRAW ]')
+    expect(html).toMatch(/<button[^>]*\sdisabled=""[^>]*>\s*\[ DEPOSIT \]/)
+    expect(html).toMatch(/<button[^>]*\sdisabled=""[^>]*>\s*\[ WITHDRAW \]/)
+  })
+
+  it('enables triggers when wallet is connected and contract is not paused', () => {
+    walletStore.connect()
+    const html = render(<DepositTriggers />)
+    expect(html).toContain('[ DEPOSIT ]')
+    expect(html).toContain('[ WITHDRAW ]')
+    expect(html).not.toMatch(/<button[^>]*\sdisabled=""[^>]*>\s*\[ DEPOSIT \]/)
+    expect(html).not.toMatch(/<button[^>]*\sdisabled=""[^>]*>\s*\[ WITHDRAW \]/)
+  })
+
+  it('disables both triggers when paused even if connected', () => {
+    walletStore.connect()
+    walletStore.setPaused(true)
+    const html = render(<DepositTriggers />)
+    expect(html).toMatch(/<button[^>]*\sdisabled=""[^>]*>\s*\[ DEPOSIT \]/)
+    expect(html).toMatch(/<button[^>]*\sdisabled=""[^>]*>\s*\[ WITHDRAW \]/)
+  })
+})

--- a/front/components/trade/deposit/DepositModal.test.tsx
+++ b/front/components/trade/deposit/DepositModal.test.tsx
@@ -81,18 +81,19 @@ describe('DepositForm', () => {
     expect(html).toContain('[ APPROVE REQUIRED ]')
   })
 
-  it('switches to [ APPROVED ] when allowance is already covered', () => {
+  it('surfaces the current allowance numerically on the allowance row', () => {
+    // Note: the `[ APPROVED ]` vs `[ APPROVE REQUIRED ]` toggle is
+    // driven by `needsApproval(amount, allowance)`. With the form's
+    // initial amount blank, `requiresApproval` always falls back to
+    // true — so the on-screen badge is exhaustively pinned by the
+    // `needsApproval` unit test in `validation.test.ts`. Here we
+    // only pin the numeric surface: the allowance value renders on
+    // the [ CURRENT ALLOWANCE ] row at the per-token display dp.
     walletStore.connect()
     walletStore.approve('USDC', '1000')
     const html = render(<DepositForm initialToken="USDC" />)
-    // Initial amount field is empty, so requiresApproval is computed on
-    // the live amount. With amount blank, validation is `empty` and
-    // requiresApproval falls back to true. Bump the amount via a
-    // controlled test: render with the form's initial state and rely
-    // on the user typing in Ladle. Here we just sanity-check the
-    // allowance row surfaces the configured 1000 alongside the badge.
     expect(html).toMatch(/CURRENT ALLOWANCE/)
-    // The allowance numeric value renders at the panel's 2dp for USDC.
+    // USDC renders at 2dp; no thousands comma below 10,000.
     expect(html).toContain('1000.00')
   })
 

--- a/front/components/trade/deposit/DepositModal.tsx
+++ b/front/components/trade/deposit/DepositModal.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import * as React from 'react'
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../../ui/dialog'
+import type { TokenSymbol } from '../../../lib/wallet/types'
+
+import { DepositForm } from './DepositForm'
+import { useDepositController } from './hooks'
+
+interface DepositModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  initialToken?: TokenSymbol
+}
+
+/**
+ * Modal chrome around `<DepositForm>`. Kept thin so the form body is
+ * also drop-inable into the F1.12 onboarding flow (#79) without
+ * pulling the Dialog primitive along with it.
+ */
+export function DepositModal({ open, onOpenChange, initialToken = 'USDC' }: DepositModalProps) {
+  // We piggyback on a separate controller instance here just to read
+  // the in-flight flag for outside-click / escape suppression. The
+  // form owns its own controller; both read the same global store, so
+  // a confirmation propagates through both.
+  const controller = useDepositController()
+  const isInFlight = controller.stage.kind === 'approving' || controller.stage.kind === 'submitting'
+
+  // We intentionally do NOT remount the form on each open. The form
+  // owns its own local state — closing the modal is a soft dismissal
+  // that doesn't tear down the timer; that's why the form reads from
+  // its own controller. If the user reopens mid-flight, they see the
+  // running stage. (This mirrors how MetaMask handles in-flight tx
+  // popovers: the underlying tx isn't tied to the modal lifetime.)
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-md border border-brand-border"
+        onPointerDownOutside={(e) => {
+          if (isInFlight) e.preventDefault()
+        }}
+        onEscapeKeyDown={(e) => {
+          if (isInFlight) e.preventDefault()
+        }}
+        aria-labelledby="deposit-modal-title"
+      >
+        <DialogTitle className="sr-only" id="deposit-modal-title">
+          Deposit
+        </DialogTitle>
+        <DialogDescription className="sr-only">
+          Move tokens from your wallet into the DarkPool engine.
+        </DialogDescription>
+        <DepositForm initialToken={initialToken} onConfirmed={() => onOpenChange(false)} />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/front/components/trade/deposit/DepositModal.tsx
+++ b/front/components/trade/deposit/DepositModal.tsx
@@ -6,7 +6,6 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../../ui/
 import type { TokenSymbol } from '../../../lib/wallet/types'
 
 import { DepositForm } from './DepositForm'
-import { useDepositController } from './hooks'
 
 interface DepositModalProps {
   open: boolean
@@ -15,34 +14,18 @@ interface DepositModalProps {
 }
 
 /**
- * Modal chrome around `<DepositForm>`. Kept thin so the form body is
- * also drop-inable into the F1.12 onboarding flow (#79) without
- * pulling the Dialog primitive along with it.
+ * Modal chrome around `<DepositForm>`. The form owns its own controller
+ * and timer lifecycle: closing the modal mid-flight unmounts the form,
+ * whose hook cleanup cancels the pending setTimeout. The mock has no
+ * on-chain side-effect to roll back, so a cancel is graceful — we don't
+ * suppress Escape / outside-click. The form is also drop-inable into the
+ * F1.12 onboarding flow (#79) without pulling the Dialog primitive along.
  */
 export function DepositModal({ open, onOpenChange, initialToken = 'USDC' }: DepositModalProps) {
-  // We piggyback on a separate controller instance here just to read
-  // the in-flight flag for outside-click / escape suppression. The
-  // form owns its own controller; both read the same global store, so
-  // a confirmation propagates through both.
-  const controller = useDepositController()
-  const isInFlight = controller.stage.kind === 'approving' || controller.stage.kind === 'submitting'
-
-  // We intentionally do NOT remount the form on each open. The form
-  // owns its own local state — closing the modal is a soft dismissal
-  // that doesn't tear down the timer; that's why the form reads from
-  // its own controller. If the user reopens mid-flight, they see the
-  // running stage. (This mirrors how MetaMask handles in-flight tx
-  // popovers: the underlying tx isn't tied to the modal lifetime.)
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className="max-w-md border border-brand-border"
-        onPointerDownOutside={(e) => {
-          if (isInFlight) e.preventDefault()
-        }}
-        onEscapeKeyDown={(e) => {
-          if (isInFlight) e.preventDefault()
-        }}
         aria-labelledby="deposit-modal-title"
       >
         <DialogTitle className="sr-only" id="deposit-modal-title">

--- a/front/components/trade/deposit/DepositTriggers.stories.tsx
+++ b/front/components/trade/deposit/DepositTriggers.stories.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+
+import { walletStore } from '../../../lib/wallet/mock-store'
+
+import { DepositTriggers } from './DepositTriggers'
+
+function useWalletScenario({ connected, paused }: { connected: boolean; paused?: boolean }) {
+  React.useEffect(() => {
+    walletStore.resetTxState()
+    if (connected) walletStore.connect()
+    else walletStore.disconnect()
+    if (paused) walletStore.setPaused(true)
+    return () => {
+      walletStore.disconnect()
+      walletStore.resetTxState()
+    }
+  }, [connected, paused])
+}
+
+function StoryFrame({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="mx-auto w-full max-w-md bg-brand-surface">
+      <div className="border border-brand-border">
+        <div className="border-b border-brand-border p-3 font-mono text-label-md uppercase tracking-label text-brand-muted">
+          {label}
+        </div>
+        {children}
+      </div>
+    </div>
+  )
+}
+
+export const Disconnected = () => {
+  useWalletScenario({ connected: false })
+  return (
+    <StoryFrame label="[ BALANCES ]">
+      <DepositTriggers />
+    </StoryFrame>
+  )
+}
+
+export const Connected = () => {
+  useWalletScenario({ connected: true })
+  return (
+    <StoryFrame label="[ BALANCES ]">
+      <DepositTriggers />
+    </StoryFrame>
+  )
+}
+
+export const Paused = () => {
+  useWalletScenario({ connected: true, paused: true })
+  return (
+    <StoryFrame label="[ BALANCES ]">
+      <DepositTriggers />
+    </StoryFrame>
+  )
+}
+
+export const Compact = () => {
+  useWalletScenario({ connected: true })
+  return (
+    <div className="mx-auto w-full max-w-md p-4">
+      <DepositTriggers compact />
+    </div>
+  )
+}

--- a/front/components/trade/deposit/DepositTriggers.tsx
+++ b/front/components/trade/deposit/DepositTriggers.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import * as React from 'react'
+
+import { Button } from '../../ui/button'
+import { useWallet } from '../../../lib/wallet/hooks'
+import type { TokenSymbol } from '../../../lib/wallet/types'
+
+import { DepositModal } from './DepositModal'
+import { useTxState } from './hooks'
+import { WithdrawModal } from './WithdrawModal'
+
+interface DepositTriggersProps {
+  /** Token to preselect when either modal opens. */
+  initialToken?: TokenSymbol
+  /** Compact mode: single-row buttons without surface chrome. */
+  compact?: boolean
+}
+
+/**
+ * Drop-in host component that pairs the deposit and withdraw modals
+ * with their `[ DEPOSIT ]` / `[ WITHDRAW ]` trigger buttons. Designed
+ * so any consumer (the trade shell, the balances panel header in a
+ * follow-up PR, an onboarding empty state) can mount the pair in one
+ * place without owning open-state plumbing.
+ */
+export function DepositTriggers({ initialToken = 'USDC', compact }: DepositTriggersProps) {
+  const [depositOpen, setDepositOpen] = React.useState(false)
+  const [withdrawOpen, setWithdrawOpen] = React.useState(false)
+  const { isConnected } = useWallet()
+  const tx = useTxState()
+  const disabled = !isConnected || tx.paused
+
+  return (
+    <div
+      className={
+        compact
+          ? 'flex items-stretch gap-2'
+          : 'flex items-stretch gap-2 border-t border-brand-border p-3'
+      }
+    >
+      <Button
+        type="button"
+        variant="primary"
+        size="sm"
+        className="flex-1"
+        disabled={disabled}
+        onClick={() => setDepositOpen(true)}
+      >
+        [ DEPOSIT ]
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        className="flex-1"
+        disabled={disabled}
+        onClick={() => setWithdrawOpen(true)}
+      >
+        [ WITHDRAW ]
+      </Button>
+      <DepositModal open={depositOpen} onOpenChange={setDepositOpen} initialToken={initialToken} />
+      <WithdrawModal
+        open={withdrawOpen}
+        onOpenChange={setWithdrawOpen}
+        initialToken={initialToken}
+      />
+    </div>
+  )
+}

--- a/front/components/trade/deposit/StepIndicator.tsx
+++ b/front/components/trade/deposit/StepIndicator.tsx
@@ -1,0 +1,91 @@
+'use client'
+
+import * as React from 'react'
+
+import { cn } from '../../ui/cn'
+
+import type { Stage } from './stage-machine'
+
+export interface Step {
+  /** Two-char zero-padded label, e.g. `01`, `02`. */
+  index: string
+  /** Uppercase tracked label, e.g. `APPROVE`, `DEPOSIT`. */
+  label: string
+}
+
+type StepState = 'pending' | 'current' | 'done' | 'failed'
+
+interface StepIndicatorProps {
+  steps: readonly Step[]
+  stage: Stage
+  /** Index in `steps` that maps to the live stage (0-based). */
+  currentIndex: number
+}
+
+/**
+ * Numbered step row, matching the `step-node` token from DESIGN.md:
+ * 30×30px outlined square, two-digit zero-padded number, tracked label
+ * underneath. The single active step picks up the lime accent (this is
+ * the modal's lime budget when an active CTA is not visible).
+ */
+export function StepIndicator({ steps, stage, currentIndex }: StepIndicatorProps) {
+  return (
+    <ol className="grid grid-cols-2 gap-3" aria-label="Transaction steps">
+      {steps.map((step, i) => {
+        const state: StepState =
+          stage.kind === 'error' && i === currentIndex
+            ? 'failed'
+            : i < currentIndex
+              ? 'done'
+              : i === currentIndex && (stage.kind === 'approving' || stage.kind === 'submitting')
+                ? 'current'
+                : stage.kind === 'confirmed' && i <= currentIndex
+                  ? 'done'
+                  : 'pending'
+        return <StepCell key={step.index} step={step} state={state} />
+      })}
+    </ol>
+  )
+}
+
+function StepCell({ step, state }: { step: Step; state: StepState }) {
+  return (
+    <li className="flex items-start gap-3">
+      <span
+        aria-hidden
+        className={cn(
+          'flex h-[30px] w-[30px] shrink-0 items-center justify-center border',
+          'font-mono text-label-md uppercase tracking-label',
+          state === 'current' && 'border-brand-accent text-brand-accent',
+          state === 'done' && 'border-brand-border text-brand-fg',
+          state === 'pending' && 'border-brand-border text-brand-muted',
+          state === 'failed' && 'border-brand-border text-brand-muted'
+        )}
+      >
+        {step.index}
+      </span>
+      <div className="min-w-0 flex-1 pt-1">
+        <p
+          className={cn(
+            'font-mono text-label-md uppercase tracking-label',
+            state === 'current' && 'text-brand-fg',
+            state === 'done' && 'text-brand-fg',
+            state === 'pending' && 'text-brand-muted',
+            state === 'failed' && 'text-brand-muted'
+          )}
+        >
+          {step.label}
+        </p>
+        <p
+          aria-live={state === 'current' ? 'polite' : 'off'}
+          className="font-mono text-label-sm uppercase tracking-label text-brand-muted"
+        >
+          {state === 'current' && '· · ·'}
+          {state === 'done' && '[ DONE ]'}
+          {state === 'pending' && '[ PENDING ]'}
+          {state === 'failed' && '[ FAILED ]'}
+        </p>
+      </div>
+    </li>
+  )
+}

--- a/front/components/trade/deposit/TokenToggle.tsx
+++ b/front/components/trade/deposit/TokenToggle.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import * as React from 'react'
+
+import { cn } from '../../ui/cn'
+import type { TokenSymbol } from '../../../lib/wallet/types'
+
+interface TokenToggleProps {
+  value: TokenSymbol
+  onChange: (token: TokenSymbol) => void
+  disabled?: boolean
+  /** Aria label for the radiogroup container. */
+  label: string
+}
+
+const TOKENS: readonly TokenSymbol[] = ['WETH', 'USDC']
+
+export function TokenToggle({ value, onChange, disabled, label }: TokenToggleProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      className="grid grid-cols-2 border border-brand-border"
+    >
+      {TOKENS.map((token) => {
+        const active = token === value
+        return (
+          <button
+            key={token}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            disabled={disabled}
+            onClick={() => onChange(token)}
+            className={cn(
+              'h-10 px-3 font-mono text-label-lg uppercase tracking-label',
+              'transition-colors duration-150 ease-out',
+              'focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-accent',
+              'disabled:cursor-not-allowed disabled:text-brand-muted',
+              active
+                ? 'bg-brand-surface text-brand-fg'
+                : 'bg-transparent text-brand-muted hover:text-brand-fg'
+            )}
+          >
+            [ {token} ]
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/front/components/trade/deposit/WithdrawForm.stories.tsx
+++ b/front/components/trade/deposit/WithdrawForm.stories.tsx
@@ -1,0 +1,89 @@
+import * as React from 'react'
+
+import { walletStore } from '../../../lib/wallet/mock-store'
+
+import { WithdrawForm } from './WithdrawForm'
+
+function useWalletScenario({
+  connected,
+  paused,
+  internal,
+}: {
+  connected: boolean
+  paused?: boolean
+  internal?: { weth?: string; usdc?: string }
+}) {
+  React.useEffect(() => {
+    walletStore.resetTxState()
+    if (connected) walletStore.connect()
+    else walletStore.disconnect()
+    if (internal?.weth) {
+      walletStore.approve('WETH', internal.weth)
+      walletStore.deposit('WETH', internal.weth)
+    }
+    if (internal?.usdc) {
+      walletStore.approve('USDC', internal.usdc)
+      walletStore.deposit('USDC', internal.usdc)
+    }
+    if (paused) walletStore.setPaused(true)
+    return () => {
+      walletStore.disconnect()
+      walletStore.resetTxState()
+    }
+  }, [connected, paused, internal?.weth, internal?.usdc])
+}
+
+function StoryFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="mx-auto w-full max-w-md border border-brand-border bg-brand-surface p-8">
+      {children}
+    </div>
+  )
+}
+
+export const Disconnected = () => {
+  useWalletScenario({ connected: false })
+  return (
+    <StoryFrame>
+      <WithdrawForm initialToken="USDC" />
+    </StoryFrame>
+  )
+}
+
+export const ConnectedEmptyDarkPool = () => {
+  useWalletScenario({ connected: true })
+  return (
+    <StoryFrame>
+      <WithdrawForm initialToken="USDC" />
+    </StoryFrame>
+  )
+}
+
+export const ConnectedWithUSDC = () => {
+  useWalletScenario({ connected: true, internal: { usdc: '500' } })
+  return (
+    <StoryFrame>
+      <WithdrawForm initialToken="USDC" />
+    </StoryFrame>
+  )
+}
+
+export const ConnectedWithWETH = () => {
+  // Seeded wallet starts with 1 WETH, so we can deposit 0.5 to leave
+  // both wallet and DarkPool with non-zero balances.
+  useWalletScenario({ connected: true, internal: { weth: '0.5' } })
+  return (
+    <StoryFrame>
+      <WithdrawForm initialToken="WETH" />
+    </StoryFrame>
+  )
+}
+
+export const Paused = () => {
+  useWalletScenario({ connected: true, paused: true, internal: { usdc: '500' } })
+  return (
+    <StoryFrame>
+      <WithdrawForm initialToken="USDC" />
+    </StoryFrame>
+  )
+}

--- a/front/components/trade/deposit/WithdrawForm.tsx
+++ b/front/components/trade/deposit/WithdrawForm.tsx
@@ -1,0 +1,283 @@
+'use client'
+
+import * as React from 'react'
+
+import { Button } from '../../ui/button'
+import { cn } from '../../ui/cn'
+import { Input } from '../../ui/input'
+import { NumericText } from '../../NumericText'
+import { useInternalBalances, useWallet } from '../../../lib/wallet/hooks'
+import type { TokenSymbol } from '../../../lib/wallet/types'
+
+import { displayDecimalsFor } from '../balances/format-balance'
+
+import { useTxState, useWithdrawController, type WithdrawRevertReason } from './hooks'
+import { StepIndicator, type Step } from './StepIndicator'
+import { TokenToggle } from './TokenToggle'
+import { validateWithdraw } from './validation'
+
+const WITHDRAW_STEPS: readonly Step[] = [{ index: '01', label: 'Withdraw' }]
+
+const IS_DEV =
+  typeof process !== 'undefined' &&
+  (process.env?.NODE_ENV === 'development' || process.env?.NODE_ENV === 'test')
+
+interface WithdrawFormProps {
+  initialToken?: TokenSymbol
+  onConfirmed?: () => void
+  titleId?: string
+}
+
+function tokenKey(token: TokenSymbol): 'weth' | 'usdc' {
+  return token === 'WETH' ? 'weth' : 'usdc'
+}
+
+export function WithdrawForm({ initialToken = 'USDC', onConfirmed, titleId }: WithdrawFormProps) {
+  const [token, setToken] = React.useState<TokenSymbol>(initialToken)
+  const [amount, setAmount] = React.useState('')
+  const { isConnected } = useWallet()
+  const internal = useInternalBalances()
+  const tx = useTxState()
+  const controller = useWithdrawController()
+
+  React.useEffect(() => {
+    if (controller.stage.kind !== 'confirmed') return
+    const t = setTimeout(() => onConfirmed?.(), 800)
+    return () => clearTimeout(t)
+  }, [controller.stage.kind, onConfirmed])
+
+  const tokenInternalBalance = internal[tokenKey(token)]
+  const validation = validateWithdraw({
+    amount,
+    internalBalance: tokenInternalBalance,
+  })
+  const isInFlight = controller.stage.kind === 'submitting'
+  const isPaused = tx.paused
+
+  const canStart = isConnected && !isInFlight && !isPaused && validation.ok
+  const formDisabled = isInFlight || controller.stage.kind === 'confirmed'
+
+  const onMax = () => {
+    if (formDisabled) return
+    setAmount(tokenInternalBalance)
+  }
+
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!canStart) return
+    controller.start({ token, amount })
+  }
+
+  const onTokenChange = (next: TokenSymbol) => {
+    setToken(next)
+    setAmount('')
+    if (controller.stage.kind === 'error') controller.reset()
+  }
+
+  return (
+    <div className="flex flex-col gap-5" data-testid="withdraw-form">
+      <header className="flex flex-col gap-2">
+        <h2 id={titleId} className="font-display text-[24px] leading-none uppercase text-brand-fg">
+          WITHDRAW&nbsp;—&nbsp;{token}
+        </h2>
+        <p className="font-mono text-body-md leading-[1.8] text-brand-muted">
+          Move {token} from the DarkPool engine back to your wallet. Withdrawals settle on the next
+          batch tick.
+        </p>
+      </header>
+
+      <form onSubmit={onSubmit} className="flex flex-col gap-5">
+        <FieldGroup label="TOKEN">
+          <TokenToggle
+            value={token}
+            onChange={onTokenChange}
+            disabled={formDisabled}
+            label="Withdraw token"
+          />
+        </FieldGroup>
+
+        <FieldGroup label="AMOUNT">
+          <div className="flex gap-2">
+            <Input
+              inputMode="decimal"
+              autoComplete="off"
+              placeholder="0.00"
+              value={amount}
+              onChange={(e) => setAmount(e.target.value)}
+              disabled={formDisabled}
+              aria-invalid={!validation.ok && amount !== ''}
+              aria-describedby={
+                !validation.ok && validation.reason !== 'empty' ? 'withdraw-error' : undefined
+              }
+              className="flex-1"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onMax}
+              disabled={formDisabled || !isConnected}
+              className="h-10"
+            >
+              [ MAX ]
+            </Button>
+          </div>
+          {!validation.ok && validation.reason !== 'empty' && amount !== '' ? (
+            <p
+              id="withdraw-error"
+              className="font-mono text-label-md uppercase tracking-label text-brand-fg"
+            >
+              {validation.message}
+            </p>
+          ) : null}
+        </FieldGroup>
+
+        <BalanceRow label="DARKPOOL BALANCE" token={token} value={tokenInternalBalance} />
+
+        <StepIndicator steps={WITHDRAW_STEPS} stage={controller.stage} currentIndex={0} />
+
+        {isPaused ? (
+          <PausedNotice />
+        ) : controller.stage.kind === 'error' ? (
+          <ErrorNotice message={controller.stage.errorMessage ?? 'Transaction reverted.'} />
+        ) : null}
+
+        <Button type="submit" variant="primary" disabled={!canStart} aria-busy={isInFlight}>
+          {primaryLabel({
+            stage: controller.stage.kind,
+            paused: isPaused,
+            connected: isConnected,
+          })}
+        </Button>
+
+        {IS_DEV && !isPaused ? (
+          <DevRevertControls
+            disabled={isInFlight || controller.stage.kind === 'confirmed'}
+            onPick={(reason) => controller.simulateRevert(reason)}
+          />
+        ) : null}
+      </form>
+    </div>
+  )
+}
+
+function FieldGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className="flex flex-col gap-2">
+      <span className="font-mono text-label-md uppercase tracking-label text-brand-muted">
+        [ {label} ]
+      </span>
+      {children}
+    </label>
+  )
+}
+
+function BalanceRow({ label, token, value }: { label: string; token: TokenSymbol; value: string }) {
+  const dp = displayDecimalsFor(token)
+  return (
+    <div className="flex items-baseline justify-between border-t border-brand-border pt-3">
+      <span className="font-mono text-label-md uppercase tracking-label text-brand-muted">
+        [ {label} ]
+      </span>
+      <span className="flex items-baseline gap-2">
+        <NumericText
+          value={value}
+          decimals={dp}
+          kind="size"
+          aria-label={`${label} ${token}`}
+          className="text-body-md"
+        />
+        <span className="font-mono text-label-md uppercase tracking-label text-brand-muted">
+          {token}
+        </span>
+      </span>
+    </div>
+  )
+}
+
+function PausedNotice() {
+  return (
+    <div
+      role="status"
+      className={cn(
+        'border border-brand-border p-3',
+        'font-mono text-body-sm leading-[1.75] text-brand-fg'
+      )}
+    >
+      <p className="font-mono text-label-md uppercase tracking-label text-brand-muted">
+        [ CONTRACT PAUSED ]
+      </p>
+      <p className="mt-2">
+        Withdrawals are suspended while the operator pauses the contract. Your DarkPool balance is
+        preserved. Try again once the pause is lifted.
+      </p>
+    </div>
+  )
+}
+
+function ErrorNotice({ message }: { message: string }) {
+  return (
+    <div
+      role="alert"
+      className="border border-brand-border p-3 font-mono text-body-sm leading-[1.75] text-brand-fg"
+    >
+      <p className="font-mono text-label-md uppercase tracking-label text-brand-muted">
+        [ REVERT ]
+      </p>
+      <p className="mt-2">{message}</p>
+    </div>
+  )
+}
+
+function DevRevertControls({
+  disabled,
+  onPick,
+}: {
+  disabled: boolean
+  onPick: (reason: WithdrawRevertReason) => void
+}) {
+  return (
+    <fieldset
+      className="border border-dashed border-brand-border p-3"
+      aria-label="Developer: simulate revert"
+    >
+      <legend className="px-1 font-mono text-label-sm uppercase tracking-label text-brand-muted">
+        [ DEV · SIMULATE REVERT ]
+      </legend>
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={() => onPick('withdraw')}
+        disabled={disabled}
+      >
+        [ ON WITHDRAW ]
+      </Button>
+    </fieldset>
+  )
+}
+
+function primaryLabel({
+  stage,
+  paused,
+  connected,
+}: {
+  stage: 'idle' | 'approving' | 'submitting' | 'confirmed' | 'error'
+  paused: boolean
+  connected: boolean
+}): string {
+  if (paused) return 'PAUSED'
+  if (!connected) return 'CONNECT WALLET'
+  switch (stage) {
+    case 'submitting':
+      return 'WITHDRAWING…'
+    case 'confirmed':
+      return 'CONFIRMED'
+    case 'error':
+      return 'RETRY'
+    case 'idle':
+    case 'approving':
+    default:
+      return 'WITHDRAW'
+  }
+}

--- a/front/components/trade/deposit/WithdrawModal.test.tsx
+++ b/front/components/trade/deposit/WithdrawModal.test.tsx
@@ -1,0 +1,74 @@
+// Smoke tests for the withdraw form composition. Same factoring
+// rationale as `DepositModal.test.tsx` — we render the form body
+// rather than the modal wrapper because Radix Portal emits no SSR.
+
+import * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { walletStore } from '../../../lib/wallet/mock-store'
+
+import { WithdrawForm } from './WithdrawForm'
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+describe('WithdrawForm', () => {
+  beforeEach(() => {
+    walletStore.disconnect()
+    walletStore.resetTxState()
+  })
+
+  afterEach(() => {
+    walletStore.disconnect()
+    walletStore.resetTxState()
+  })
+
+  it('renders the bracketed header, token toggle, and DarkPool balance', () => {
+    walletStore.connect()
+    const html = render(<WithdrawForm initialToken="USDC" />)
+    expect(html).toContain('WITHDRAW')
+    expect(html).toContain('USDC')
+    expect(html).toContain('[ TOKEN ]')
+    expect(html).toContain('[ AMOUNT ]')
+    expect(html).toContain('[ DARKPOOL BALANCE ]')
+    expect(html).toContain('01')
+    expect(html).toContain('Withdraw')
+  })
+
+  it('shows the paused notice + PAUSED primary label when tx state is paused', () => {
+    walletStore.connect()
+    walletStore.setPaused(true)
+    const html = render(<WithdrawForm initialToken="USDC" />)
+    expect(html).toContain('[ CONTRACT PAUSED ]')
+    expect(html).toMatch(/Withdrawals are suspended/i)
+    expect(html).toContain('PAUSED')
+  })
+
+  it('surfaces CONNECT WALLET when disconnected', () => {
+    const html = render(<WithdrawForm initialToken="USDC" />)
+    expect(html).toContain('CONNECT WALLET')
+  })
+
+  it('reflects the seeded DarkPool balance (0 by default after connect)', () => {
+    walletStore.connect()
+    const html = render(<WithdrawForm initialToken="USDC" />)
+    expect(html).toContain('0.00')
+  })
+
+  it('reflects a non-zero internal balance after a deposit roundtrip', () => {
+    walletStore.connect()
+    walletStore.approve('USDC', '500')
+    walletStore.deposit('USDC', '500')
+    const html = render(<WithdrawForm initialToken="USDC" />)
+    expect(html).toContain('500.00')
+  })
+
+  it('exposes the dev simulate-revert affordance in test/dev builds', () => {
+    walletStore.connect()
+    const html = render(<WithdrawForm initialToken="USDC" />)
+    expect(html).toContain('[ DEV · SIMULATE REVERT ]')
+    expect(html).toContain('[ ON WITHDRAW ]')
+  })
+})

--- a/front/components/trade/deposit/WithdrawModal.tsx
+++ b/front/components/trade/deposit/WithdrawModal.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import * as React from 'react'
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../../ui/dialog'
+import type { TokenSymbol } from '../../../lib/wallet/types'
+
+import { useWithdrawController } from './hooks'
+import { WithdrawForm } from './WithdrawForm'
+
+interface WithdrawModalProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  initialToken?: TokenSymbol
+}
+
+/**
+ * Modal chrome around `<WithdrawForm>`. See DepositModal for the
+ * factoring rationale.
+ */
+export function WithdrawModal({ open, onOpenChange, initialToken = 'USDC' }: WithdrawModalProps) {
+  const controller = useWithdrawController()
+  const isInFlight = controller.stage.kind === 'submitting'
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className="max-w-md border border-brand-border"
+        onPointerDownOutside={(e) => {
+          if (isInFlight) e.preventDefault()
+        }}
+        onEscapeKeyDown={(e) => {
+          if (isInFlight) e.preventDefault()
+        }}
+        aria-labelledby="withdraw-modal-title"
+      >
+        <DialogTitle className="sr-only" id="withdraw-modal-title">
+          Withdraw
+        </DialogTitle>
+        <DialogDescription className="sr-only">
+          Move tokens from the DarkPool engine back to your wallet.
+        </DialogDescription>
+        <WithdrawForm initialToken={initialToken} onConfirmed={() => onOpenChange(false)} />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/front/components/trade/deposit/WithdrawModal.tsx
+++ b/front/components/trade/deposit/WithdrawModal.tsx
@@ -5,7 +5,6 @@ import * as React from 'react'
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from '../../ui/dialog'
 import type { TokenSymbol } from '../../../lib/wallet/types'
 
-import { useWithdrawController } from './hooks'
 import { WithdrawForm } from './WithdrawForm'
 
 interface WithdrawModalProps {
@@ -15,23 +14,16 @@ interface WithdrawModalProps {
 }
 
 /**
- * Modal chrome around `<WithdrawForm>`. See DepositModal for the
- * factoring rationale.
+ * Modal chrome around `<WithdrawForm>`. See `DepositModal` for the
+ * cancellation rationale: the form's hook cleanup cancels the
+ * setTimeout on unmount, so Esc / outside-click is intentionally not
+ * suppressed.
  */
 export function WithdrawModal({ open, onOpenChange, initialToken = 'USDC' }: WithdrawModalProps) {
-  const controller = useWithdrawController()
-  const isInFlight = controller.stage.kind === 'submitting'
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className="max-w-md border border-brand-border"
-        onPointerDownOutside={(e) => {
-          if (isInFlight) e.preventDefault()
-        }}
-        onEscapeKeyDown={(e) => {
-          if (isInFlight) e.preventDefault()
-        }}
         aria-labelledby="withdraw-modal-title"
       >
         <DialogTitle className="sr-only" id="withdraw-modal-title">

--- a/front/components/trade/deposit/hooks.ts
+++ b/front/components/trade/deposit/hooks.ts
@@ -1,0 +1,228 @@
+'use client'
+
+import * as React from 'react'
+
+import { walletStore, type TxState } from '../../../lib/wallet/mock-store'
+import type { TokenSymbol } from '../../../lib/wallet/types'
+
+import { reduceStage, INITIAL_STAGE, type Stage } from './stage-machine'
+import { needsApproval } from './validation'
+
+// Step cadence per the F1.5 spec: each fake on-chain step takes ~1s.
+// Exposed so tests / stories can override without monkey-patching
+// `setTimeout`. Kept on a single object so a future caller can swap
+// the whole timing profile (e.g. for `prefers-reduced-motion`) at once.
+export interface StepTiming {
+  approveMs: number
+  submitMs: number
+}
+
+export const DEFAULT_STEP_TIMING: StepTiming = {
+  approveMs: 1000,
+  submitMs: 1000,
+}
+
+/** Read the tx-state slice (paused + allowances) reactively. */
+export function useTxState(): TxState {
+  return React.useSyncExternalStore(
+    walletStore.subscribe,
+    walletStore.getTxState,
+    walletStore.getTxState
+  )
+}
+
+export type DepositRevertReason = 'approve' | 'deposit'
+export type WithdrawRevertReason = 'withdraw'
+
+interface UseTxControllerOptions {
+  timing?: StepTiming
+}
+
+export interface DepositController {
+  stage: Stage
+  isPaused: boolean
+  /** Trigger the deposit flow; safe to call only when the stage is idle. */
+  start(args: { token: TokenSymbol; amount: string }): void
+  /**
+   * Prime the next start() to revert. The reason determines which step
+   * fails — used by the dev-only "Simulate revert" affordance.
+   */
+  simulateRevert(reason: DepositRevertReason): void
+  reset(): void
+}
+
+export function useDepositController({
+  timing = DEFAULT_STEP_TIMING,
+}: UseTxControllerOptions = {}): DepositController {
+  const [stage, dispatch] = React.useReducer(reduceStage, INITIAL_STAGE)
+  const tx = useTxState()
+  // Refs survive across re-renders without re-triggering effects. The
+  // revert flag is consumed by start() and cleared once read.
+  const revertRef = React.useRef<DepositRevertReason | null>(null)
+  const cancelRef = React.useRef<() => void>(() => {})
+
+  const simulateRevert = React.useCallback((reason: DepositRevertReason) => {
+    revertRef.current = reason
+  }, [])
+
+  const reset = React.useCallback(() => {
+    cancelRef.current()
+    revertRef.current = null
+    dispatch({ type: 'reset' })
+  }, [])
+
+  const start = React.useCallback(
+    ({ token, amount }: { token: TokenSymbol; amount: string }) => {
+      cancelRef.current()
+      const tokenKey = token === 'WETH' ? 'weth' : 'usdc'
+      const currentAllowance = walletStore.getTxState().allowances[tokenKey]
+      const requiresApproval = needsApproval(amount, currentAllowance)
+
+      dispatch({ type: 'start', needsApproval: requiresApproval })
+
+      let cancelled = false
+      cancelRef.current = () => {
+        cancelled = true
+      }
+
+      const reject = (msg: string) => {
+        if (cancelled) return
+        dispatch({ type: 'fail', message: msg })
+      }
+
+      const runSubmit = () => {
+        const submitTimer = setTimeout(() => {
+          if (cancelled) return
+          if (revertRef.current === 'deposit') {
+            revertRef.current = null
+            reject('Deposit reverted.')
+            return
+          }
+          try {
+            walletStore.deposit(token, amount)
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : 'Deposit reverted.'
+            reject(msg)
+            return
+          }
+          if (cancelled) return
+          dispatch({ type: 'submitted' })
+        }, timing.submitMs)
+        cancelRef.current = () => {
+          cancelled = true
+          clearTimeout(submitTimer)
+        }
+      }
+
+      if (requiresApproval) {
+        const approveTimer = setTimeout(() => {
+          if (cancelled) return
+          if (revertRef.current === 'approve') {
+            revertRef.current = null
+            reject('Approve reverted.')
+            return
+          }
+          try {
+            walletStore.approve(token, amount)
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : 'Approve reverted.'
+            reject(msg)
+            return
+          }
+          if (cancelled) return
+          dispatch({ type: 'approvalDone' })
+          runSubmit()
+        }, timing.approveMs)
+        cancelRef.current = () => {
+          cancelled = true
+          clearTimeout(approveTimer)
+        }
+      } else {
+        runSubmit()
+      }
+    },
+    [timing.approveMs, timing.submitMs]
+  )
+
+  React.useEffect(() => {
+    return () => cancelRef.current()
+  }, [])
+
+  return {
+    stage,
+    isPaused: tx.paused,
+    start,
+    simulateRevert,
+    reset,
+  }
+}
+
+export interface WithdrawController {
+  stage: Stage
+  isPaused: boolean
+  start(args: { token: TokenSymbol; amount: string }): void
+  simulateRevert(reason: WithdrawRevertReason): void
+  reset(): void
+}
+
+export function useWithdrawController({
+  timing = DEFAULT_STEP_TIMING,
+}: UseTxControllerOptions = {}): WithdrawController {
+  const [stage, dispatch] = React.useReducer(reduceStage, INITIAL_STAGE)
+  const tx = useTxState()
+  const revertRef = React.useRef<WithdrawRevertReason | null>(null)
+  const cancelRef = React.useRef<() => void>(() => {})
+
+  const simulateRevert = React.useCallback((reason: WithdrawRevertReason) => {
+    revertRef.current = reason
+  }, [])
+
+  const reset = React.useCallback(() => {
+    cancelRef.current()
+    revertRef.current = null
+    dispatch({ type: 'reset' })
+  }, [])
+
+  const start = React.useCallback(
+    ({ token, amount }: { token: TokenSymbol; amount: string }) => {
+      cancelRef.current()
+      dispatch({ type: 'start', needsApproval: false })
+
+      let cancelled = false
+      const timer = setTimeout(() => {
+        if (cancelled) return
+        if (revertRef.current === 'withdraw') {
+          revertRef.current = null
+          dispatch({ type: 'fail', message: 'Withdraw reverted.' })
+          return
+        }
+        try {
+          walletStore.withdraw(token, amount)
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : 'Withdraw reverted.'
+          dispatch({ type: 'fail', message: msg })
+          return
+        }
+        dispatch({ type: 'submitted' })
+      }, timing.submitMs)
+
+      cancelRef.current = () => {
+        cancelled = true
+        clearTimeout(timer)
+      }
+    },
+    [timing.submitMs]
+  )
+
+  React.useEffect(() => {
+    return () => cancelRef.current()
+  }, [])
+
+  return {
+    stage,
+    isPaused: tx.paused,
+    start,
+    simulateRevert,
+    reset,
+  }
+}

--- a/front/components/trade/deposit/index.ts
+++ b/front/components/trade/deposit/index.ts
@@ -1,0 +1,33 @@
+export { DepositForm } from './DepositForm'
+export { DepositModal } from './DepositModal'
+export { DepositTriggers } from './DepositTriggers'
+export { WithdrawForm } from './WithdrawForm'
+export { WithdrawModal } from './WithdrawModal'
+export {
+  DEFAULT_STEP_TIMING,
+  useDepositController,
+  useTxState,
+  useWithdrawController,
+  type DepositController,
+  type DepositRevertReason,
+  type StepTiming,
+  type WithdrawController,
+  type WithdrawRevertReason,
+} from './hooks'
+export {
+  INITIAL_STAGE,
+  isInFlight,
+  isTerminal,
+  reduceStage,
+  type Stage,
+  type StageAction,
+  type StageKind,
+} from './stage-machine'
+export {
+  needsApproval,
+  validateDeposit,
+  validateWithdraw,
+  type ValidationErr,
+  type ValidationOk,
+  type ValidationResult,
+} from './validation'

--- a/front/components/trade/deposit/stage-machine.test.ts
+++ b/front/components/trade/deposit/stage-machine.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { INITIAL_STAGE, isInFlight, isTerminal, reduceStage, type Stage } from './stage-machine'
+
+describe('reduceStage', () => {
+  it('starts in idle', () => {
+    expect(INITIAL_STAGE).toEqual({ kind: 'idle' })
+  })
+
+  it('deposit flow: idle -> approving -> submitting -> confirmed', () => {
+    let s: Stage = INITIAL_STAGE
+    s = reduceStage(s, { type: 'start', needsApproval: true })
+    expect(s).toEqual({ kind: 'approving' })
+    s = reduceStage(s, { type: 'approvalDone' })
+    expect(s).toEqual({ kind: 'submitting' })
+    s = reduceStage(s, { type: 'submitted' })
+    expect(s).toEqual({ kind: 'confirmed' })
+  })
+
+  it('skips approving when allowance is already sufficient', () => {
+    const s = reduceStage(INITIAL_STAGE, { type: 'start', needsApproval: false })
+    expect(s).toEqual({ kind: 'submitting' })
+  })
+
+  it('fail during approving transitions to error', () => {
+    const start = reduceStage(INITIAL_STAGE, { type: 'start', needsApproval: true })
+    const failed = reduceStage(start, { type: 'fail', message: 'Approve reverted.' })
+    expect(failed).toEqual({ kind: 'error', errorMessage: 'Approve reverted.' })
+  })
+
+  it('fail during submitting transitions to error', () => {
+    const submitting = reduceStage(INITIAL_STAGE, { type: 'start', needsApproval: false })
+    const failed = reduceStage(submitting, { type: 'fail', message: 'Deposit reverted.' })
+    expect(failed).toEqual({ kind: 'error', errorMessage: 'Deposit reverted.' })
+  })
+
+  it('reset returns to idle from any stage', () => {
+    const stages: Stage[] = [
+      { kind: 'idle' },
+      { kind: 'approving' },
+      { kind: 'submitting' },
+      { kind: 'confirmed' },
+      { kind: 'error', errorMessage: 'x' },
+    ]
+    for (const s of stages) {
+      expect(reduceStage(s, { type: 'reset' })).toEqual(INITIAL_STAGE)
+    }
+  })
+
+  it('start is a no-op while in flight', () => {
+    const approving: Stage = { kind: 'approving' }
+    expect(reduceStage(approving, { type: 'start', needsApproval: true })).toEqual(approving)
+    const submitting: Stage = { kind: 'submitting' }
+    expect(reduceStage(submitting, { type: 'start', needsApproval: false })).toEqual(submitting)
+  })
+
+  it('start re-enters from an error state (retry)', () => {
+    const errored: Stage = { kind: 'error', errorMessage: 'previous failure' }
+    const restarted = reduceStage(errored, { type: 'start', needsApproval: true })
+    expect(restarted).toEqual({ kind: 'approving' })
+  })
+
+  it('approvalDone is ignored if not currently approving', () => {
+    const submitting: Stage = { kind: 'submitting' }
+    expect(reduceStage(submitting, { type: 'approvalDone' })).toEqual(submitting)
+  })
+
+  it('submitted is ignored if not currently submitting', () => {
+    const approving: Stage = { kind: 'approving' }
+    expect(reduceStage(approving, { type: 'submitted' })).toEqual(approving)
+  })
+
+  it('fail is ignored when terminal (stale timer cannot reopen)', () => {
+    const confirmed: Stage = { kind: 'confirmed' }
+    expect(reduceStage(confirmed, { type: 'fail', message: 'x' })).toEqual(confirmed)
+    const errored: Stage = { kind: 'error', errorMessage: 'prev' }
+    expect(reduceStage(errored, { type: 'fail', message: 'x' })).toEqual(errored)
+  })
+
+  it('fail is ignored from idle (defence against bad call order)', () => {
+    expect(reduceStage(INITIAL_STAGE, { type: 'fail', message: 'x' })).toEqual(INITIAL_STAGE)
+  })
+})
+
+describe('isInFlight / isTerminal', () => {
+  it('classifies stages correctly', () => {
+    expect(isInFlight({ kind: 'idle' })).toBe(false)
+    expect(isInFlight({ kind: 'approving' })).toBe(true)
+    expect(isInFlight({ kind: 'submitting' })).toBe(true)
+    expect(isInFlight({ kind: 'confirmed' })).toBe(false)
+    expect(isInFlight({ kind: 'error', errorMessage: 'x' })).toBe(false)
+
+    expect(isTerminal({ kind: 'idle' })).toBe(false)
+    expect(isTerminal({ kind: 'approving' })).toBe(false)
+    expect(isTerminal({ kind: 'submitting' })).toBe(false)
+    expect(isTerminal({ kind: 'confirmed' })).toBe(true)
+    expect(isTerminal({ kind: 'error', errorMessage: 'x' })).toBe(true)
+  })
+})

--- a/front/components/trade/deposit/stage-machine.ts
+++ b/front/components/trade/deposit/stage-machine.ts
@@ -1,0 +1,60 @@
+// Pure reducer for the deposit/withdraw transaction staging.
+//
+// Splitting the stage transitions out as a reducer keeps the hook layer
+// thin (it only owns the 1s timers + the side-effecting store calls)
+// and means the contract is exhaustively unit-testable in node with no
+// React or DOM.
+//
+// Deposit flow:  idle -> [approving]? -> submitting -> confirmed -> close
+// Withdraw flow: idle ->                 submitting -> confirmed -> close
+// Error path:    any in-flight stage -> error -> reset returns to idle.
+
+export type StageKind = 'idle' | 'approving' | 'submitting' | 'confirmed' | 'error'
+
+export interface Stage {
+  kind: StageKind
+  /** Filled only when `kind === 'error'`. */
+  errorMessage?: string
+}
+
+export type StageAction =
+  | { type: 'start'; needsApproval: boolean }
+  | { type: 'approvalDone' }
+  | { type: 'submitted' }
+  | { type: 'fail'; message: string }
+  | { type: 'reset' }
+
+export const INITIAL_STAGE: Stage = { kind: 'idle' }
+
+export function reduceStage(state: Stage, action: StageAction): Stage {
+  switch (action.type) {
+    case 'start':
+      // start is a no-op while a tx is in flight; the user must reset
+      // (e.g. close the modal) before kicking off a new one. Allowed
+      // entry points: idle, or recovering from an error.
+      if (state.kind !== 'idle' && state.kind !== 'error') return state
+      return { kind: action.needsApproval ? 'approving' : 'submitting' }
+    case 'approvalDone':
+      if (state.kind !== 'approving') return state
+      return { kind: 'submitting' }
+    case 'submitted':
+      if (state.kind !== 'submitting') return state
+      return { kind: 'confirmed' }
+    case 'fail':
+      // A fail is meaningful only while a tx is mid-flight; idle/
+      // confirmed/error states ignore it so a stale timer callback
+      // can't undo a happy-path completion.
+      if (state.kind !== 'approving' && state.kind !== 'submitting') return state
+      return { kind: 'error', errorMessage: action.message }
+    case 'reset':
+      return INITIAL_STAGE
+  }
+}
+
+export function isInFlight(stage: Stage): boolean {
+  return stage.kind === 'approving' || stage.kind === 'submitting'
+}
+
+export function isTerminal(stage: Stage): boolean {
+  return stage.kind === 'confirmed' || stage.kind === 'error'
+}

--- a/front/components/trade/deposit/validation.test.ts
+++ b/front/components/trade/deposit/validation.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest'
+import { needsApproval, validateDeposit, validateWithdraw } from './validation'
+
+describe('validateDeposit', () => {
+  it('rejects empty input', () => {
+    const r = validateDeposit({ amount: '', walletBalance: '1' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.reason).toBe('empty')
+      expect(r.message).toMatch(/Enter an amount/i)
+    }
+  })
+
+  it('rejects whitespace-only input', () => {
+    const r = validateDeposit({ amount: '   ', walletBalance: '1' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('empty')
+  })
+
+  it('rejects malformed numbers', () => {
+    const r = validateDeposit({ amount: 'banana', walletBalance: '1' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('invalid')
+  })
+
+  it('rejects zero and negative amounts', () => {
+    expect(validateDeposit({ amount: '0', walletBalance: '1' }).ok).toBe(false)
+    expect(validateDeposit({ amount: '-1', walletBalance: '1' }).ok).toBe(false)
+  })
+
+  it('rejects when amount exceeds wallet balance', () => {
+    const r = validateDeposit({ amount: '1.1', walletBalance: '1' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.reason).toBe('exceeds-balance')
+      expect(r.message).toMatch(/Insufficient wallet balance/i)
+    }
+  })
+
+  it('accepts an amount equal to the wallet balance', () => {
+    const r = validateDeposit({ amount: '1000', walletBalance: '1000' })
+    expect(r.ok).toBe(true)
+  })
+
+  it('decimal math: 0.1 + 0.2 boundaries stay precise', () => {
+    // 0.30000000000000004 in float — must not creep in.
+    const r = validateDeposit({ amount: '0.3', walletBalance: '0.3' })
+    expect(r.ok).toBe(true)
+  })
+
+  it('treats missing balance as zero', () => {
+    const r = validateDeposit({ amount: '1', walletBalance: '' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) expect(r.reason).toBe('exceeds-balance')
+  })
+})
+
+describe('validateWithdraw', () => {
+  it('mirrors deposit empty/invalid handling', () => {
+    expect(validateWithdraw({ amount: '', internalBalance: '1' }).ok).toBe(false)
+    expect(validateWithdraw({ amount: 'banana', internalBalance: '1' }).ok).toBe(false)
+  })
+
+  it('rejects when amount exceeds DarkPool balance', () => {
+    const r = validateWithdraw({ amount: '1.1', internalBalance: '1' })
+    expect(r.ok).toBe(false)
+    if (!r.ok) {
+      expect(r.reason).toBe('exceeds-balance')
+      expect(r.message).toMatch(/Insufficient DarkPool balance/i)
+    }
+  })
+
+  it('accepts when amount equals DarkPool balance', () => {
+    const r = validateWithdraw({ amount: '500', internalBalance: '500' })
+    expect(r.ok).toBe(true)
+  })
+})
+
+describe('needsApproval', () => {
+  it('returns true when allowance < amount', () => {
+    expect(needsApproval('100', '50')).toBe(true)
+  })
+
+  it('returns false when allowance >= amount', () => {
+    expect(needsApproval('100', '100')).toBe(false)
+    expect(needsApproval('50', '100')).toBe(false)
+  })
+
+  it('handles empty inputs defensively (default zero)', () => {
+    expect(needsApproval('', '')).toBe(false)
+    expect(needsApproval('1', '')).toBe(true)
+    expect(needsApproval('', '1')).toBe(false)
+  })
+
+  it('falls back to requiring approval on malformed input', () => {
+    expect(needsApproval('banana', '100')).toBe(true)
+  })
+})

--- a/front/components/trade/deposit/validation.ts
+++ b/front/components/trade/deposit/validation.ts
@@ -1,0 +1,96 @@
+// Pure validators for the deposit/withdraw forms.
+//
+// Numeric fields stay as decimal strings end-to-end. We compare via
+// decimal.js so 0.1 + 0.2 doesn't drift, and the validator returns a
+// branded result rather than a boolean so the modal can render the
+// exact failure reason inline (the design language has no green/red,
+// so failures must read in copy).
+
+import { Decimal } from '../../../lib/units'
+
+export type ValidationOk = { ok: true; amount: Decimal }
+export type ValidationErr = {
+  ok: false
+  reason: 'empty' | 'invalid' | 'non-positive' | 'exceeds-balance' | 'exceeds-allowance'
+  message: string
+}
+export type ValidationResult = ValidationOk | ValidationErr
+
+export interface ValidateDepositArgs {
+  amount: string
+  walletBalance: string
+}
+
+export interface ValidateWithdrawArgs {
+  amount: string
+  internalBalance: string
+}
+
+function parseAmount(raw: string): { ok: true; amount: Decimal } | ValidationErr {
+  const trimmed = raw.trim()
+  if (trimmed === '') {
+    return { ok: false, reason: 'empty', message: 'Enter an amount.' }
+  }
+  let d: Decimal
+  try {
+    d = new Decimal(trimmed)
+  } catch {
+    return { ok: false, reason: 'invalid', message: 'Amount is not a valid number.' }
+  }
+  if (!d.isFinite()) {
+    return { ok: false, reason: 'invalid', message: 'Amount is not a valid number.' }
+  }
+  if (d.lte(0)) {
+    return { ok: false, reason: 'non-positive', message: 'Amount must be greater than zero.' }
+  }
+  return { ok: true, amount: d }
+}
+
+export function validateDeposit({ amount, walletBalance }: ValidateDepositArgs): ValidationResult {
+  const parsed = parseAmount(amount)
+  if (!parsed.ok) return parsed
+  const wallet = new Decimal(walletBalance || '0')
+  if (parsed.amount.gt(wallet)) {
+    return {
+      ok: false,
+      reason: 'exceeds-balance',
+      message: 'Insufficient wallet balance.',
+    }
+  }
+  return parsed
+}
+
+export function validateWithdraw({
+  amount,
+  internalBalance,
+}: ValidateWithdrawArgs): ValidationResult {
+  const parsed = parseAmount(amount)
+  if (!parsed.ok) return parsed
+  const internal = new Decimal(internalBalance || '0')
+  if (parsed.amount.gt(internal)) {
+    return {
+      ok: false,
+      reason: 'exceeds-balance',
+      message: 'Insufficient DarkPool balance.',
+    }
+  }
+  return parsed
+}
+
+/**
+ * Decide whether an approval step is needed before deposit. The mock
+ * mirrors the on-chain ERC-20 contract: deposit consumes allowance and
+ * an explicit `approve` is required whenever the current allowance is
+ * below the requested amount.
+ */
+export function needsApproval(amount: string, allowance: string): boolean {
+  let amt: Decimal
+  let allow: Decimal
+  try {
+    amt = new Decimal(amount || '0')
+    allow = new Decimal(allowance || '0')
+  } catch {
+    return true
+  }
+  return amt.gt(allow)
+}

--- a/front/lib/wallet/mock-store.test.ts
+++ b/front/lib/wallet/mock-store.test.ts
@@ -4,6 +4,7 @@ import { MOCK_ADDRESS, walletStore } from './mock-store'
 describe('walletStore', () => {
   beforeEach(() => {
     walletStore.disconnect()
+    walletStore.resetTxState()
   })
 
   it('starts disconnected with zeroed balances', () => {
@@ -69,5 +70,154 @@ describe('walletStore', () => {
     walletStore.disconnect()
     expect(fires).toBe(0)
     unsubscribe()
+  })
+
+  describe('tx state (F1.5)', () => {
+    it('defaults to unpaused with zero allowances', () => {
+      const tx = walletStore.getTxState()
+      expect(tx.paused).toBe(false)
+      expect(tx.allowances).toEqual({ weth: '0', usdc: '0' })
+    })
+
+    it('setPaused flips the flag and notifies', () => {
+      let fires = 0
+      const unsubscribe = walletStore.subscribe(() => {
+        fires += 1
+      })
+      walletStore.setPaused(true)
+      expect(walletStore.getTxState().paused).toBe(true)
+      expect(fires).toBe(1)
+      // Idempotent: same value does not re-notify.
+      walletStore.setPaused(true)
+      expect(fires).toBe(1)
+      unsubscribe()
+    })
+
+    it('approve writes per-token allowance and is idempotent for repeats', () => {
+      let fires = 0
+      const unsubscribe = walletStore.subscribe(() => {
+        fires += 1
+      })
+      walletStore.approve('USDC', '500')
+      expect(walletStore.getTxState().allowances).toEqual({ weth: '0', usdc: '500' })
+      expect(fires).toBe(1)
+      walletStore.approve('USDC', '500')
+      expect(fires).toBe(1)
+      walletStore.approve('WETH', '0.5')
+      expect(walletStore.getTxState().allowances).toEqual({ weth: '0.5', usdc: '500' })
+      expect(fires).toBe(2)
+      unsubscribe()
+    })
+
+    it('approve rejects negative or malformed amounts', () => {
+      expect(() => walletStore.approve('USDC', '-1')).toThrow(/non-negative/)
+      expect(() => walletStore.approve('USDC', 'banana')).toThrow(/decimal string/)
+    })
+
+    it('deposit moves balance wallet→internal, consumes allowance, and notifies', () => {
+      walletStore.connect()
+      walletStore.approve('USDC', '500')
+      let fires = 0
+      const unsubscribe = walletStore.subscribe(() => {
+        fires += 1
+      })
+      walletStore.deposit('USDC', '250')
+      const state = walletStore.getState()
+      expect(state.walletBalances.usdc).toBe('750')
+      expect(state.internalBalances.usdc).toBe('250')
+      expect(walletStore.getTxState().allowances.usdc).toBe('250')
+      // Two notifications: one for the wallet state, one for the tx state.
+      expect(fires).toBe(2)
+      unsubscribe()
+    })
+
+    it('deposit decimal amounts compose correctly across multiple operations', () => {
+      walletStore.connect()
+      walletStore.approve('WETH', '1')
+      walletStore.deposit('WETH', '0.25')
+      walletStore.deposit('WETH', '0.5')
+      const state = walletStore.getState()
+      expect(state.walletBalances.weth).toBe('0.25')
+      expect(state.internalBalances.weth).toBe('0.75')
+      expect(walletStore.getTxState().allowances.weth).toBe('0.25')
+    })
+
+    it('deposit rejects when amount > wallet balance', () => {
+      walletStore.connect()
+      walletStore.approve('USDC', '99999')
+      expect(() => walletStore.deposit('USDC', '1001')).toThrow(/insufficient wallet balance/)
+    })
+
+    it('deposit rejects when amount > allowance even if wallet is funded', () => {
+      walletStore.connect()
+      walletStore.approve('USDC', '100')
+      expect(() => walletStore.deposit('USDC', '101')).toThrow(/insufficient allowance/)
+    })
+
+    it('deposit rejects when paused', () => {
+      walletStore.connect()
+      walletStore.approve('USDC', '500')
+      walletStore.setPaused(true)
+      expect(() => walletStore.deposit('USDC', '50')).toThrow(/paused/)
+    })
+
+    it('deposit rejects when amount is zero or negative', () => {
+      walletStore.connect()
+      walletStore.approve('USDC', '500')
+      expect(() => walletStore.deposit('USDC', '0')).toThrow(/greater than zero/)
+      expect(() => walletStore.deposit('USDC', '-1')).toThrow(/non-negative/)
+    })
+
+    it('deposit rejects when disconnected', () => {
+      expect(() => walletStore.deposit('USDC', '1')).toThrow(/disconnected/)
+    })
+
+    it('withdraw moves balance internal→wallet and notifies once', () => {
+      walletStore.connect()
+      walletStore.approve('USDC', '500')
+      walletStore.deposit('USDC', '500')
+      let fires = 0
+      const unsubscribe = walletStore.subscribe(() => {
+        fires += 1
+      })
+      walletStore.withdraw('USDC', '200')
+      const state = walletStore.getState()
+      expect(state.walletBalances.usdc).toBe('700')
+      expect(state.internalBalances.usdc).toBe('300')
+      // Withdraw touches only the wallet slice.
+      expect(fires).toBe(1)
+      unsubscribe()
+    })
+
+    it('withdraw rejects when amount > internal balance', () => {
+      walletStore.connect()
+      walletStore.approve('USDC', '500')
+      walletStore.deposit('USDC', '100')
+      expect(() => walletStore.withdraw('USDC', '101')).toThrow(/insufficient DarkPool balance/)
+    })
+
+    it('withdraw rejects when paused', () => {
+      walletStore.connect()
+      walletStore.approve('USDC', '500')
+      walletStore.deposit('USDC', '500')
+      walletStore.setPaused(true)
+      expect(() => walletStore.withdraw('USDC', '10')).toThrow(/paused/)
+    })
+
+    it('disconnect does not reset tx state (allowances persist)', () => {
+      walletStore.connect()
+      walletStore.approve('USDC', '123')
+      walletStore.disconnect()
+      expect(walletStore.getTxState().allowances.usdc).toBe('123')
+    })
+
+    it('resetTxState clears allowances and paused', () => {
+      walletStore.connect()
+      walletStore.approve('USDC', '50')
+      walletStore.setPaused(true)
+      walletStore.resetTxState()
+      const tx = walletStore.getTxState()
+      expect(tx).toEqual({ paused: false, allowances: { weth: '0', usdc: '0' } })
+    })
   })
 })

--- a/front/lib/wallet/mock-store.ts
+++ b/front/lib/wallet/mock-store.ts
@@ -1,4 +1,5 @@
-import type { Address, Balances, WalletState } from './types'
+import { Decimal } from '../units'
+import type { Address, Balances, TokenSymbol, WalletState } from './types'
 
 export const MOCK_ADDRESS: Address = '0x1111111111111111111111111111111111111111'
 
@@ -12,13 +13,58 @@ const DISCONNECTED_STATE: WalletState = {
   internalBalances: ZERO_BALANCES,
 }
 
+// Tx state lives alongside (not inside) WalletState so the existing
+// reactive contract (balances + status) stays a one-purpose surface.
+// Both slices share the same listener set: changes to tx state never
+// re-render balance subscribers, because useSyncExternalStore compares
+// the snapshot reference per slice. F1.5 (#72) is the only writer.
+export interface TxState {
+  paused: boolean
+  allowances: Balances
+}
+
+const INITIAL_TX_STATE: TxState = {
+  paused: false,
+  allowances: ZERO_BALANCES,
+}
+
 type Listener = () => void
+
+function keyFor(token: TokenSymbol): keyof Balances {
+  return token === 'WETH' ? 'weth' : 'usdc'
+}
+
+function assertNonNegative(amount: string, label: string): Decimal {
+  let d: Decimal
+  try {
+    d = new Decimal(amount)
+  } catch {
+    throw new RangeError(`walletStore: ${label} must be a decimal string (got "${amount}")`)
+  }
+  if (!d.isFinite() || d.isNegative()) {
+    throw new RangeError(
+      `walletStore: ${label} must be a non-negative finite decimal (got "${amount}")`
+    )
+  }
+  return d
+}
+
+function add(a: string, b: Decimal): string {
+  return new Decimal(a).plus(b).toFixed()
+}
+
+function sub(a: string, b: Decimal): string {
+  return new Decimal(a).minus(b).toFixed()
+}
 
 class MockWalletStore {
   private state: WalletState = DISCONNECTED_STATE
+  private tx: TxState = INITIAL_TX_STATE
   private readonly listeners = new Set<Listener>()
 
   getState = (): WalletState => this.state
+
+  getTxState = (): TxState => this.tx
 
   subscribe = (listener: Listener): (() => void) => {
     this.listeners.add(listener)
@@ -29,7 +75,7 @@ class MockWalletStore {
 
   connect = (): void => {
     if (this.state.status === 'connected') return
-    this.setState({
+    this.setWalletState({
       status: 'connected',
       address: MOCK_ADDRESS,
       walletBalances: { ...INITIAL_WALLET_BALANCES },
@@ -39,11 +85,107 @@ class MockWalletStore {
 
   disconnect = (): void => {
     if (this.state.status === 'disconnected') return
-    this.setState(DISCONNECTED_STATE)
+    this.setWalletState(DISCONNECTED_STATE)
   }
 
-  private setState(next: WalletState): void {
+  setPaused = (paused: boolean): void => {
+    if (this.tx.paused === paused) return
+    this.setTxState({ ...this.tx, paused })
+  }
+
+  approve = (token: TokenSymbol, amount: string): void => {
+    assertNonNegative(amount, 'allowance')
+    const key = keyFor(token)
+    if (this.tx.allowances[key] === amount) return
+    this.setTxState({
+      ...this.tx,
+      allowances: { ...this.tx.allowances, [key]: amount },
+    })
+  }
+
+  deposit = (token: TokenSymbol, amount: string): void => {
+    if (this.state.status !== 'connected') {
+      throw new Error('walletStore: cannot deposit while disconnected')
+    }
+    if (this.tx.paused) {
+      throw new Error('walletStore: contract is paused')
+    }
+    const d = assertNonNegative(amount, 'deposit amount')
+    if (d.isZero()) {
+      throw new RangeError('walletStore: deposit amount must be greater than zero')
+    }
+    const key = keyFor(token)
+    const wallet = new Decimal(this.state.walletBalances[key])
+    if (d.gt(wallet)) {
+      throw new RangeError(`walletStore: insufficient wallet balance for ${token}`)
+    }
+    const allowance = new Decimal(this.tx.allowances[key])
+    if (d.gt(allowance)) {
+      throw new RangeError(`walletStore: insufficient allowance for ${token}`)
+    }
+    this.setWalletState({
+      ...this.state,
+      walletBalances: {
+        ...this.state.walletBalances,
+        [key]: sub(this.state.walletBalances[key], d),
+      },
+      internalBalances: {
+        ...this.state.internalBalances,
+        [key]: add(this.state.internalBalances[key], d),
+      },
+    })
+    // ERC-20 semantics: spent allowance is consumed.
+    this.setTxState({
+      ...this.tx,
+      allowances: { ...this.tx.allowances, [key]: sub(this.tx.allowances[key], d) },
+    })
+  }
+
+  withdraw = (token: TokenSymbol, amount: string): void => {
+    if (this.state.status !== 'connected') {
+      throw new Error('walletStore: cannot withdraw while disconnected')
+    }
+    if (this.tx.paused) {
+      throw new Error('walletStore: contract is paused')
+    }
+    const d = assertNonNegative(amount, 'withdraw amount')
+    if (d.isZero()) {
+      throw new RangeError('walletStore: withdraw amount must be greater than zero')
+    }
+    const key = keyFor(token)
+    const internal = new Decimal(this.state.internalBalances[key])
+    if (d.gt(internal)) {
+      throw new RangeError(`walletStore: insufficient DarkPool balance for ${token}`)
+    }
+    this.setWalletState({
+      ...this.state,
+      walletBalances: {
+        ...this.state.walletBalances,
+        [key]: add(this.state.walletBalances[key], d),
+      },
+      internalBalances: {
+        ...this.state.internalBalances,
+        [key]: sub(this.state.internalBalances[key], d),
+      },
+    })
+  }
+
+  resetTxState = (): void => {
+    if (this.tx === INITIAL_TX_STATE) return
+    this.setTxState(INITIAL_TX_STATE)
+  }
+
+  private setWalletState(next: WalletState): void {
     this.state = next
+    this.notify()
+  }
+
+  private setTxState(next: TxState): void {
+    this.tx = next
+    this.notify()
+  }
+
+  private notify(): void {
     this.listeners.forEach((listener) => listener())
   }
 }


### PR DESCRIPTION
Closes #72

## Summary

- New `front/components/trade/deposit/` module: `DepositModal`, `WithdrawModal`, the standalone `DepositTriggers` host (two trigger buttons + both modals), and the underlying `DepositForm` / `WithdrawForm` bodies.
- Pure stage machine + decimal-precise validation extracted into separate files so the in-flight tx logic is unit-testable in node without jsdom.
- Wallet mock-store gains `approve`, `deposit`, `withdraw`, `setPaused`, `resetTxState` (the documented file-scope exception per `docs/PARALLEL-WORK.md`). The new tx slice (paused + allowances) lives alongside `WalletState` so the existing reactive balances contract is untouched.

## Behavior maps to the AC

- **Modals collect token + amount; show current allowance for deposit.** `TokenToggle` segmented `[ WETH ] / [ USDC ]`, `Input` with `[ MAX ]` shortcut, dedicated `[ CURRENT ALLOWANCE ]` row in the deposit form with an inline `[ APPROVE REQUIRED ]` / `[ APPROVED ]` badge.
- **Staged UI 1s + 1s → confirmed → close. Balances update on confirmed.** Deposit: `idle → approving → submitting → confirmed → onConfirmed()`. Withdraw: `idle → submitting → confirmed → onConfirmed()`. The store mutator runs at the end of each step, so the F1.4 balances panel re-renders the moment the stage flips to confirmed.
- **Error path via "Simulate revert" in dev builds.** Each form embeds a `[ DEV · SIMULATE REVERT ]` fieldset (gated on `NODE_ENV` ≠ `production`) — `[ ON APPROVE ]` / `[ ON DEPOSIT ]` for deposits, `[ ON WITHDRAW ]` for withdrawals. The primed reason is consumed by the next `start()` and short-circuits the corresponding step into a `[ REVERT ]` panel.
- **Validation: amount > 0; deposit ≤ wallet; withdraw ≤ DarkPool.** `validateDeposit` / `validateWithdraw` return a discriminated result; the primary CTA stays disabled until `validation.ok`, and the inline error message is rendered in mono on `primary` (no green/red — DESIGN.md).
- **Paused.** `walletStore.setPaused(true)` swaps the primary label to `PAUSED`, disables the trigger buttons, and renders a `[ CONTRACT PAUSED ]` notice inside each form. Copy explains the pause is operational and balances are preserved.

## Notable design decisions

- **No panel-side edits.** Per file scope, `BalancesPanel.tsx` is untouched. The `DepositTriggers` host is a drop-in for whichever PR composes the panel header — it owns its own modal open state and respects the connect / paused gates.
- **Form bodies are extracted.** `DepositForm` / `WithdrawForm` are renderable without Radix Portal so the existing `renderToStaticMarkup` test pattern works (Radix `Dialog` emits no SSR markup). The forms are also a clean reuse target for the F1.12 onboarding flow.
- **Single accent budget.** Lime is reserved for the primary CTA (per `docs/DESIGN-INSPIRATIONS.md` deposit/withdraw row). The step indicator borrows lime only on the active step.
- **Numeric strings only.** All amount math goes through `decimal.js`; no JS-number coercion.

## Tests

- `lib/wallet/mock-store.test.ts` — 16 new cases covering paused, allowance, deposit, withdraw, idempotency, disconnected guards, and decimal-precise composition.
- `components/trade/deposit/validation.test.ts` — 15 cases for amount parsing, balance bounds, and `needsApproval`.
- `components/trade/deposit/stage-machine.test.ts` — 12 cases pinning every transition + the stale-timer guards.
- `components/trade/deposit/DepositModal.test.tsx` + `WithdrawModal.test.tsx` — composition smoke tests against the form bodies (matching the existing `BalancesPanel.test.tsx` pattern).

Total: **235 tests pass** across the front workspace.

## Test plan

- [ ] `npm test` (vitest) — 235 pass.
- [ ] `npm run typecheck` — clean.
- [ ] `npm run lint` — clean.
- [ ] `npm run format:check` — clean.
- [ ] `npm run ladle:build` — builds; stories cover disconnected / connected / paused / WETH / USDC / withdraw-with-balance for both forms, plus the trigger row.
- [ ] `npm run build` — Next.js production build clean.
- [ ] Spot-check in Ladle: idle copy, paused notice, dev simulate-revert buttons, allowance row badge.