### PR TITLE
Add one-command local observability stack

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,48 @@ services:
       - "${DARKPOOL_GRPC_PORT:-9090}:9090"
       - "${DARKPOOL_HTTP_PORT:-8080}:8080"
 
+  jaeger:
+    image: jaegertracing/all-in-one:1.62.0
+    container_name: darkpool-jaeger
+    profiles: ["obs"]
+    restart: unless-stopped
+    environment:
+      COLLECTOR_OTLP_ENABLED: "true"
+    ports:
+      - "${JAEGER_UI_PORT:-16686}:16686"
+      - "${JAEGER_OTLP_GRPC_PORT:-4317}:4317"
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    container_name: darkpool-prometheus
+    profiles: ["obs"]
+    restart: unless-stopped
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --web.enable-lifecycle
+    volumes:
+      - ./observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "${PROMETHEUS_PORT:-9091}:9090"
+
+  grafana:
+    image: grafana/grafana:11.3.0
+    container_name: darkpool-grafana
+    profiles: ["obs"]
+    restart: unless-stopped
+    depends_on:
+      prometheus:
+        condition: service_started
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    volumes:
+      - ./observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./observability/grafana/darkpool.json:/var/lib/grafana/dashboards/darkpool.json:ro
+    ports:
+      - "${GRAFANA_PORT:-3001}:3000"
+
   keygen:
     image: darkpool-server:dev
     container_name: darkpool-keygen

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,6 +104,10 @@ services:
       DARKPOOL_RATE_BURST: ${DARKPOOL_RATE_BURST:-20}
       DARKPOOL_RATE_STALE_AFTER: ${DARKPOOL_RATE_STALE_AFTER:-10m}
       RUST_LOG: ${RUST_LOG:-info,dp_event=debug,dp_engine=info}
+      OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
+      OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-darkpool-api}
+      DP_ENVIRONMENT: ${DP_ENVIRONMENT:-local}
+      DP_LOG_FORMAT: ${DP_LOG_FORMAT:-json}
     entrypoint:
       - /bin/sh
       - -c

--- a/justfile
+++ b/justfile
@@ -100,6 +100,19 @@ up-zk:
     DARKPOOL_ZK_PROVING_KEY={{ZK_KEYS}} \
     {{COMPOSE}} --profile zk up -d --build
 
+# Bring up the obs stack (default services + prometheus/grafana/jaeger; server pushes OTLP to jaeger)
+up-obs:
+    OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://jaeger:4317} \
+    {{COMPOSE}} --profile obs up -d --build
+
+# Tear down only the obs services (leaves postgres/anvil/deployer/darkpool-server up)
+down-obs:
+    {{COMPOSE}} --profile obs rm -sf prometheus grafana jaeger
+
+# Tail logs for the obs services
+logs-obs:
+    {{COMPOSE}} --profile obs logs -f prometheus grafana jaeger
+
 # Foreground (logs streamed)
 up-fg:
     {{COMPOSE}} up --build

--- a/observability/README.md
+++ b/observability/README.md
@@ -25,6 +25,10 @@ surface.
 | `OTEL_SERVICE_NAME`            | `dp-api`                               | Resource attribute on every exported span.                                                                                            |
 | `DP_ENVIRONMENT`               | `development`                          | Sets the `deployment.environment` OTel resource attribute so spans from local / staging / prod are filterable in the collector. Falls back to `DEPLOYMENT_ENVIRONMENT` if unset.  |
 
+Defaults above are the binary's own fallbacks. `docker-compose.yml` overrides
+some of them for the obs stack (`OTEL_SERVICE_NAME=darkpool-api`,
+`DP_ENVIRONMENT=local`); see the quick-start section.
+
 ## Metric catalogue
 
 | Name                                              | Type      | Labels    | Description                                                  |
@@ -39,6 +43,66 @@ surface.
 | `darkpool_settlement_confirmations_total`         | counter   |           | `BatchSettled` events handled by `BatchSink::on_batch_settled`. |
 | `darkpool_active_orders`                          | gauge     |           | Orders resting in the book after each tick.                  |
 | `darkpool_event_log_size_bytes`                   | gauge     |           | Polled every 30 s. Backend-specific: `pg_total_relation_size('events')` for postgres, `metadata().len()` for the file store, `0` for in-memory. |
