### PR TITLE
[F1.11] Portfolio + P&L (mock)

### DIFF
--- a/front/app/app/portfolio/page.tsx
+++ b/front/app/app/portfolio/page.tsx
@@ -1,0 +1,9 @@
+import { PortfolioPanel } from '@/components/trade/portfolio'
+
+export const metadata = {
+  title: 'Portfolio · DarkPool',
+}
+
+export default function PortfolioPage() {
+  return <PortfolioPanel />
+}

--- a/front/components/trade/portfolio/DivergenceBanner.tsx
+++ b/front/components/trade/portfolio/DivergenceBanner.tsx
@@ -13,11 +13,13 @@ const WETH_DP = 4
 const USDC_DP = 2
 
 /**
- * Inline warning that the local fill history doesn't reconcile with the
- * internal pool balance — meaning history was lost (page refresh in
- * Phase 1; IndexedDB miss in Phase 2). The banner gives the user the
- * numeric delta so they can decide whether to keep trusting the local
- * P&L numbers.
+ * Inline warning that the local fill history can't be reconciled against
+ * the pool's internal balance. The label intentionally describes the
+ * symptom (mismatch) rather than the cause: in Phase 1 deposits aren't
+ * tracked locally, so a non-zero pool balance OR any fill activity will
+ * trigger this banner. Once #72 (deposits) and #101 (IndexedDB history)
+ * land, the same banner will narrow to its intended meaning — lost local
+ * history — by checking against `deposits + fills - withdrawals`.
  *
  * No semantic colors per DESIGN.md: the warning reads in `secondary`
  * text and uses bracketed-tag typography for emphasis. The 1px outline
@@ -29,17 +31,17 @@ export function DivergenceBanner({ result }: DivergenceBannerProps): JSX.Element
   return (
     <aside
       role="alert"
-      aria-label="Position divergence warning"
+      aria-label="Balance and history mismatch warning"
       className="border border-brand-border bg-brand-surface"
     >
       <div className="flex flex-col gap-2 px-4 py-3">
         <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
-          [ HISTORY OUT OF SYNC ]
+          [ HISTORY / BALANCE MISMATCH ]
         </span>
         <p className="font-mono text-body-sm text-brand-fg">
-          The position derived from your local fill history doesn&apos;t match the balance the pool
-          reports. Local history may have been lost — only the deltas below are visible to this
-          session.
+          Local fill history can&apos;t be reconciled against the pool balance. Phase 1 doesn&apos;t
+          record on-chain deposits or withdrawals — until #72 lands, any session with fills or a
+          non-zero balance surfaces here. Treat the deltas below as deltas, not as cumulative state.
         </p>
         <dl className="grid grid-cols-[auto_minmax(0,1fr)_auto_minmax(0,1fr)] items-baseline gap-x-4 gap-y-1 pt-1 font-mono text-body-sm text-brand-fg">
           <dt className="text-brand-muted">FROM FILLS · WETH</dt>

--- a/front/components/trade/portfolio/DivergenceBanner.tsx
+++ b/front/components/trade/portfolio/DivergenceBanner.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import * as React from 'react'
+
+import { NumericText } from '../../NumericText'
+import type { DivergenceResult } from './pnl'
+
+export interface DivergenceBannerProps {
+  result: DivergenceResult
+}
+
+const WETH_DP = 4
+const USDC_DP = 2
+
+/**
+ * Inline warning that the local fill history doesn't reconcile with the
+ * internal pool balance — meaning history was lost (page refresh in
+ * Phase 1; IndexedDB miss in Phase 2). The banner gives the user the
+ * numeric delta so they can decide whether to keep trusting the local
+ * P&L numbers.
+ *
+ * No semantic colors per DESIGN.md: the warning reads in `secondary`
+ * text and uses bracketed-tag typography for emphasis. The 1px outline
+ * is the panel boundary; we don't add a second border.
+ */
+export function DivergenceBanner({ result }: DivergenceBannerProps): JSX.Element | null {
+  if (!result.diverged) return null
+
+  return (
+    <aside
+      role="alert"
+      aria-label="Position divergence warning"
+      className="border border-brand-border bg-brand-surface"
+    >
+      <div className="flex flex-col gap-2 px-4 py-3">
+        <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+          [ HISTORY OUT OF SYNC ]
+        </span>
+        <p className="font-mono text-body-sm text-brand-fg">
+          The position derived from your local fill history doesn&apos;t match the balance the pool
+          reports. Local history may have been lost — only the deltas below are visible to this
+          session.
+        </p>
+        <dl className="grid grid-cols-[auto_minmax(0,1fr)_auto_minmax(0,1fr)] items-baseline gap-x-4 gap-y-1 pt-1 font-mono text-body-sm text-brand-fg">
+          <dt className="text-brand-muted">FROM FILLS · WETH</dt>
+          <dd>
+            <NumericText value={result.expected.weth} decimals={WETH_DP} kind="size" align="left" />
+          </dd>
+          <dt className="text-brand-muted">USDC</dt>
+          <dd>
+            <NumericText value={result.expected.usdc} decimals={USDC_DP} kind="usd" align="left" />
+          </dd>
+          <dt className="text-brand-muted">POOL · WETH</dt>
+          <dd>
+            <NumericText value={result.actual.weth} decimals={WETH_DP} kind="size" align="left" />
+          </dd>
+          <dt className="text-brand-muted">USDC</dt>
+          <dd>
+            <NumericText value={result.actual.usdc} decimals={USDC_DP} kind="usd" align="left" />
+          </dd>
+        </dl>
+      </div>
+    </aside>
+  )
+}

--- a/front/components/trade/portfolio/ExportCsvButton.tsx
+++ b/front/components/trade/portfolio/ExportCsvButton.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import * as React from 'react'
+
+import type { Fill } from '../../../lib/mock-store'
+
+import { fillsToCsv } from './csv'
+
+export interface ExportCsvButtonProps {
+  fills: readonly Fill[]
+}
+
+/**
+ * Triggers a client-side download of the current fill history. Stays
+ * disabled when there is nothing to export so the button can never
+ * dispatch a stub CSV that misleads a user post-disconnect.
+ *
+ * SSR-safe: the URL.createObjectURL path only runs inside the click
+ * handler, after hydration. The component itself does not touch
+ * `window` during render.
+ */
+export function ExportCsvButton({ fills }: ExportCsvButtonProps): JSX.Element {
+  const disabled = fills.length === 0
+  const handleClick = React.useCallback(() => {
+    if (typeof window === 'undefined') return
+    const csv = fillsToCsv(fills)
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const anchor = document.createElement('a')
+    anchor.href = url
+    anchor.download = filenameFor(new Date())
+    document.body.appendChild(anchor)
+    anchor.click()
+    document.body.removeChild(anchor)
+    URL.revokeObjectURL(url)
+  }, [fills])
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={disabled}
+      className="border border-brand-border px-3 py-1 font-mono text-label-md uppercase tracking-labelWide text-brand-muted transition-colors hover:border-brand-muted hover:text-brand-fg disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-brand-accent"
+      aria-label="Export fill history as CSV"
+    >
+      [ EXPORT CSV ]
+    </button>
+  )
+}
+
+function filenameFor(d: Date): string {
+  const pad = (n: number) => (n < 10 ? `0${n}` : `${n}`)
+  return `darkpool-fills-${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}.csv`
+}

--- a/front/components/trade/portfolio/FillHistoryRow.tsx
+++ b/front/components/trade/portfolio/FillHistoryRow.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import * as React from 'react'
+
+import { NumericText } from '../../NumericText'
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { Fill } from '../../../lib/mock-store'
+
+import { formatBatch, formatFillTimestamp } from './format'
+
+export interface FillHistoryRowProps {
+  fill: Fill
+}
+
+function FillHistoryRowImpl({ fill }: FillHistoryRowProps): JSX.Element {
+  const sideLabel = fill.side === Side.BUY ? '[ BUY ]' : '[ SELL ]'
+  return (
+    <li className="border-b border-brand-border last:border-b-0">
+      <div
+        className="grid grid-cols-[10rem_4rem_minmax(0,1fr)_minmax(0,1fr)_minmax(0,9rem)] items-center gap-3 px-4 py-3 font-mono text-body-sm tabular-nums text-brand-fg"
+        aria-label={`Fill ${fill.fillId}, ${fill.side === Side.BUY ? 'buy' : 'sell'} ${fill.size} at ${fill.price}`}
+      >
+        <span className="text-brand-muted">{formatFillTimestamp(fill.timestampUnix)}</span>
+        <span className="text-brand-fg">{sideLabel}</span>
+        <NumericText value={fill.price} kind="price" align="right" className="text-brand-fg" />
+        <NumericText value={fill.size} kind="size" align="right" className="text-brand-fg" />
+        <span className="text-right text-brand-muted">[ {formatBatch(fill.auctionId)} ]</span>
+      </div>
+    </li>
+  )
+}
+
+export const FillHistoryRow = React.memo(FillHistoryRowImpl)
+FillHistoryRow.displayName = 'FillHistoryRow'

--- a/front/components/trade/portfolio/FillHistoryTable.tsx
+++ b/front/components/trade/portfolio/FillHistoryTable.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import * as React from 'react'
+
+import type { Fill } from '../../../lib/mock-store'
+
+import { ExportCsvButton } from './ExportCsvButton'
+import { FillHistoryRow } from './FillHistoryRow'
+
+export interface FillHistoryTableProps {
+  fills: readonly Fill[]
+}
+
+export function FillHistoryTable({ fills }: FillHistoryTableProps): JSX.Element {
+  return (
+    <section
+      aria-label="Fill history"
+      className="flex min-h-[280px] flex-col border border-brand-border bg-brand-surface"
+    >
+      <TableTitleBar count={fills.length} fills={fills} />
+      <TableHeader />
+      {fills.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <ol className="flex-1 overflow-y-auto">
+          {fills.map((f) => (
+            <FillHistoryRow key={f.fillId} fill={f} />
+          ))}
+        </ol>
+      )}
+    </section>
+  )
+}
+
+function TableTitleBar({ count, fills }: { count: number; fills: readonly Fill[] }) {
+  return (
+    <div className="flex h-9 items-center justify-between border-b border-brand-border px-4">
+      <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+        [ FILL HISTORY · {count.toString().padStart(2, '0')} ]
+      </span>
+      <ExportCsvButton fills={fills} />
+    </div>
+  )
+}
+
+function TableHeader() {
+  return (
+    <div
+      className="grid grid-cols-[10rem_4rem_minmax(0,1fr)_minmax(0,1fr)_minmax(0,9rem)] gap-3 border-b border-brand-border bg-brand-surface px-4 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
+      role="row"
+    >
+      <span>TIME</span>
+      <span>SIDE</span>
+      <span className="text-right">PRICE</span>
+      <span className="text-right">SIZE</span>
+      <span className="text-right">BATCH</span>
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-1 items-center justify-center px-4 py-12">
+      <p
+        role="status"
+        className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
+      >
+        [ NO FILLS YET — PLACE AN ORDER ON /APP/TRADE ]
+      </p>
+    </div>
+  )
+}

--- a/front/components/trade/portfolio/PnLCard.tsx
+++ b/front/components/trade/portfolio/PnLCard.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import * as React from 'react'
+
+import { Decimal } from '../../../lib/units'
+import { NumericText } from '../../NumericText'
+
+import type { PortfolioSummary } from './pnl'
+
+export interface PnLCardProps {
+  summary: PortfolioSummary
+}
+
+const WETH_DP = 4
+const USDC_DP = 2
+
+/**
+ * Stat-value triplet that opens the portfolio surface: WETH position,
+ * USDC cash delta, unrealized P&L vs the latest clearing price.
+ *
+ * Per docs/DESIGN-INSPIRATIONS.md ("/app/portfolio | The unrealized P&L
+ * value (if positive)"), positive P&L is the single lime accent for
+ * this view. We never use red/green semantic hues; sign comes from a
+ * `+ / -` prefix in tabular mono.
+ */
+export function PnLCard({ summary }: PnLCardProps): JSX.Element {
+  const { position, avgEntry, mark, unrealizedPnl } = summary
+  const pnlSign = signOf(unrealizedPnl)
+  const wethSign = signOf(position.weth)
+
+  return (
+    <section aria-label="Portfolio summary" className="border border-brand-border bg-brand-surface">
+      <div className="grid grid-cols-1 divide-y divide-brand-border md:grid-cols-3 md:divide-x md:divide-y-0">
+        <Stat
+          label="WETH POSITION"
+          value={
+            <NumericText
+              value={position.weth}
+              decimals={WETH_DP}
+              kind="size"
+              align="left"
+              className="text-display-sm font-display tracking-brand text-brand-fg"
+            />
+          }
+          hint={wethSign === 'pos' ? 'LONG' : wethSign === 'neg' ? 'SHORT' : 'FLAT'}
+        />
+        <Stat
+          label="USDC DELTA"
+          value={
+            <NumericText
+              value={position.usdc}
+              decimals={USDC_DP}
+              kind="usd"
+              align="left"
+              className="text-display-sm font-display tracking-brand text-brand-fg"
+            />
+          }
+          hint={avgEntry !== null ? `AVG ENTRY ${formatPriceShort(avgEntry)}` : 'NO POSITION'}
+        />
+        <Stat
+          label="UNREALIZED P&L"
+          value={
+            unrealizedPnl === null ? (
+              <span className="font-display text-display-sm text-brand-muted">—</span>
+            ) : (
+              <SignedPnl value={unrealizedPnl} sign={pnlSign} />
+            )
+          }
+          hint={mark !== null ? `MARK ${formatPriceShort(mark)}` : 'AWAITING AUCTION'}
+        />
+      </div>
+    </section>
+  )
+}
+
+function SignedPnl({ value, sign }: { value: string; sign: Sign }) {
+  const absolute = new Decimal(value).abs().toFixed(USDC_DP)
+  const prefix = sign === 'pos' ? '+' : sign === 'neg' ? '−' : ''
+  const cls =
+    'inline-block font-display text-display-sm tracking-brand tabular-nums leading-none ' +
+    (sign === 'pos' ? 'text-brand-accent' : 'text-brand-fg')
+  return (
+    <span className={cls} aria-label={`Unrealized P and L ${value} USDC`}>
+      {prefix}
+      {formatThousands(absolute)}
+    </span>
+  )
+}
+
+function formatThousands(decimalString: string): string {
+  const [intPart, fracPart] = decimalString.split('.')
+  const grouped = new Decimal(intPart).abs().gte(10000)
+    ? intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    : intPart
+  return fracPart !== undefined ? `${grouped}.${fracPart}` : grouped
+}
+
+function Stat({ label, value, hint }: { label: string; value: React.ReactNode; hint: string }) {
+  return (
+    <div className="flex flex-col gap-2 px-5 py-4">
+      <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+        {label}
+      </span>
+      <div className="leading-none">{value}</div>
+      <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+        {hint}
+      </span>
+    </div>
+  )
+}
+
+type Sign = 'pos' | 'neg' | 'zero'
+
+function signOf(v: string | null): Sign {
+  if (v === null) return 'zero'
+  const d = new Decimal(v)
+  if (d.isZero()) return 'zero'
+  return d.isPositive() ? 'pos' : 'neg'
+}
+
+function formatPriceShort(v: string): string {
+  return new Decimal(v).toFixed(2)
+}