+
+## Quick start (local stack)
+
+The repo ships a complete Prometheus + Grafana + Jaeger stack wired
+to `darkpool-server`, gated behind a docker compose profile so the
+default `just up` is unaffected.
+
+```bash
+just up-obs
+```
+
+That brings up `postgres`, `anvil`, `deployer`, `darkpool-server`,
+`prometheus`, `grafana`, and `jaeger`. `OTEL_EXPORTER_OTLP_ENDPOINT`
+is exported in the recipe so the server ships spans to the in-network
+Jaeger at `http://jaeger:4317`.
+
+Smoke test (under a minute):
+
+```bash
+# 1. Server is healthy + emitting metric families
+curl -fsS http://localhost:8080/healthz
+curl -fsS http://localhost:8080/metrics | grep '^darkpool_' | head
+
+# 2. Prometheus has the darkpool target marked "up"
+curl -fsS http://localhost:9091/api/v1/targets \
+  | jq '.data.activeTargets[] | {labels, health}'
+
+# 3. Generate a handful of HTTP spans
+for i in $(seq 1 5); do curl -s http://localhost:8080/healthz > /dev/null; done
+```
+
+Open in a browser:
+
+- Grafana — http://localhost:3001 (anonymous admin) → Dashboards → **DarkPool Operator**. Host port `3001` avoids collision with `front/` Next.js dev (3000); override with `GRAFANA_PORT`.
+- Jaeger — http://localhost:16686 → Service `darkpool-api` → Find Traces
+
+Tear down the obs services only (leaves the trading stack running):
+
+```bash
+just down-obs
+```
+
+Tail the obs logs:
+
+```bash
+just logs-obs
+```
+
+Notes:
+- Histograms (`darkpool_auction_duration_seconds`,
+  `darkpool_batch_submission_duration_seconds`) only register after the
+  first observation. With no traffic the dashboard's percentile panels
+  stay empty — counters and gauges should still render.
+- Dashboard rate panels use a 5-minute window (`rate(...[5m])`). A
+  sub-5m smoke run will show flat lines even with traffic; let the stack
+  run ≥5 minutes before judging rate panels.
+- Grafana runs with anonymous admin access. Local dev only — do not
+  copy this config into a deployed environment.
+- Prometheus is published on host port `9091` (not `9090`) to avoid
+  colliding with the gRPC listener.
 
 ## Local development
 

--- a/observability/README.md
+++ b/observability/README.md
@@ -13,7 +13,7 @@ surface.
 | ---------- | ------ | ------------------------------------------------------- |
 | `/healthz` | `GET`  | Liveness. Returns `200 {"status":"ok"}` while the process is running. |
 | `/readyz`  | `GET`  | Readiness. `200` once every probe (event store, aggregator binary) is healthy; `503 {"status":"not_ready","failed":<probe_name>}` otherwise. The detailed failure reason is logged server-side (the endpoint is unauthenticated, so it must not echo internals). |
-| `/metrics` | `GET`  | Prometheus text exposition (`v0.0.4`). Pre-registers every metric the operator emits so families show up even before the first auction tick. |
+| `/metrics` | `GET`  | Prometheus text exposition (`v0.0.4`). Counter and gauge families are force-registered at startup so they appear before the first auction tick. Histogram families (`darkpool_auction_duration_seconds`, `darkpool_batch_submission_duration_seconds`) only appear after their first observation — see the histogram note in the quick-start section. |
 
 ## Environment variables
 

--- a/observability/grafana/darkpool.json
+++ b/observability/grafana/darkpool.json
@@ -166,7 +166,7 @@
         "name": "datasource",
         "type": "datasource",
         "query": "prometheus",
-        "current": { "selected": false, "text": "Prometheus", "value": "Prometheus" }
+        "current": { "selected": false, "text": "Prometheus", "value": "prometheus" }
       }
     ]
   },

--- a/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: darkpool
+    orgId: 1
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/observability/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/observability/prometheus.yml
+++ b/observability/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  external_labels:
+    environment: local
+
+scrape_configs:
+  - job_name: darkpool
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['darkpool-server:8080']


### PR DESCRIPTION
## Summary

- New `obs` docker compose profile spins up Prometheus, Grafana, and Jaeger alongside the existing trading stack and wires `darkpool-server` to ship OTLP spans at `http://jaeger:4317`.
- Grafana provisioning auto-loads the existing `observability/grafana/darkpool.json` dashboard against a Prometheus datasource with `uid: prometheus` (dashboard template fixed to match the lowercased uid).
- `just up-obs` / `just down-obs` / `just logs-obs` recipes; plain `just up` unchanged.
- Quick-start section in `observability/README.md` walks through smoke-testing in under a minute.

Refs #26. Lets the two unchecked manual-validation boxes on #121 be ticked locally.

## Test plan

- [x] `docker compose config --quiet` passes default profile
- [x] `docker compose --profile obs config --quiet` passes
- [x] `just up-obs` brings up postgres/anvil/deployer/darkpool-server + prometheus/grafana/jaeger (deployer exits 0)
- [x] `curl :8080/healthz` → `{"status":"ok"}`
- [x] `curl :8080/metrics` exposes 7 `darkpool_*` families pre-registered
- [x] `curl :9091/api/v1/targets` reports `job=darkpool health=up`
- [x] Grafana → datasource `prometheus` provisioned + default; dashboard "DarkPool Operator" auto-loaded; proxy query returns vector
- [x] 5× `curl :8080/healthz` → 5 `http` spans in Jaeger with `path=/healthz`, `service=darkpool-api`, `request_id` UUID
- [x] `just down-obs` removes only obs services; trading stack still healthy

## Notes

- `jaegertracing/all-in-one:1.62.0` (full semver; the short `1.62` tag does not resolve on Docker Hub).
- Grafana published on host `:3001` to avoid collision with `front/` Next.js dev (`:3000`); override via `GRAFANA_PORT`.
- Prometheus published on host `:9091` to avoid collision with the gRPC listener (`:9090`).
- Histograms and 5-minute-window rate panels stay empty without traffic — expected, documented in the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced optional observability stack with Prometheus, Grafana, and Jaeger for monitoring and tracing application performance.
  * Added new convenience commands for starting, stopping, and accessing logs from observability services.

* **Documentation**
  * Added comprehensive observability setup guide including quick-start workflow, access instructions, and operational guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->