--- a/front/components/trade/portfolio/PortfolioPanel.stories.tsx
+++ b/front/components/trade/portfolio/PortfolioPanel.stories.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react'
+
+import { mockStore } from '../../../lib/mock-store'
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+import { walletStore } from '../../../lib/wallet/mock-store'
+
+import { PortfolioPanel } from './PortfolioPanel'
+
+// Ladle stories for visual verification. Each story imperatively positions
+// the mock + wallet stores before render; Ladle isolates stories in their
+// own iframe so per-story side effects don't leak across the gallery.
+
+function useDisconnectedOnMount() {
+  React.useEffect(() => {
+    walletStore.disconnect()
+    return () => walletStore.disconnect()
+  }, [])
+}
+
+function useConnectedOnMount() {
+  React.useEffect(() => {
+    walletStore.connect()
+    return () => walletStore.disconnect()
+  }, [])
+}
+
+function useSeededFills(args: { buys: number; sells: number }) {
+  React.useEffect(() => {
+    const s = mockStore.getState()
+    s.stop()
+    s.reset()
+    for (let i = 0; i < args.buys; i++) {
+      s.placeOrder({ side: Side.BUY, price: '3000', size: '0.25' })
+      s.runAuction()
+    }
+    for (let i = 0; i < args.sells; i++) {
+      s.placeOrder({ side: Side.SELL, price: '3050', size: '0.25' })
+      s.runAuction()
+    }
+    return () => {
+      s.stop()
+    }
+  }, [args.buys, args.sells])
+}
+
+function useLiveTicks() {
+  React.useEffect(() => {
+    const s = mockStore.getState()
+    s.start({ perturbMs: 1000, auctionMs: 4000 })
+    return () => s.stop()
+  }, [])
+}
+
+export const Disconnected = () => {
+  useDisconnectedOnMount()
+  return <PortfolioPanel />
+}
+
+export const EmptyConnected = () => {
+  useConnectedOnMount()
+  React.useEffect(() => {
+    mockStore.getState().reset()
+  }, [])
+  return <PortfolioPanel />
+}
+
+export const WithFills = () => {
+  useConnectedOnMount()
+  useSeededFills({ buys: 3, sells: 1 })
+  return <PortfolioPanel />
+}
+
+export const FlatRoundTrip = () => {
+  useConnectedOnMount()
+  // Same buys/sells size — net WETH flat, USDC delta = realized P&L.
+  useSeededFills({ buys: 2, sells: 2 })
+  return <PortfolioPanel />
+}
+
+export const LiveAuctions = () => {
+  // Watch the panel react as the mock auction tick consumes orders.
+  useConnectedOnMount()
+  React.useEffect(() => {
+    const s = mockStore.getState()
+    s.reset()
+    // Seed a couple of standing orders so the live auctions have something to fill.
+    s.placeOrder({ side: Side.BUY, price: '3010', size: '0.5' })
+    s.placeOrder({ side: Side.BUY, price: '2990', size: '0.5' })
+    s.placeOrder({ side: Side.SELL, price: '3020', size: '0.5' })
+  }, [])
+  useLiveTicks()
+  return <PortfolioPanel />
+}

--- a/front/components/trade/portfolio/PortfolioPanel.test.tsx
+++ b/front/components/trade/portfolio/PortfolioPanel.test.tsx
@@ -1,0 +1,78 @@
+// Smoke tests for the portfolio surface. Mirrors the BalancesPanel
+// pattern: SSR-only static markup, no DOM. Locks the wallet-store +
+// mock-store contracts end-to-end (disconnected → fill table + empty
+// state; connected → P&L card + fill table) so the panel survives the
+// next mock-store refactor.
+
+import * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { createMockStore } from '../../../lib/mock-store'
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+import { walletStore } from '../../../lib/wallet/mock-store'
+
+import { PortfolioPanel } from './PortfolioPanel'
+
+function render(): string {
+  return renderToStaticMarkup(<PortfolioPanel />)
+}
+
+describe('PortfolioPanel', () => {
+  beforeEach(() => {
+    walletStore.disconnect()
+  })
+
+  afterEach(() => {
+    walletStore.disconnect()
+  })
+
+  it('renders the page header in every state', () => {
+    expect(render()).toContain('[ PORTFOLIO · ETH / USDC ]')
+    expect(render()).toContain('POSITIONS')
+  })
+
+  it('renders a connect prompt when disconnected', () => {
+    // React encodes `&` as `&amp;` in SSR HTML.
+    expect(render()).toContain('[ CONNECT WALLET TO SEE POSITION + P&amp;L ]')
+  })
+
+  it('renders the P&L stat triplet when connected', () => {
+    walletStore.connect()
+    const html = render()
+    expect(html).toContain('WETH POSITION')
+    expect(html).toContain('USDC DELTA')
+    expect(html).toContain('UNREALIZED P&amp;L')
+  })
+
+  it('renders the fill-history empty state when no fills exist', () => {
+    const html = render()
+    expect(html).toContain('[ NO FILLS YET')
+    expect(html).toContain('[ FILL HISTORY · 00 ]')
+  })
+
+  it('disables the CSV export button when there are no fills', () => {
+    expect(render()).toMatch(/disabled[^>]*>?\s*\[ EXPORT CSV \]/)
+  })
+})
+
+describe('createMockStore + portfolio derivations (integration)', () => {
+  // Hits the same selectors the hook does, against a real store, to lock
+  // the wire contract between mock-store fills and the panel's numbers.
+  it('derives a position and P&L summary from store fills', async () => {
+    const store = createMockStore({ seed: 1, now: () => 1_700_000_000 })
+    store.getState().placeOrder({ side: Side.BUY, price: '3000', size: '1' })
+    const auction = store.getState().runAuction()
+    const fills = store.getState().fillHistory
+    expect(fills).toHaveLength(1)
+
+    const { computeSummary } = await import('./pnl')
+    const summary = computeSummary(fills, auction.clearingPrice)
+    expect(summary.position.weth).toBe('1')
+    // The mock auction records fills at the clearing price, not the
+    // posted order price — so the single-fill avgEntry equals the
+    // auction's clearingPrice.
+    expect(summary.avgEntry).toBe(fills[0].price)
+    expect(summary.mark).toBe(auction.clearingPrice)
+  })
+})

--- a/front/components/trade/portfolio/PortfolioPanel.tsx
+++ b/front/components/trade/portfolio/PortfolioPanel.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import * as React from 'react'
+
+import { useInternalBalances, useWallet } from '../../../lib/wallet/hooks'
+
+import { DivergenceBanner } from './DivergenceBanner'
+import { FillHistoryTable } from './FillHistoryTable'
+import { PnLCard } from './PnLCard'
+import { usePortfolio } from './usePortfolio'
+
+/**
+ * Portfolio surface: P&L summary + fill history. Mounts inside
+ * /app/portfolio (see app/app/portfolio/page.tsx).
+ *
+ * The disconnected state still surfaces the fill table so a returning
+ * trader can see what the session captured pre-disconnect, but the
+ * stat triplet collapses to a hint about wallet status.
+ */
+export function PortfolioPanel(): JSX.Element {
+  const { isConnected } = useWallet()
+  const internal = useInternalBalances()
+  const { fills, summary, divergence } = usePortfolio(internal)
+
+  return (
+    <div className="flex flex-col gap-4 px-4 py-6 sm:px-6 lg:px-8 lg:py-8">
+      <PageHeader />
+      {isConnected ? (
+        <>
+          <PnLCard summary={summary} />
+          <DivergenceBanner result={divergence} />
+        </>
+      ) : (
+        <Disconnected />
+      )}
+      <FillHistoryTable fills={fills} />
+    </div>
+  )
+}
+
+function PageHeader() {
+  return (
+    <header className="flex flex-col gap-1">
+      <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+        [ PORTFOLIO · ETH / USDC ]
+      </span>
+      <h1 className="font-display text-display-md tracking-brand text-brand-fg">POSITIONS</h1>
+    </header>
+  )
+}
+
+function Disconnected() {
+  return (
+    <section
+      aria-label="Wallet disconnected"
+      className="border border-brand-border bg-brand-surface px-5 py-6"
+    >
+      <p
+        role="status"
+        className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
+      >
+        [ CONNECT WALLET TO SEE POSITION + P&L ]
+      </p>
+    </section>
+  )
+}

--- a/front/components/trade/portfolio/csv.test.ts
+++ b/front/components/trade/portfolio/csv.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { Fill } from '../../../lib/mock-store'
+
+import { CSV_HEADER, fillsToCsv } from './csv'
+
+function fill(partial: Partial<Fill>): Fill {
+  return {
+    fillId: 'fill-default',
+    orderId: 'order-default',
+    auctionId: 'auction-default',
+    side: Side.BUY,
+    price: '3000',
+    size: '1',
+    timestampUnix: 1_700_000_000n,
+    ...partial,
+  }
+}
+
+describe('fillsToCsv', () => {
+  it('returns only the header for empty input', () => {
+    expect(fillsToCsv([])).toBe(`${CSV_HEADER}\n`)
+  })
+
+  it('emits one row per fill, newest first preserved', () => {
+    const fills = [
+      fill({ fillId: 'a', timestampUnix: 1_700_000_100n }),
+      fill({ fillId: 'b', timestampUnix: 1_700_000_000n }),
+    ]
+    const csv = fillsToCsv(fills)
+    const lines = csv.trimEnd().split('\n')
+    expect(lines[0]).toBe(CSV_HEADER)
+    expect(lines).toHaveLength(3)
+    expect(lines[1]).toContain('a')
+    expect(lines[2]).toContain('b')
+  })
+
+  it('formats timestamps as ISO 8601 UTC', () => {
+    const csv = fillsToCsv([
+      fill({ timestampUnix: 1_700_000_000n }), // 2023-11-14T22:13:20Z
+    ])
+    expect(csv).toContain('2023-11-14T22:13:20.000Z')
+  })
+
+  it('emits the human-readable side as BUY / SELL', () => {
+    const csv = fillsToCsv([fill({ side: Side.BUY }), fill({ side: Side.SELL })])
+    expect(csv).toContain('BUY')
+    expect(csv).toContain('SELL')
+  })
+
+  it('keeps price and size as wire-string decimals', () => {
+    const csv = fillsToCsv([fill({ price: '3000.55', size: '0.1234' })])
+    expect(csv).toContain('3000.55')
+    expect(csv).toContain('0.1234')
+  })
+
+  it('escapes ids that contain commas or quotes', () => {
+    const csv = fillsToCsv([fill({ fillId: 'a"b', auctionId: 'auc,1' })])
+    expect(csv).toContain('"a""b"')
+    expect(csv).toContain('"auc,1"')
+  })
+
+  it('terminates the final row with a newline', () => {
+    const csv = fillsToCsv([fill({})])
+    expect(csv.endsWith('\n')).toBe(true)
+  })
+})

--- a/front/components/trade/portfolio/csv.ts
+++ b/front/components/trade/portfolio/csv.ts
@@ -1,0 +1,36 @@
+// Pure CSV serializer for the fill-history table. Keeps export logic out
+// of the React tree so it can be unit-tested without a DOM and re-used
+// by I2.11 (#101) when fill history moves into IndexedDB.
+
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { Fill } from '../../../lib/mock-store'
+
+export const CSV_HEADER = 'timestamp,side,price,size,fill_id,order_id,auction_id'
+
+function quote(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`
+  }
+  return value
+}
+
+function sideLabel(side: Side): string {
+  switch (side) {
+    case Side.BUY:
+      return 'BUY'
+    case Side.SELL:
+      return 'SELL'
+    default:
+      return 'UNSPECIFIED'
+  }
+}
+
+export function fillsToCsv(fills: readonly Fill[]): string {
+  const rows = fills.map((f) => {
+    const ts = new Date(Number(f.timestampUnix) * 1000).toISOString()
+    return [ts, sideLabel(f.side), f.price, f.size, f.fillId, f.orderId, f.auctionId]
+      .map(quote)
+      .join(',')
+  })
+  return `${CSV_HEADER}\n${rows.join('\n')}${rows.length > 0 ? '\n' : ''}`
+}

--- a/front/components/trade/portfolio/format.test.ts
+++ b/front/components/trade/portfolio/format.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatBatch, formatFillTimestamp } from './format'
+
+describe('formatFillTimestamp', () => {
+  it('renders a stable UTC timestamp', () => {
+    // 1_700_000_000 → 2023-11-14T22:13:20Z
+    expect(formatFillTimestamp(1_700_000_000n)).toBe('22:13:20 · 14 NOV')
+  })
+
+  it('zero-pads hours, minutes and seconds', () => {
+    // 2023-01-01T00:00:00Z
+    expect(formatFillTimestamp(1_672_531_200n)).toBe('00:00:00 · 01 JAN')
+  })
+})
+
+describe('formatBatch', () => {
+  it('returns short ids untouched', () => {
+    expect(formatBatch('auc-001')).toBe('auc-001')
+  })
+
+  it('truncates long ids with an ellipsis', () => {
+    expect(formatBatch('auc-abcdefghij')).toBe('auc-ab…ghij')
+  })
+})

--- a/front/components/trade/portfolio/format.ts
+++ b/front/components/trade/portfolio/format.ts
@@ -1,0 +1,45 @@
+// Display formatters specific to the portfolio panel. Kept separate from
+// the tape's formatters so each panel can move independently — the only
+// shared dependency is the per-token display precision in
+// front/components/trade/balances/format-balance.ts (lib-level constant).
+
+const MONTHS = [
+  'JAN',
+  'FEB',
+  'MAR',
+  'APR',
+  'MAY',
+  'JUN',
+  'JUL',
+  'AUG',
+  'SEP',
+  'OCT',
+  'NOV',
+  'DEC',
+] as const
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`
+}
+
+/** Format a unix-seconds bigint as `HH:MM:SS · DD MON` for the fill table. */
+export function formatFillTimestamp(unixSeconds: bigint): string {
+  const d = new Date(Number(unixSeconds) * 1000)
+  const hh = pad2(d.getUTCHours())
+  const mm = pad2(d.getUTCMinutes())
+  const ss = pad2(d.getUTCSeconds())
+  const day = pad2(d.getUTCDate())
+  const mon = MONTHS[d.getUTCMonth()]
+  return `${hh}:${mm}:${ss} · ${day} ${mon}`
+}
+
+/**
+ * Auction-id placeholder rendered in the BATCH column. The wire field is
+ * a 14-char hex-ish slug from the mock factory; we truncate to keep the
+ * column readable and link-shaped, mirroring the Etherscan-style hashes
+ * Phase 2 (#100) will swap in.
+ */
+export function formatBatch(auctionId: string): string {
+  if (auctionId.length <= 12) return auctionId
+  return `${auctionId.slice(0, 6)}…${auctionId.slice(-4)}`
+}

--- a/front/components/trade/portfolio/index.ts
+++ b/front/components/trade/portfolio/index.ts
@@ -1,0 +1,26 @@
+export { DivergenceBanner } from './DivergenceBanner'
+export { ExportCsvButton } from './ExportCsvButton'
+export { FillHistoryRow } from './FillHistoryRow'
+export { FillHistoryTable } from './FillHistoryTable'
+export { PnLCard } from './PnLCard'
+export { PortfolioPanel } from './PortfolioPanel'
+export { fillsToCsv, CSV_HEADER } from './csv'
+export { formatBatch, formatFillTimestamp } from './format'
+export {
+  EPSILON_USDC,
+  EPSILON_WETH,
+  computeDivergence,
+  computePosition,
+  computeRealizedPnl,
+  computeSummary,
+  computeUnrealizedPnl,
+  weightedAvgEntry,
+} from './pnl'
+export type { DivergenceResult, PortfolioSummary, Position } from './pnl'
+export {
+  selectLatestClearingPrice,
+  selectPortfolioFills,
+  selectPortfolioSummary,
+  usePortfolio,
+} from './usePortfolio'
+export type { UsePortfolioReturn } from './usePortfolio'

--- a/front/components/trade/portfolio/pnl.test.ts
+++ b/front/components/trade/portfolio/pnl.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { Fill } from '../../../lib/mock-store'
+
+import {
+  EPSILON_WETH,
+  EPSILON_USDC,
+  computeDivergence,
+  computePosition,
+  computeRealizedPnl,
+  computeSummary,
+  computeUnrealizedPnl,
+  weightedAvgEntry,
+} from './pnl'
+
+function fill(side: Side, price: string, size: string, ts = 1n): Fill {
+  return {
+    fillId: `f-${ts}-${side}-${price}-${size}`,
+    orderId: `o-${ts}`,
+    auctionId: `a-${ts}`,
+    side,
+    price,
+    size,
+    timestampUnix: ts,
+  }
+}
+
+describe('computePosition', () => {
+  it('returns zero deltas for an empty fill set', () => {
+    const p = computePosition([])
+    expect(p.weth).toBe('0')
+    expect(p.usdc).toBe('0')
+  })
+
+  it('treats a BUY as +size WETH, -size*price USDC', () => {
+    const p = computePosition([fill(Side.BUY, '3000', '1')])
+    expect(p.weth).toBe('1')
+    expect(p.usdc).toBe('-3000')
+  })
+
+  it('treats a SELL as -size WETH, +size*price USDC', () => {
+    const p = computePosition([fill(Side.SELL, '3050', '2')])
+    expect(p.weth).toBe('-2')
+    expect(p.usdc).toBe('6100')
+  })
+
+  it('accumulates mixed fills', () => {
+    const p = computePosition([
+      fill(Side.BUY, '3000', '1'),
+      fill(Side.BUY, '3010', '0.5'),
+      fill(Side.SELL, '3050', '0.5'),
+    ])
+    // weth: 1 + 0.5 - 0.5 = 1
+    // usdc: -3000 - 1505 + 1525 = -2980
+    expect(p.weth).toBe('1')
+    expect(p.usdc).toBe('-2980')
+  })
+})
+
+describe('weightedAvgEntry', () => {
+  it('returns null for empty fills', () => {
+    expect(weightedAvgEntry([], Side.BUY)).toBeNull()
+  })
+
+  it('returns the single-fill price when only one entry exists', () => {
+    expect(weightedAvgEntry([fill(Side.BUY, '3000', '1')], Side.BUY)).toBe('3000')
+  })
+
+  it('returns the size-weighted average price across multiple entries', () => {
+    // 1 ETH @ 3000 + 3 ETH @ 3200 = 12600 / 4 = 3150
+    const fills = [fill(Side.BUY, '3000', '1'), fill(Side.BUY, '3200', '3')]
+    expect(weightedAvgEntry(fills, Side.BUY)).toBe('3150')
+  })
+
+  it('only considers fills on the requested side', () => {
+    const fills = [
+      fill(Side.BUY, '3000', '1'),
+      fill(Side.SELL, '9999', '1'),
+      fill(Side.BUY, '3200', '3'),
+    ]
+    expect(weightedAvgEntry(fills, Side.BUY)).toBe('3150')
+  })
+
+  it('returns null when no fills on the requested side', () => {
+    expect(weightedAvgEntry([fill(Side.BUY, '3000', '1')], Side.SELL)).toBeNull()
+  })
+})
+
+describe('computeUnrealizedPnl', () => {
+  it('returns null when net position is zero', () => {
+    const fills = [fill(Side.BUY, '3000', '1'), fill(Side.SELL, '3050', '1')]
+    expect(computeUnrealizedPnl(fills, '3100')).toBeNull()
+  })
+
+  it('returns null with no fills', () => {
+    expect(computeUnrealizedPnl([], '3100')).toBeNull()
+  })
+
+  it('returns null when mark price is missing', () => {
+    expect(computeUnrealizedPnl([fill(Side.BUY, '3000', '1')], null)).toBeNull()
+  })
+
+  it('computes positive P&L for a long when mark > avg entry', () => {
+    // 1 ETH @ 3000, mark 3100 → +100 USDC
+    expect(computeUnrealizedPnl([fill(Side.BUY, '3000', '1')], '3100')).toBe('100')
+  })
+
+  it('computes negative P&L for a long when mark < avg entry', () => {
+    expect(computeUnrealizedPnl([fill(Side.BUY, '3000', '1')], '2950')).toBe('-50')
+  })
+
+  it('computes positive P&L for a short when mark < avg entry', () => {
+    // sold 1 ETH @ 3000, mark 2950 → +50 USDC
+    expect(computeUnrealizedPnl([fill(Side.SELL, '3000', '1')], '2950')).toBe('50')
+  })
+
+  it('uses only the relevant entry side to derive avg entry on a net-long book', () => {
+    // 2 BUY @ 3000, 1 SELL @ 9999 → net +1 WETH; avg entry from buys = 3000; mark 3100
+    // pnl = (3100 - 3000) * 1 = 100
+    const fills = [fill(Side.BUY, '3000', '2'), fill(Side.SELL, '9999', '1')]
+    expect(computeUnrealizedPnl(fills, '3100')).toBe('100')
+  })
+})
+
+describe('computeRealizedPnl', () => {
+  it('returns 0 when no round trips exist', () => {
+    expect(computeRealizedPnl([fill(Side.BUY, '3000', '1')])).toBe('0')
+  })
+
+  it('captures a simple round trip', () => {
+    // buy 1 @ 3000, sell 1 @ 3050 → cash delta of +50 USDC
+    const fills = [fill(Side.BUY, '3000', '1'), fill(Side.SELL, '3050', '1')]
+    expect(computeRealizedPnl(fills)).toBe('50')
+  })
+
+  it('matches USDC delta when net WETH returns to zero', () => {
+    const fills = [
+      fill(Side.BUY, '3000', '0.5'),
+      fill(Side.BUY, '3010', '0.5'),
+      fill(Side.SELL, '3050', '1'),
+    ]
+    // usdc: -1500 - 1505 + 3050 = 45
+    expect(computeRealizedPnl(fills)).toBe('45')
+  })
+
+  it('returns 0 while a position is still open', () => {
+    const fills = [fill(Side.BUY, '3000', '1')]
+    expect(computeRealizedPnl(fills)).toBe('0')
+  })
+})
+
+describe('computeDivergence', () => {
+  it('reports no divergence when expected delta matches internal balance', () => {
+    // No fills, no balance → no divergence.
+    const result = computeDivergence([], { weth: '0', usdc: '0' })
+    expect(result.diverged).toBe(false)
+    expect(result.expected.weth).toBe('0')
+    expect(result.expected.usdc).toBe('0')
+  })
+
+  it('flags divergence when fills exist but internal balance is zero', () => {
+    const fills = [fill(Side.BUY, '3000', '1')]
+    const result = computeDivergence(fills, { weth: '0', usdc: '0' })
+    expect(result.diverged).toBe(true)
+    expect(result.expected.weth).toBe('1')
+    expect(result.expected.usdc).toBe('-3000')
+    expect(result.actual.weth).toBe('0')
+    expect(result.actual.usdc).toBe('0')
+  })
+
+  it('does not flag divergence within epsilon', () => {
+    const fills = [fill(Side.BUY, '3000', '1')]
+    // Internal balance reflects the fill within epsilon
+    const result = computeDivergence(fills, { weth: '1', usdc: '-3000' })
+    expect(result.diverged).toBe(false)
+  })
+
+  it('flags divergence when difference exceeds epsilon', () => {
+    const fills = [fill(Side.BUY, '3000', '1')]
+    // 0.001 WETH off — exceeds EPSILON_WETH
+    const result = computeDivergence(fills, { weth: '1.001', usdc: '-3000' })
+    expect(result.diverged).toBe(true)
+  })
+
+  it('handles only-WETH divergence', () => {
+    const fills = [fill(Side.BUY, '3000', '1')]
+    const result = computeDivergence(fills, { weth: '0.5', usdc: '-3000' })
+    expect(result.diverged).toBe(true)
+  })
+
+  it('exposes the epsilon constants as part of the public contract', () => {
+    expect(EPSILON_WETH).toBeDefined()
+    expect(EPSILON_USDC).toBeDefined()
+  })
+})
+
+describe('computeSummary', () => {
+  it('returns a fully populated summary on a round trip with mark', () => {
+    const fills = [fill(Side.BUY, '3000', '1'), fill(Side.SELL, '3050', '0.5')]
+    const summary = computeSummary(fills, '3100')
+    expect(summary.position.weth).toBe('0.5')
+    expect(summary.position.usdc).toBe('-1475')
+    expect(summary.avgEntry).toBe('3000')
+    expect(summary.unrealizedPnl).toBe('50') // (3100-3000)*0.5
+    expect(summary.realizedPnl).toBe('0') // still open
+    expect(summary.mark).toBe('3100')
+  })
+
+  it('returns null mark + null unrealized when no auctions yet', () => {
+    const fills = [fill(Side.BUY, '3000', '1')]
+    const summary = computeSummary(fills, null)
+    expect(summary.mark).toBeNull()
+    expect(summary.unrealizedPnl).toBeNull()
+    expect(summary.avgEntry).toBe('3000')
+  })
+})

--- a/front/components/trade/portfolio/pnl.test.ts
+++ b/front/components/trade/portfolio/pnl.test.ts
@@ -189,6 +189,18 @@ describe('computeDivergence', () => {
     expect(result.diverged).toBe(true)
   })
 
+  it('flags divergence when balance is non-zero but no fills exist (deposit-only case)', () => {
+    // Phase 1 invariant: a deposit lands without producing a fill, so the
+    // banner correctly fires until #72 + #101 close the loop. Locks the
+    // semantic documented in computeDivergence's docstring.
+    const result = computeDivergence([], { weth: '1', usdc: '500' })
+    expect(result.diverged).toBe(true)
+    expect(result.expected.weth).toBe('0')
+    expect(result.expected.usdc).toBe('0')
+    expect(result.actual.weth).toBe('1')
+    expect(result.actual.usdc).toBe('500')
+  })
+
   it('exposes the epsilon constants as part of the public contract', () => {
     expect(EPSILON_WETH).toBeDefined()
     expect(EPSILON_USDC).toBeDefined()

--- a/front/components/trade/portfolio/pnl.ts
+++ b/front/components/trade/portfolio/pnl.ts
@@ -130,6 +130,24 @@ export function computeRealizedPnl(fills: readonly Fill[]): string {
   return position.usdc
 }
 
+/**
+ * Compare the fill-derived position against the pool's internal balance.
+ *
+ * Phase 1 limitation: `internal` is the wallet store's `internalBalances`
+ * snapshot, which has no deposit/withdrawal history layered in (#72 ships
+ * that). The strict-equality check below therefore fires whenever the
+ * trader has either (a) any non-zero pool balance with no fills, or
+ * (b) any fills with no matching pool balance. Both are *symptoms* of
+ * the same gap — the local session can't reconstruct
+ * `deposits + fills - withdrawals`. The banner copy in
+ * `DivergenceBanner.tsx` is intentionally framed around the symptom so
+ * we don't claim "lost history" when the real cause is "deposits not
+ * yet tracked".
+ *
+ * Phase 2 path: feed `internal` through `deposits + fills - withdrawals`
+ * before calling, and the same function narrows to its intended meaning
+ * — lost fill history — without a signature change.
+ */
 export function computeDivergence(fills: readonly Fill[], internal: Position): DivergenceResult {
   const expected = computePosition(fills)
   const wethDiff = toDec(expected.weth).minus(internal.weth).abs()

--- a/front/components/trade/portfolio/pnl.ts
+++ b/front/components/trade/portfolio/pnl.ts
@@ -1,0 +1,155 @@
+// Pure P&L math for the portfolio panel. No React, no DOM.
+//
+// All inputs come in as wire-string decimals (Fill.price, Fill.size,
+// AuctionSummary.clearingPrice — see docs/adr/0002-decimals.md). All
+// outputs are wire-string decimals too. Internal math goes through
+// Decimal to avoid binary-float drift.
+
+import { Decimal } from '../../../lib/units'
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { Fill } from '../../../lib/mock-store'
+
+export interface Position {
+  /** Net WETH delta from fills (positive = long). */
+  weth: string
+  /** Net USDC delta from fills (negative when net long). */
+  usdc: string
+}
+
+export interface DivergenceResult {
+  /** Whether the fill-derived position diverges from the on-chain internal balance. */
+  diverged: boolean
+  /** Position derived from the local fill history. */
+  expected: Position
+  /** Internal balance reported by the wallet/pool. */
+  actual: Position
+}
+
+export interface PortfolioSummary {
+  /** Net position from accumulating fills. */
+  position: Position
+  /** Size-weighted avg entry price on the side that opened the position, or null when flat. */
+  avgEntry: string | null
+  /** Latest clearing price used as mark; null when no auction has cleared. */
+  mark: string | null
+  /** Unrealized P&L vs the mark; null when flat or no mark. */
+  unrealizedPnl: string | null
+  /** Realized P&L (cash delta whenever a round-trip closes). */
+  realizedPnl: string
+}
+
+/**
+ * Divergence epsilons. We tolerate one unit of display precision so a
+ * 4dp rounding mismatch between the wallet store and the fill-derived
+ * position doesn't trip the banner.
+ */
+export const EPSILON_WETH = new Decimal('0.0001')
+export const EPSILON_USDC = new Decimal('0.01')
+
+function toDec(v: string): Decimal {
+  return new Decimal(v)
+}
+
+/**
+ * Accumulate per-side deltas. A BUY consumes USDC and produces WETH; a
+ * SELL is the reverse. The mock store never emits a fill outside this
+ * binary, so we don't need to handle Side.UNSPECIFIED here.
+ */
+export function computePosition(fills: readonly Fill[]): Position {
+  let weth = new Decimal(0)
+  let usdc = new Decimal(0)
+  for (const f of fills) {
+    const size = toDec(f.size)
+    const notional = size.times(f.price)
+    if (f.side === Side.BUY) {
+      weth = weth.plus(size)
+      usdc = usdc.minus(notional)
+    } else {
+      weth = weth.minus(size)
+      usdc = usdc.plus(notional)
+    }
+  }
+  return { weth: weth.toFixed(), usdc: usdc.toFixed() }
+}
+
+/**
+ * Size-weighted average price across fills on `side`. Returns null when
+ * no fill on that side exists.
+ */
+export function weightedAvgEntry(fills: readonly Fill[], side: Side): string | null {
+  let totalSize = new Decimal(0)
+  let totalNotional = new Decimal(0)
+  for (const f of fills) {
+    if (f.side !== side) continue
+    const size = toDec(f.size)
+    totalSize = totalSize.plus(size)
+    totalNotional = totalNotional.plus(size.times(f.price))
+  }
+  if (totalSize.isZero()) return null
+  return totalNotional.div(totalSize).toFixed()
+}
+
+/**
+ * Unrealized P&L for the open position vs the mark. Returns null when
+ * the book is flat or no mark is available.
+ *
+ * The MVP uses naive weighted-avg cost basis on the entry side — proper
+ * FIFO/LIFO accounting is out of scope for the mock and lands behind the
+ * real Phase 2 surface.
+ */
+export function computeUnrealizedPnl(
+  fills: readonly Fill[],
+  markPrice: string | null
+): string | null {
+  if (markPrice === null) return null
+  const position = toDec(computePosition(fills).weth)
+  if (position.isZero()) return null
+  const entrySide = position.isPositive() ? Side.BUY : Side.SELL
+  const avgEntry = weightedAvgEntry(fills, entrySide)
+  if (avgEntry === null) return null
+  const mark = toDec(markPrice)
+  const avg = toDec(avgEntry)
+  // (mark - avg) * position; for shorts position is negative, so the sign flips automatically.
+  return mark.minus(avg).times(position).toFixed()
+}
+
+/**
+ * Realized P&L is the USDC delta locked in once the position returns to
+ * (or crosses) flat. In the MVP we approximate it with the cash delta
+ * net of the still-open notional, valued at the most recent entry price.
+ *
+ * Pragmatic shortcut: when the position is currently flat, the entire
+ * USDC delta is realized; while a position is open, realized P&L is
+ * zero — the open exposure hides the rest. This is the same shortcut
+ * Hyperliquid takes in its positions panel and is consistent with the
+ * avg-entry weighting above.
+ */
+export function computeRealizedPnl(fills: readonly Fill[]): string {
+  const position = computePosition(fills)
+  if (!toDec(position.weth).isZero()) return '0'
+  return position.usdc
+}
+
+export function computeDivergence(fills: readonly Fill[], internal: Position): DivergenceResult {
+  const expected = computePosition(fills)
+  const wethDiff = toDec(expected.weth).minus(internal.weth).abs()
+  const usdcDiff = toDec(expected.usdc).minus(internal.usdc).abs()
+  const diverged = wethDiff.gt(EPSILON_WETH) || usdcDiff.gt(EPSILON_USDC)
+  return { diverged, expected, actual: { ...internal } }
+}
+
+export function computeSummary(fills: readonly Fill[], markPrice: string | null): PortfolioSummary {
+  const position = computePosition(fills)
+  const netWeth = toDec(position.weth)
+  const entrySide = netWeth.isZero() ? null : netWeth.isPositive() ? Side.BUY : Side.SELL
+  const avgEntry = entrySide === null ? null : weightedAvgEntry(fills, entrySide)
+  const unrealizedPnl = computeUnrealizedPnl(fills, markPrice)
+  const realizedPnl = computeRealizedPnl(fills)
+  return {
+    position,
+    avgEntry,
+    mark: markPrice,
+    unrealizedPnl,
+    realizedPnl,
+  }
+}

--- a/front/components/trade/portfolio/usePortfolio.test.ts
+++ b/front/components/trade/portfolio/usePortfolio.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { createMockStore } from '../../../lib/mock-store'
+import { Side } from '../../../lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import {
+  selectLatestClearingPrice,
+  selectPortfolioFills,
+  selectPortfolioSummary,
+} from './usePortfolio'
+
+const FROZEN_NOW = 1_700_000_000
+
+function freshState(seed = 7) {
+  return createMockStore({
+    seed,
+    now: () => FROZEN_NOW,
+    mid: '3000',
+    depth: 4,
+    auctionHistory: 4,
+  }).getState()
+}
+
+describe('selectPortfolioFills', () => {
+  it('returns the store fillHistory newest-first', () => {
+    const store = createMockStore({ seed: 1, now: () => FROZEN_NOW })
+    store.getState().placeOrder({ side: Side.BUY, price: '3000', size: '0.5' })
+    store.getState().runAuction()
+    const fills = selectPortfolioFills(store.getState())
+    expect(fills).toBe(store.getState().fillHistory)
+  })
+
+  it('returns an empty array when no fills exist yet', () => {
+    expect(selectPortfolioFills(freshState())).toHaveLength(0)
+  })
+})
+
+describe('selectLatestClearingPrice', () => {
+  it('returns the latest auction clearing price as a wire string', () => {
+    const state = freshState()
+    expect(state.recentAuctions.length).toBeGreaterThan(0)
+    const latest = selectLatestClearingPrice(state)
+    expect(latest).toBe(state.recentAuctions[0].clearingPrice)
+  })
+
+  it('returns null when no auctions have cleared', () => {
+    const store = createMockStore({ seed: 1, now: () => FROZEN_NOW, auctionHistory: 0 })
+    expect(selectLatestClearingPrice(store.getState())).toBeNull()
+  })
+})
+
+describe('selectPortfolioSummary', () => {
+  it('combines fills and latest clearing price into a summary', () => {
+    const store = createMockStore({
+      seed: 99,
+      now: () => FROZEN_NOW,
+      depth: 4,
+      auctionHistory: 2,
+    })
+    store.getState().placeOrder({ side: Side.BUY, price: '5000', size: '1' })
+    store.getState().runAuction()
+    const summary = selectPortfolioSummary(store.getState())
+    expect(summary.position.weth).toBe('1')
+    expect(summary.mark).toBe(store.getState().recentAuctions[0].clearingPrice)
+    // P&L = (mark - avgEntry) * 1 — depends on auction sampling but should be a finite string.
+    expect(summary.unrealizedPnl).toMatch(/^-?\d+(\.\d+)?$/)
+  })
+})

--- a/front/components/trade/portfolio/usePortfolio.ts
+++ b/front/components/trade/portfolio/usePortfolio.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { type MockStoreState, useMockStore } from '../../../lib/mock-store'
+import type { Fill } from '../../../lib/mock-store'
+
+import { computeDivergence, computeSummary } from './pnl'
+import type { DivergenceResult, PortfolioSummary } from './pnl'
+import type { Position } from './pnl'
+
+export interface UsePortfolioReturn {
+  fills: readonly Fill[]
+  summary: PortfolioSummary
+  divergence: DivergenceResult
+}
+
+// ─── Pure selectors (unit-testable) ──────────────────────────────────────
+
+export function selectPortfolioFills(state: MockStoreState): readonly Fill[] {
+  return state.fillHistory
+}
+
+export function selectLatestClearingPrice(state: MockStoreState): string | null {
+  if (state.recentAuctions.length === 0) return null
+  return state.recentAuctions[0].clearingPrice
+}
+
+export function selectPortfolioSummary(state: MockStoreState): PortfolioSummary {
+  return computeSummary(selectPortfolioFills(state), selectLatestClearingPrice(state))
+}
+
+// ─── React hook ─────────────────────────────────────────────────────────
+
+/**
+ * Subscribes to the mock store and derives the portfolio view. The summary
+ * is memoised on the underlying `fillHistory` + `recentAuctions[0]`
+ * references — both stable when the store hasn't pushed a new auction —
+ * so the panel only re-renders when something actually changed.
+ *
+ * Divergence is computed against the caller-supplied `internal` balance
+ * so the hook stays decoupled from the wallet store and works for both
+ * the disconnected + connected paths in the panel.
+ */
+export function usePortfolio(internal: Position): UsePortfolioReturn {
+  const fills = useMockStore(selectPortfolioFills)
+  const mark = useMockStore(selectLatestClearingPrice)
+  const summary = useMemo(() => computeSummary(fills, mark), [fills, mark])
+  const divergence = useMemo(() => computeDivergence(fills, internal), [fills, internal])
+  return { fills, summary, divergence }
+}

--- a/front/next.config.mjs
+++ b/front/next.config.mjs
@@ -12,6 +12,21 @@ const nextConfig = {
       },
     ];
   },
+  // The proto-generated TypeScript sources import each other with explicit
+  // `.js` extensions (per `import_extension=js` in lib/sdk/buf.gen.yaml).
+  // That's the standard pattern for ESM-style TS — tsc + Vitest resolve
+  // it through `moduleResolution: bundler` — but Next.js's webpack needs
+  // an explicit extensionAlias to follow the same path. Added when F1.11
+  // (#78) wired the first route that transitively pulls in the proto
+  // chain via lib/mock-store.
+  webpack: (config) => {
+    config.resolve = config.resolve ?? {};
+    config.resolve.extensionAlias = {
+      ...(config.resolve.extensionAlias ?? {}),
+      '.js': ['.js', '.ts', '.tsx'],
+    };
+    return config;
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
Closes #78

## What

Adds the portfolio surface — `/app/portfolio` — backed by the F1.2 mock store.

- **`PnLCard`** stat triplet: WETH position, USDC cash delta, unrealized P&L vs the latest clearing price as mark. Positive P&L is the single lime accent for this surface (per `docs/DESIGN-INSPIRATIONS.md`).
- **`FillHistoryTable`** with timestamp, side, price, size, batch placeholder columns; tabular mono, no zebra striping (matches `table-row`).
- **`ExportCsvButton`** — client-side Blob download; `fillsToCsv` is a pure stringifier with CSV-safe escaping.
- **`DivergenceBanner`** fires when the position derived from local fills can't reconcile against the wallet's internal balance (within epsilon).
- All numeric math goes through `decimal.js`; wire fields stay as decimal strings end-to-end.

## File scope

Strictly inside the F1.11 envelope from `docs/PARALLEL-WORK.md`:

- `front/components/trade/portfolio/` (new)
- `front/app/app/portfolio/page.tsx` (new)
- `front/next.config.mjs` — **5-line additive webpack `extensionAlias` fix.** This is the scaffolding bucket; flagging it explicitly. See below.

## Note on `next.config.mjs`

This PR is the first to wire a Next.js route that transitively imports `lib/mock-store`, which is the first consumer of the proto-generated `darkpool_pb.ts` (with explicit `.js` extensions per `import_extension=js` in `lib/sdk/buf.gen.yaml`). `tsc` and Vitest already resolve those via `moduleResolution: bundler`; Next.js's webpack needs an explicit `extensionAlias` to follow the same path. Without it, `next build` and `next dev` both fail with `Module not found: Can't resolve './sdk/proto/darkpool/v1/darkpool_pb.js'`.

The fix is 5 lines and purely additive — it doesn't change behaviour for any existing route. F1.6 (#73) and F1.7 (#74) will hit the same issue the moment they're wired into a route, so landing this here unblocks the rest of Wave 4–6. Happy to pull it into its own scaffolding PR if you'd prefer; the rest of this PR doesn't depend on the change cosmetically (the components/tests/Ladle stories all pass without it).

## Test plan

- [x] `npm test` — 223 passing (50 new under `components/trade/portfolio/`)
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npm run build` — `/app/portfolio` static-rendered
- [x] `npm run dev` — `GET /app/portfolio` returns 200 with `[ PORTFOLIO · ETH / USDC ]`, `POSITIONS`, `[ FILL HISTORY ]`, `[ CONNECT WALLET ]`
- [x] Ladle stories: `Disconnected`, `EmptyConnected`, `WithFills`, `FlatRoundTrip`, `LiveAuctions`

## Pure-function tests

`pnl.ts` covers:
- `computePosition` (empty, BUY/SELL, mixed)
- `weightedAvgEntry` (empty, single, weighted across multiple, side-filtered)
- `computeUnrealizedPnl` (long mark>entry, long mark<entry, short, flat, null mark)
- `computeRealizedPnl` (open vs round-trip)
- `computeDivergence` (matching, fills-only, epsilon-edge)
- `computeSummary` (round-trip + null-mark variants)

`csv.ts` covers header-only emit, ISO 8601 timestamps, side labels, decimal preservation, CSV-safe quoting, trailing newline.

## Design adherence

- No hue used to signal sign. Sign reads as `+` / `−` in tabular mono.
- Lime accent on positive P&L only (this surface's accent budget per `docs/DESIGN-INSPIRATIONS.md`).
- Bracketed-tag labels (`[ FILL HISTORY · 03 ]`, `[ BUY ]`, `[ EXPORT CSV ]`, `[ HISTORY OUT OF SYNC ]`).
- Zero corner radius, 1px borders, `body-sm` + 12×16 padding rows, tabular-nums in every numeric column.