### PR TITLE
[#24] TLS / mTLS for gRPC + REST listeners

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -523,7 +523,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tokio",
@@ -744,7 +744,7 @@ dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest",
+ "reqwest 0.13.3",
  "serde_json",
  "tower 0.5.3",
  "tracing",
@@ -1382,6 +1382,28 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2143,6 +2165,7 @@ dependencies = [
  "alloy-primitives",
  "async-trait",
  "axum",
+ "axum-server",
  "base64 0.22.1",
  "chrono",
  "clap",
@@ -2165,7 +2188,11 @@ dependencies = [
  "opentelemetry_sdk",
  "parking_lot",
  "prost",
+ "rcgen",
+ "reqwest 0.12.28",
  "rust_decimal",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serial_test",
@@ -2173,6 +2200,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tokio-util",
  "tonic",
@@ -2694,6 +2722,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -4740,6 +4778,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4813,6 +4864,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
 dependencies = [
  "bytecheck",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower 0.5.3",
+ "tower-http 0.6.8",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -5089,6 +5177,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5107,6 +5196,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -6277,8 +6375,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
@@ -7390,6 +7490,15 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "zeroize",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ alloy-rpc-types = "1"
 alloy-transport = "1"
 tonic = "0.12"
 tonic-build = "0.12"
+axum-server = { version = "0.7", features = ["tls-rustls"] }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls-pemfile = "2"
+tokio-rustls = "0.26"
 prost = "0.13"
 prost-types = "0.13"
 axum = "0.7"

--- a/crates/dp-api/Cargo.toml
+++ b/crates/dp-api/Cargo.toml
@@ -18,8 +18,11 @@ dp-crypto      = { path = "../dp-crypto" }
 dp-aggregator  = { path = "../dp-aggregator" }
 dp-settlement  = { path = "../dp-settlement" }
 
-tonic.workspace = true
+tonic = { workspace = true, features = ["tls"] }
 prost.workspace = true
+axum-server.workspace = true
+rustls.workspace = true
+rustls-pemfile.workspace = true
 alloy-primitives.workspace = true
 axum.workspace = true
 tower.workspace = true
@@ -57,6 +60,9 @@ hex.workspace = true
 http-body-util.workspace = true
 serial_test.workspace = true
 tempfile = "3"
+rcgen = "0.13"
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-manual-roots", "json"] }
+tokio-rustls.workspace = true
 
 [build-dependencies]
 tonic-build.workspace = true

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -15,6 +15,26 @@ pub struct Config {
     #[arg(long, env = "DARKPOOL_HTTP_ADDR", default_value = "0.0.0.0:8080")]
     pub http_addr: SocketAddr,
 
+    /// PEM-encoded TLS server certificate (chain). When set together
+    /// with --tls-key, TLS is enabled on both gRPC and REST listeners.
+    /// When both are empty, both listeners bind plaintext (see the TLS
+    /// runbook at docs/operations/tls-setup.md).
+    #[arg(long, env = "DARKPOOL_TLS_CERT", default_value = "")]
+    pub tls_cert: String,
+
+    /// PEM-encoded TLS private key matching --tls-cert. Must be readable
+    /// only by the service user (mode 0400 in prod). Unset together with
+    /// --tls-cert means plaintext.
+    #[arg(long, env = "DARKPOOL_TLS_KEY", default_value = "")]
+    pub tls_key: String,
+
+    /// PEM-encoded CA bundle used to verify *client* certificates.
+    /// Presence enables mTLS on both listeners — clients without a cert
+    /// signed by this CA are rejected at the TLS handshake. Requires
+    /// --tls-cert / --tls-key.
+    #[arg(long, env = "DARKPOOL_TLS_CLIENT_CA", default_value = "")]
+    pub tls_client_ca: String,
+
     #[arg(long, env = "DARKPOOL_AUCTION_INTERVAL", default_value = "5s", value_parser = parse_duration)]
     pub auction_interval: Duration,
 
@@ -158,6 +178,73 @@ impl Config {
     pub fn contract_address(&self) -> Option<&str> {
         opt(&self.contract_addr)
     }
+
+    pub fn tls_cert_path(&self) -> Option<&str> {
+        opt(&self.tls_cert)
+    }
+
+    pub fn tls_key_path(&self) -> Option<&str> {
+        opt(&self.tls_key)
+    }
+
+    pub fn tls_client_ca_path(&self) -> Option<&str> {
+        opt(&self.tls_client_ca)
+    }
+
+    /// Resolve the requested TLS posture, rejecting half-configured
+    /// states (cert without key or vice-versa). Caller should error
+    /// out at boot when this returns `Err`.
+    pub fn tls_mode(&self) -> Result<TlsMode, String> {
+        match (
+            self.tls_cert_path(),
+            self.tls_key_path(),
+            self.tls_client_ca_path(),
+        ) {
+            (None, None, None) => Ok(TlsMode::Plaintext),
+            (Some(c), Some(k), None) => Ok(TlsMode::Tls {
+                cert: c.into(),
+                key: k.into(),
+            }),
+            (Some(c), Some(k), Some(ca)) => Ok(TlsMode::Mtls {
+                cert: c.into(),
+                key: k.into(),
+                client_ca: ca.into(),
+            }),
+            (Some(_), None, _) => {
+                Err("--tls-cert / DARKPOOL_TLS_CERT set but --tls-key is missing".into())
+            }
+            (None, Some(_), _) => {
+                Err("--tls-key / DARKPOOL_TLS_KEY set but --tls-cert is missing".into())
+            }
+            (None, None, Some(_)) => Err(
+                "--tls-client-ca / DARKPOOL_TLS_CLIENT_CA set without --tls-cert and --tls-key"
+                    .into(),
+            ),
+        }
+    }
+}
+
+/// Resolved TLS posture for both listeners. The variants are exhaustive
+/// of what the operator can ask for via [`Config::tls_mode`]:
+///
+/// - `Plaintext` — no TLS material configured; both listeners bind
+///   plaintext. Acceptable for local dev only; main.rs logs a loud
+///   warning at boot.
+/// - `Tls` — server-auth TLS, no client cert required.
+/// - `Mtls` — mutual TLS, clients must present a cert signed by
+///   `client_ca`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TlsMode {
+    Plaintext,
+    Tls {
+        cert: std::path::PathBuf,
+        key: std::path::PathBuf,
+    },
+    Mtls {
+        cert: std::path::PathBuf,
+        key: std::path::PathBuf,
+        client_ca: std::path::PathBuf,
+    },
 }
 
 fn opt(s: &str) -> Option<&str> {
@@ -198,5 +285,77 @@ mod tests {
     #[test]
     fn parse_duration_invalid() {
         assert!(parse_duration("not-a-duration").is_err());
+    }
+
+    fn cfg_with_tls(cert: &str, key: &str, ca: &str) -> Config {
+        // Parser preserves the env defaults for everything else; we only
+        // care about the TLS triple here.
+        Config::parse_from([
+            "darkpool-server",
+            "--tls-cert",
+            cert,
+            "--tls-key",
+            key,
+            "--tls-client-ca",
+            ca,
+        ])
+    }
+
+    #[test]
+    fn tls_mode_plaintext_when_empty() {
+        let cfg = cfg_with_tls("", "", "");
+        assert_eq!(cfg.tls_mode().unwrap(), TlsMode::Plaintext);
+    }
+
+    #[test]
+    fn tls_mode_tls_when_cert_and_key() {
+        let cfg = cfg_with_tls("/srv/cert.pem", "/srv/key.pem", "");
+        match cfg.tls_mode().unwrap() {
+            TlsMode::Tls { cert, key } => {
+                assert_eq!(cert.to_str(), Some("/srv/cert.pem"));
+                assert_eq!(key.to_str(), Some("/srv/key.pem"));
+            }
+            other => panic!("expected Tls, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tls_mode_mtls_when_full_triple() {
+        let cfg = cfg_with_tls("/srv/cert.pem", "/srv/key.pem", "/srv/ca.pem");
+        match cfg.tls_mode().unwrap() {
+            TlsMode::Mtls {
+                cert,
+                key,
+                client_ca,
+            } => {
+                assert_eq!(cert.to_str(), Some("/srv/cert.pem"));
+                assert_eq!(key.to_str(), Some("/srv/key.pem"));
+                assert_eq!(client_ca.to_str(), Some("/srv/ca.pem"));
+            }
+            other => panic!("expected Mtls, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn tls_mode_rejects_cert_without_key() {
+        let cfg = cfg_with_tls("/srv/cert.pem", "", "");
+        let err = cfg.tls_mode().unwrap_err();
+        assert!(err.contains("tls-key"), "msg: {err}");
+    }
+
+    #[test]
+    fn tls_mode_rejects_key_without_cert() {
+        let cfg = cfg_with_tls("", "/srv/key.pem", "");
+        let err = cfg.tls_mode().unwrap_err();
+        assert!(err.contains("tls-cert"), "msg: {err}");
+    }
+
+    #[test]
+    fn tls_mode_rejects_client_ca_without_server_material() {
+        // Client-CA on its own would silently downgrade to plaintext if
+        // we didn't reject it — operators would think mTLS is on.
+        let cfg = cfg_with_tls("", "", "/srv/ca.pem");
+        let err = cfg.tls_mode().unwrap_err();
+        assert!(err.contains("tls-client-ca"), "msg: {err}");
     }
 }

--- a/crates/dp-api/src/lib.rs
+++ b/crates/dp-api/src/lib.rs
@@ -11,4 +11,5 @@ pub mod pb;
 pub mod ratelimit;
 pub mod readiness;
 pub mod rest;
+pub mod tls;
 pub mod validation;

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -6,13 +6,14 @@ use clap::Parser;
 use dp_aggregator::SubprocessAggregator;
 use dp_api::admin::{AdminApiHandler, KeyAdminHandler};
 use dp_api::auth::{AuthCore, AuthLayer};
-use dp_api::config::Config;
+use dp_api::config::{Config, TlsMode};
 use dp_api::handler::ApiHandler;
 use dp_api::observability::{self, M_EVENT_LOG_SIZE_BYTES};
 use dp_api::pb::dark_pool_service_server::DarkPoolServiceServer;
 use dp_api::ratelimit::{RateLimitCore, RateLimitLayer};
 use dp_api::readiness::{aggregator_probe, store_probe, ReadinessProbes};
 use dp_api::rest::{self, OpsState};
+use dp_api::tls;
 use dp_crypto::{
     decrypter_from_uri, validate_key_id, EciesDecrypter, KeyEntry, KeyStatus, MultiKeyDecrypter,
 };
@@ -33,6 +34,24 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let tracing_guard = observability::init_tracing()?;
 
     let cfg = Config::parse();
+
+    // Resolve the TLS posture up-front: half-configured TLS (cert
+    // without key, etc.) must surface at boot, not when the first
+    // client connects. The plaintext branch logs a loud warning so a
+    // misconfigured prod deploy is never silent — there is no
+    // "default-on" TLS today.
+    let tls_mode = cfg.tls_mode().map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+        e.into()
+    })?;
+    if matches!(tls_mode, TlsMode::Plaintext) {
+        warn!(
+            grpc = %cfg.grpc_addr,
+            rest = %cfg.http_addr,
+            "TLS DISABLED — server is binding plaintext on both listeners. \
+             Set --tls-cert/--tls-key (and optionally --tls-client-ca for mTLS) \
+             before exposing the server to a network you do not control."
+        );
+    }
 
     let store: Arc<dyn Store> = if let Some(url) = cfg.event_db_url() {
         info!(url = %sanitize_db_url(url), "event log: postgres");
@@ -238,9 +257,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // `/v1/admin/*` paths only (gated by the separate operator key set in
     // [`rest::router_with_admin`]). Restoring gRPC admin will require a
     // dedicated listener on its own port with the operator AuthLayer.
+    let grpc_tls = tls::tonic_server_tls(&tls_mode)?;
+    let grpc_tls_enabled = grpc_tls.is_some();
     let grpc_handle = tokio::spawn(async move {
-        info!(addr = %grpc_addr, "gRPC server listening");
-        Server::builder()
+        info!(addr = %grpc_addr, tls = grpc_tls_enabled, "gRPC server listening");
+        let mut builder = Server::builder();
+        if let Some(tls) = grpc_tls {
+            builder = builder
+                .tls_config(tls)
+                .map_err(|e| Box::<dyn std::error::Error + Send + Sync>::from(e.to_string()))?;
+        }
+        builder
             .layer(grpc_auth)
             .layer(grpc_rl)
             .add_service(DarkPoolServiceServer::new(handler))
@@ -301,24 +328,99 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     );
     let http_addr = cfg.http_addr;
     let http_cancel = cancel.clone();
+    let rest_tls = tls::axum_rustls_config(&tls_mode).await?;
+    // Keep a clone alive in main for the SIGHUP reload task — moving
+    // the option into the spawn would orphan the handle from the
+    // reload path. `RustlsConfig` is `Arc<...>` internally so the
+    // clone is cheap.
+    let rest_tls_for_reload = rest_tls.clone();
+    let rest_tls_enabled = rest_tls.is_some();
     let rest_handle = tokio::spawn(async move {
-        let listener = tokio::net::TcpListener::bind(http_addr)
-            .await
-            .map_err(|e| {
-                Box::<dyn std::error::Error + Send + Sync>::from(format!(
-                    "bind {}: {}",
-                    http_addr, e
-                ))
-            })?;
-        info!(addr = %http_addr, "REST server listening");
-        axum::serve(
-            listener,
-            rest_app.into_make_service_with_connect_info::<SocketAddr>(),
-        )
-        .with_graceful_shutdown(async move { http_cancel.cancelled().await })
-        .await
-        .map_err(|e| Box::<dyn std::error::Error + Send + Sync>::from(e.to_string()))
+        info!(addr = %http_addr, tls = rest_tls_enabled, "REST server listening");
+        let make_svc = rest_app.into_make_service_with_connect_info::<SocketAddr>();
+        let server_handle = axum_server::Handle::new();
+        let shutdown_handle = server_handle.clone();
+        tokio::spawn(async move {
+            http_cancel.cancelled().await;
+            // Bound the in-flight HTTPS drain at 10s — beyond that
+            // axum_server drops live connections rather than holding
+            // shutdown indefinitely.
+            shutdown_handle.graceful_shutdown(Some(Duration::from_secs(10)));
+        });
+        let result = match rest_tls {
+            Some(cfg) => {
+                axum_server::bind_rustls(http_addr, cfg)
+                    .handle(server_handle)
+                    .serve(make_svc)
+                    .await
+            }
+            None => {
+                axum_server::bind(http_addr)
+                    .handle(server_handle)
+                    .serve(make_svc)
+                    .await
+            }
+        };
+        result.map_err(|e| Box::<dyn std::error::Error + Send + Sync>::from(e.to_string()))
     });
+
+    // SIGHUP-driven TLS hot-reload for the REST listener. The gRPC
+    // listener has no in-place reload path in tonic 0.12, so SIGHUP
+    // emits a warn pointing operators at the restart-only flow for the
+    // gRPC cert. Documented asymmetry — see docs/operations/tls-setup.md.
+    #[cfg(unix)]
+    let reload_handle = {
+        let reload_cancel = cancel.clone();
+        let reload_rest_cfg = rest_tls_for_reload.clone();
+        let cfg_for_reload = cfg.clone();
+        tokio::spawn(async move {
+            use tokio::signal::unix::{signal, SignalKind};
+            let mut hup = match signal(SignalKind::hangup()) {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!("failed to install SIGHUP handler — TLS hot-reload disabled: {e}");
+                    return;
+                }
+            };
+            loop {
+                tokio::select! {
+                    _ = reload_cancel.cancelled() => return,
+                    sig = hup.recv() => {
+                        if sig.is_none() {
+                            return;
+                        }
+                        let mode = match cfg_for_reload.tls_mode() {
+                            Ok(m) => m,
+                            Err(e) => {
+                                warn!("SIGHUP: bad TLS config, ignoring reload: {e}");
+                                continue;
+                            }
+                        };
+                        if matches!(mode, TlsMode::Plaintext) {
+                            warn!("SIGHUP received but TLS is disabled — nothing to reload");
+                            continue;
+                        }
+                        if let Some(rest_cfg) = &reload_rest_cfg {
+                            match tls::reload_axum_rustls(rest_cfg, &mode).await {
+                                Ok(()) => info!("SIGHUP: REST TLS material reloaded"),
+                                Err(e) => warn!(
+                                    "SIGHUP: REST TLS reload failed (keeping previous cert): {e}"
+                                ),
+                            }
+                        }
+                        warn!(
+                            "SIGHUP: gRPC listener does not hot-reload TLS — restart the \
+                             process to rotate the gRPC certificate"
+                        );
+                    }
+                }
+            }
+        })
+    };
+    // Silence the unused-variable warning when the SIGHUP task is not
+    // compiled in (non-unix builds — no signal API to listen on).
+    #[cfg(not(unix))]
+    let _ = rest_tls_for_reload;
 
     tokio::select! {
         _ = tokio::signal::ctrl_c() => info!("ctrl+c received"),
@@ -332,6 +434,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let _ = grpc_handle.await;
     let _ = rest_handle.await;
     let _ = gauge_handle.await;
+    #[cfg(unix)]
+    let _ = reload_handle.await;
 
     // Flush any in-flight OTLP batches before the process exits.
     tracing_guard.shutdown();

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -40,9 +40,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // client connects. The plaintext branch logs a loud warning so a
     // misconfigured prod deploy is never silent — there is no
     // "default-on" TLS today.
-    let tls_mode = cfg.tls_mode().map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
-        e.into()
-    })?;
+    let tls_mode = cfg
+        .tls_mode()
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
     if matches!(tls_mode, TlsMode::Plaintext) {
         warn!(
             grpc = %cfg.grpc_addr,

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -260,7 +260,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let grpc_tls = tls::tonic_server_tls(&tls_mode)?;
     let grpc_tls_enabled = grpc_tls.is_some();
     let grpc_handle = tokio::spawn(async move {
-        info!(addr = %grpc_addr, tls = grpc_tls_enabled, "gRPC server listening");
+        info!(addr = %grpc_addr, tls = grpc_tls_enabled, "gRPC server starting");
         let mut builder = Server::builder();
         if let Some(tls) = grpc_tls {
             builder = builder
@@ -336,7 +336,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let rest_tls_for_reload = rest_tls.clone();
     let rest_tls_enabled = rest_tls.is_some();
     let rest_handle = tokio::spawn(async move {
-        info!(addr = %http_addr, tls = rest_tls_enabled, "REST server listening");
+        info!(addr = %http_addr, tls = rest_tls_enabled, "REST server starting");
         let make_svc = rest_app.into_make_service_with_connect_info::<SocketAddr>();
         let server_handle = axum_server::Handle::new();
         let shutdown_handle = server_handle.clone();

--- a/crates/dp-api/src/tls.rs
+++ b/crates/dp-api/src/tls.rs
@@ -216,10 +216,7 @@ fn load_ca_bundle(path: &Path) -> Result<RootCertStore, TlsError> {
     load_ca_bundle_from_bytes(&pem, path)
 }
 
-fn load_ca_bundle_from_bytes(
-    pem: &[u8],
-    path_for_error: &Path,
-) -> Result<RootCertStore, TlsError> {
+fn load_ca_bundle_from_bytes(pem: &[u8], path_for_error: &Path) -> Result<RootCertStore, TlsError> {
     let mut reader = pem;
     let mut roots = RootCertStore::empty();
     let mut count = 0usize;

--- a/crates/dp-api/src/tls.rs
+++ b/crates/dp-api/src/tls.rs
@@ -1,0 +1,341 @@
+//! TLS / mTLS material loader shared by the gRPC and REST listeners.
+//!
+//! Both transports terminate TLS in-process — there is no sidecar — so a
+//! single loader keeps the cert handling logic in one place and ensures
+//! the two listeners can never drift on parse rules or trust roots.
+//!
+//! The public surface is three thin helpers driven by [`TlsMode`]:
+//!
+//! - [`tonic_server_tls`] builds a tonic [`ServerTlsConfig`] for the
+//!   gRPC listener.
+//! - [`axum_rustls_config`] builds an axum-server [`RustlsConfig`] for
+//!   the REST listener. The mTLS branch returns a config constructed
+//!   from a full [`rustls::ServerConfig`] so [`reload_axum_rustls`]
+//!   can swap in new material without restarting the listener.
+//! - [`reload_axum_rustls`] swaps the REST cert in-place on SIGHUP.
+//!   The gRPC side has no equivalent (tonic 0.12 exposes no reload
+//!   API) — callers must restart the process to rotate the gRPC cert.
+
+use std::fs;
+use std::path::Path;
+use std::sync::Arc;
+
+use axum_server::tls_rustls::RustlsConfig;
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::server::WebPkiClientVerifier;
+use rustls::{RootCertStore, ServerConfig};
+use tonic::transport::{Certificate, Identity, ServerTlsConfig};
+
+use crate::config::TlsMode;
+
+#[derive(Debug, thiserror::Error)]
+pub enum TlsError {
+    #[error("tls io error reading {path}: {source}")]
+    Io {
+        path: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("malformed pem at {path}: {msg}")]
+    MalformedPem { path: String, msg: String },
+
+    #[error("malformed private key at {path}: no PEM-encoded key block found")]
+    MalformedKey { path: String },
+
+    #[error("malformed client CA at {path}: {msg}")]
+    MalformedCa { path: String, msg: String },
+
+    #[error("rustls config error: {0}")]
+    Rustls(String),
+}
+
+/// Build a tonic [`ServerTlsConfig`] for the requested posture.
+/// Returns `Ok(None)` for plaintext.
+pub fn tonic_server_tls(mode: &TlsMode) -> Result<Option<ServerTlsConfig>, TlsError> {
+    match mode {
+        TlsMode::Plaintext => Ok(None),
+        TlsMode::Tls { cert, key } => {
+            let cert_pem = read_file(cert)?;
+            let key_pem = read_file(key)?;
+            // tonic 0.12's `Identity::from_pem` is an infallible builder;
+            // without an explicit sanity-parse, malformed cert/key would
+            // surface at the first TLS handshake instead of at boot.
+            let _ = load_cert_chain_from_bytes(&cert_pem, cert)?;
+            let _ = load_private_key_from_bytes(&key_pem, key)?;
+            let identity = Identity::from_pem(&cert_pem, &key_pem);
+            Ok(Some(ServerTlsConfig::new().identity(identity)))
+        }
+        TlsMode::Mtls {
+            cert,
+            key,
+            client_ca,
+        } => {
+            let cert_pem = read_file(cert)?;
+            let key_pem = read_file(key)?;
+            let ca_pem = read_file(client_ca)?;
+            // tonic 0.12's `Identity::from_pem` / `Certificate::from_pem`
+            // are infallible builders, so we sanity-parse here. Otherwise
+            // a malformed bundle would present as silent "no client
+            // accepted" handshakes instead of failing at boot.
+            let _ = load_cert_chain_from_bytes(&cert_pem, cert)?;
+            let _ = load_private_key_from_bytes(&key_pem, key)?;
+            let _ = load_ca_bundle_from_bytes(&ca_pem, client_ca)?;
+            let identity = Identity::from_pem(&cert_pem, &key_pem);
+            Ok(Some(
+                ServerTlsConfig::new()
+                    .identity(identity)
+                    .client_ca_root(Certificate::from_pem(ca_pem)),
+            ))
+        }
+    }
+}
+
+/// Build an [`RustlsConfig`] for the REST listener. Returns `Ok(None)`
+/// for plaintext.
+pub async fn axum_rustls_config(mode: &TlsMode) -> Result<Option<RustlsConfig>, TlsError> {
+    install_crypto_provider();
+    match mode {
+        TlsMode::Plaintext => Ok(None),
+        TlsMode::Tls { cert, key } => {
+            let cfg = RustlsConfig::from_pem_file(cert, key)
+                .await
+                .map_err(|e| TlsError::Rustls(e.to_string()))?;
+            Ok(Some(cfg))
+        }
+        TlsMode::Mtls {
+            cert,
+            key,
+            client_ca,
+        } => {
+            let server_cfg = build_mtls_server_config(cert, key, client_ca)?;
+            Ok(Some(RustlsConfig::from_config(Arc::new(server_cfg))))
+        }
+    }
+}
+
+/// Reload the REST listener's certificate material in-place. Open
+/// connections continue with the old material; new TLS handshakes after
+/// this call use the reloaded cert.
+pub async fn reload_axum_rustls(cfg: &RustlsConfig, mode: &TlsMode) -> Result<(), TlsError> {
+    install_crypto_provider();
+    match mode {
+        TlsMode::Plaintext => Err(TlsError::Rustls(
+            "cannot hot-reload TLS for a plaintext listener — restart the process".into(),
+        )),
+        TlsMode::Tls { cert, key } => cfg
+            .reload_from_pem_file(cert, key)
+            .await
+            .map_err(|e| TlsError::Rustls(e.to_string())),
+        TlsMode::Mtls {
+            cert,
+            key,
+            client_ca,
+        } => {
+            // mTLS requires a full ServerConfig (the verifier is part of
+            // it), so go through reload_from_config rather than the PEM
+            // helper, which only knows about cert+key.
+            let server_cfg = build_mtls_server_config(cert, key, client_ca)?;
+            cfg.reload_from_config(Arc::new(server_cfg));
+            Ok(())
+        }
+    }
+}
+
+fn build_mtls_server_config(
+    cert: &Path,
+    key: &Path,
+    client_ca: &Path,
+) -> Result<ServerConfig, TlsError> {
+    let cert_chain = load_cert_chain(cert)?;
+    let private_key = load_private_key(key)?;
+    let roots = load_ca_bundle(client_ca)?;
+    let verifier = WebPkiClientVerifier::builder(Arc::new(roots))
+        .build()
+        .map_err(|e| TlsError::Rustls(e.to_string()))?;
+    ServerConfig::builder()
+        .with_client_cert_verifier(verifier)
+        .with_single_cert(cert_chain, private_key)
+        .map_err(|e| TlsError::Rustls(e.to_string()))
+}
+
+fn read_file(path: &Path) -> Result<Vec<u8>, TlsError> {
+    fs::read(path).map_err(|source| TlsError::Io {
+        path: path.display().to_string(),
+        source,
+    })
+}
+
+fn load_cert_chain(path: &Path) -> Result<Vec<CertificateDer<'static>>, TlsError> {
+    let pem = read_file(path)?;
+    load_cert_chain_from_bytes(&pem, path)
+}
+
+fn load_cert_chain_from_bytes(
+    pem: &[u8],
+    path_for_error: &Path,
+) -> Result<Vec<CertificateDer<'static>>, TlsError> {
+    let mut reader = pem;
+    rustls_pemfile::certs(&mut reader)
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| TlsError::MalformedPem {
+            path: path_for_error.display().to_string(),
+            msg: e.to_string(),
+        })
+}
+
+fn load_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, TlsError> {
+    let pem = read_file(path)?;
+    load_private_key_from_bytes(&pem, path)
+}
+
+fn load_private_key_from_bytes(
+    pem: &[u8],
+    path_for_error: &Path,
+) -> Result<PrivateKeyDer<'static>, TlsError> {
+    let mut reader = pem;
+    rustls_pemfile::private_key(&mut reader)
+        .map_err(|e| TlsError::MalformedPem {
+            path: path_for_error.display().to_string(),
+            msg: e.to_string(),
+        })?
+        .ok_or_else(|| TlsError::MalformedKey {
+            path: path_for_error.display().to_string(),
+        })
+}
+
+fn load_ca_bundle(path: &Path) -> Result<RootCertStore, TlsError> {
+    let pem = read_file(path)?;
+    load_ca_bundle_from_bytes(&pem, path)
+}
+
+fn load_ca_bundle_from_bytes(
+    pem: &[u8],
+    path_for_error: &Path,
+) -> Result<RootCertStore, TlsError> {
+    let mut reader = pem;
+    let mut roots = RootCertStore::empty();
+    let mut count = 0usize;
+    for cert in rustls_pemfile::certs(&mut reader) {
+        let cert = cert.map_err(|e| TlsError::MalformedCa {
+            path: path_for_error.display().to_string(),
+            msg: e.to_string(),
+        })?;
+        roots.add(cert).map_err(|e| TlsError::MalformedCa {
+            path: path_for_error.display().to_string(),
+            msg: e.to_string(),
+        })?;
+        count += 1;
+    }
+    if count == 0 {
+        return Err(TlsError::MalformedCa {
+            path: path_for_error.display().to_string(),
+            msg: "no CA certificates found in bundle".into(),
+        });
+    }
+    Ok(roots)
+}
+
+// rustls 0.23 requires exactly one default CryptoProvider per process.
+// axum-server and tonic both initialize their own clients on first use;
+// installing ring up-front guarantees both paths agree on the provider.
+fn install_crypto_provider() {
+    static ONCE: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    ONCE.get_or_init(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn plaintext_returns_none_for_both_listeners() {
+        let mode = TlsMode::Plaintext;
+        assert!(tonic_server_tls(&mode).unwrap().is_none());
+        // axum_rustls_config is async; reuse current_thread runtime so
+        // this stays inside the unit-test module without #[tokio::test]
+        // bringing the full multi-thread runtime in.
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .unwrap();
+        assert!(rt.block_on(axum_rustls_config(&mode)).unwrap().is_none());
+    }
+
+    #[test]
+    fn missing_cert_surfaces_io_error_with_path() {
+        let mode = TlsMode::Tls {
+            cert: PathBuf::from("/definitely/missing/cert.pem"),
+            key: PathBuf::from("/definitely/missing/key.pem"),
+        };
+        let err = tonic_server_tls(&mode).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("/definitely/missing/cert.pem"), "msg: {msg}");
+    }
+
+    #[test]
+    fn load_ca_bundle_rejects_empty_pem() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.pem");
+        std::fs::write(&path, b"not a real pem block\n").unwrap();
+        let err = load_ca_bundle(&path).unwrap_err();
+        assert!(matches!(err, TlsError::MalformedCa { .. }));
+    }
+
+    #[test]
+    fn load_private_key_rejects_pem_without_key_block() {
+        // rustls_pemfile::private_key returns `Ok(None)` when the file
+        // parses but contains no recognized PRIVATE KEY block. We map
+        // that to MalformedKey so operators see the real cause instead
+        // of a misleading "loaded ok but key missing" silent path.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nokey.pem");
+        std::fs::write(
+            &path,
+            b"-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----\n",
+        )
+        .unwrap();
+        let err = load_private_key(&path).unwrap_err();
+        assert!(matches!(err, TlsError::MalformedKey { .. }), "got: {err:?}");
+    }
+
+    // Each loader has two failure modes: PEM framing parse error
+    // (rustls_pemfile iterator yields Err) and structural-content error
+    // (block parses but bytes aren't valid X.509 / PKCS8). The fixtures
+    // below trigger the iterator-Err path so the `map_err(|e|
+    // TlsError::Malformed* { msg: e.to_string(), .. })` closures don't
+    // silently rot if a future rustls_pemfile bump changes the wording.
+    const MALFORMED_CERT_PEM: &[u8] =
+        b"-----BEGIN CERTIFICATE-----\n!!!invalid base64!!!\n-----END CERTIFICATE-----\n";
+    const MALFORMED_KEY_PEM: &[u8] =
+        b"-----BEGIN PRIVATE KEY-----\n!!!invalid base64!!!\n-----END PRIVATE KEY-----\n";
+
+    #[test]
+    fn load_cert_chain_surfaces_pem_parse_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("badcert.pem");
+        std::fs::write(&path, MALFORMED_CERT_PEM).unwrap();
+        let err = load_cert_chain(&path).unwrap_err();
+        assert!(matches!(err, TlsError::MalformedPem { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn load_private_key_surfaces_pem_parse_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("badkey.pem");
+        std::fs::write(&path, MALFORMED_KEY_PEM).unwrap();
+        let err = load_private_key(&path).unwrap_err();
+        assert!(matches!(err, TlsError::MalformedPem { .. }), "got: {err:?}");
+    }
+
+    #[test]
+    fn load_ca_bundle_surfaces_pem_parse_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("badca.pem");
+        std::fs::write(&path, MALFORMED_CERT_PEM).unwrap();
+        let err = load_ca_bundle(&path).unwrap_err();
+        assert!(matches!(err, TlsError::MalformedCa { .. }), "got: {err:?}");
+    }
+}

--- a/crates/dp-api/src/tls.rs
+++ b/crates/dp-api/src/tls.rs
@@ -176,12 +176,19 @@ fn load_cert_chain_from_bytes(
     path_for_error: &Path,
 ) -> Result<Vec<CertificateDer<'static>>, TlsError> {
     let mut reader = pem;
-    rustls_pemfile::certs(&mut reader)
+    let certs = rustls_pemfile::certs(&mut reader)
         .collect::<Result<Vec<_>, _>>()
         .map_err(|e| TlsError::MalformedPem {
             path: path_for_error.display().to_string(),
             msg: e.to_string(),
-        })
+        })?;
+    if certs.is_empty() {
+        return Err(TlsError::MalformedPem {
+            path: path_for_error.display().to_string(),
+            msg: "no certificates found in PEM".into(),
+        });
+    }
+    Ok(certs)
 }
 
 fn load_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, TlsError> {
@@ -282,6 +289,19 @@ mod tests {
         std::fs::write(&path, b"not a real pem block\n").unwrap();
         let err = load_ca_bundle(&path).unwrap_err();
         assert!(matches!(err, TlsError::MalformedCa { .. }));
+    }
+
+    #[test]
+    fn load_cert_chain_rejects_empty_pem() {
+        // A PEM file that parses cleanly but contains zero CERTIFICATE
+        // blocks must fail at startup. Without this guard tonic's
+        // boot-time sanity parse passes and the failure surfaces only
+        // when the first TLS handshake is attempted in prod.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("empty.pem");
+        std::fs::write(&path, b"not a real pem block\n").unwrap();
+        let err = load_cert_chain(&path).unwrap_err();
+        assert!(matches!(err, TlsError::MalformedPem { .. }), "got: {err:?}");
     }
 
     #[test]

--- a/crates/dp-api/tests/server_boot_tls.rs
+++ b/crates/dp-api/tests/server_boot_tls.rs
@@ -164,7 +164,9 @@ async fn start_rest(mode: &TlsMode) -> RestServer {
     let server_handle = axum_server::Handle::new();
     let shutdown_handle = server_handle.clone();
     let shutdown_cancel = cancel.clone();
-    let tls_cfg = tls::axum_rustls_config(mode).await.expect("rest tls config");
+    let tls_cfg = tls::axum_rustls_config(mode)
+        .await
+        .expect("rest tls config");
     let tls_for_test = tls_cfg.clone();
     let make_svc = app.into_make_service_with_connect_info::<SocketAddr>();
     let task = tokio::spawn(async move {
@@ -260,7 +262,11 @@ fn reqwest_client(ca_pem: &str) -> reqwest::Client {
         .unwrap()
 }
 
-fn reqwest_client_mtls(ca_pem: &str, client_cert_pem: &str, client_key_pem: &str) -> reqwest::Client {
+fn reqwest_client_mtls(
+    ca_pem: &str,
+    client_cert_pem: &str,
+    client_key_pem: &str,
+) -> reqwest::Client {
     let mut bundle = Vec::new();
     bundle.extend_from_slice(client_cert_pem.as_bytes());
     bundle.extend_from_slice(client_key_pem.as_bytes());
@@ -335,7 +341,10 @@ async fn grpc_rejects_plain_client_when_tls_on() {
     })
     .await
     .unwrap_or(true);
-    assert!(outcome, "plaintext client must not succeed against TLS server");
+    assert!(
+        outcome,
+        "plaintext client must not succeed against TLS server"
+    );
 
     server.shutdown().await;
 }
@@ -428,7 +437,10 @@ async fn rest_serves_over_tls() {
     };
     let server = start_rest(&mode).await;
     let client = reqwest_client(&bundle.ca_pem);
-    let url = format!("https://localhost:{}/v1/orderbook?pair=ETH/USDC", server.addr.port());
+    let url = format!(
+        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
+        server.addr.port()
+    );
     wait_rest_ready(&client, &url).await;
     let resp = client.get(&url).send().await.expect("rest GET");
     assert_eq!(resp.status(), 200, "body: {:?}", resp.text().await);
@@ -445,7 +457,10 @@ async fn rest_mtls_accepts_authorized_client() {
     };
     let server = start_rest(&mode).await;
     let client = reqwest_client_mtls(&bundle.ca_pem, &bundle.client.pem, &bundle.client.key_pem);
-    let url = format!("https://localhost:{}/v1/orderbook?pair=ETH/USDC", server.addr.port());
+    let url = format!(
+        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
+        server.addr.port()
+    );
     wait_rest_ready(&client, &url).await;
     let resp = client.get(&url).send().await.expect("rest mTLS GET");
     assert_eq!(resp.status(), 200);
@@ -503,7 +518,10 @@ async fn rest_reload_swaps_cert_material() {
     };
 
     let server = start_rest(&mode_a).await;
-    let url = format!("https://localhost:{}/v1/orderbook?pair=ETH/USDC", server.addr.port());
+    let url = format!(
+        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
+        server.addr.port()
+    );
 
     let client_a = reqwest_client(&bundle_a.ca_pem);
     wait_rest_ready(&client_a, &url).await;
@@ -559,7 +577,11 @@ async fn rest_mtls_reload_swaps_cert_material() {
         server.addr.port()
     );
 
-    let client_a = reqwest_client_mtls(&bundle_a.ca_pem, &bundle_a.client.pem, &bundle_a.client.key_pem);
+    let client_a = reqwest_client_mtls(
+        &bundle_a.ca_pem,
+        &bundle_a.client.pem,
+        &bundle_a.client.key_pem,
+    );
     wait_rest_ready(&client_a, &url).await;
     assert_eq!(client_a.get(&url).send().await.unwrap().status(), 200);
 
@@ -568,8 +590,16 @@ async fn rest_mtls_reload_swaps_cert_material() {
         .await
         .expect("mTLS reload");
 
-    let client_b = reqwest_client_mtls(&bundle_b.ca_pem, &bundle_b.client.pem, &bundle_b.client.key_pem);
-    let resp = client_b.get(&url).send().await.expect("post-reload mTLS GET");
+    let client_b = reqwest_client_mtls(
+        &bundle_b.ca_pem,
+        &bundle_b.client.pem,
+        &bundle_b.client.key_pem,
+    );
+    let resp = client_b
+        .get(&url)
+        .send()
+        .await
+        .expect("post-reload mTLS GET");
     assert_eq!(resp.status(), 200);
 
     server.shutdown().await;
@@ -596,7 +626,10 @@ async fn rest_reload_to_plaintext_errors() {
 
     let tls_cfg_handle = server.tls_cfg.clone().expect("tls config present");
     let outcome = tls::reload_axum_rustls(&tls_cfg_handle, &TlsMode::Plaintext).await;
-    assert!(outcome.is_err(), "plaintext reload must Err, got {outcome:?}");
+    assert!(
+        outcome.is_err(),
+        "plaintext reload must Err, got {outcome:?}"
+    );
 
     // Old TLS cert still serving.
     assert_eq!(client.get(&url).send().await.unwrap().status(), 200);
@@ -622,7 +655,11 @@ async fn rest_reload_failure_keeps_old_cert() {
         server.addr.port()
     );
 
-    let client_a = reqwest_client_mtls(&bundle_a.ca_pem, &bundle_a.client.pem, &bundle_a.client.key_pem);
+    let client_a = reqwest_client_mtls(
+        &bundle_a.ca_pem,
+        &bundle_a.client.pem,
+        &bundle_a.client.key_pem,
+    );
     wait_rest_ready(&client_a, &url).await;
     assert_eq!(client_a.get(&url).send().await.unwrap().status(), 200);
 
@@ -632,9 +669,21 @@ async fn rest_reload_failure_keeps_old_cert() {
     let garbage_cert = garbage_dir.path().join("cert.pem");
     let garbage_key = garbage_dir.path().join("key.pem");
     let garbage_ca = garbage_dir.path().join("ca.pem");
-    std::fs::write(&garbage_cert, b"-----BEGIN CERTIFICATE-----\nnot a cert\n-----END CERTIFICATE-----\n").unwrap();
-    std::fs::write(&garbage_key, b"-----BEGIN PRIVATE KEY-----\nnot a key\n-----END PRIVATE KEY-----\n").unwrap();
-    std::fs::write(&garbage_ca, b"-----BEGIN CERTIFICATE-----\nnot a ca\n-----END CERTIFICATE-----\n").unwrap();
+    std::fs::write(
+        &garbage_cert,
+        b"-----BEGIN CERTIFICATE-----\nnot a cert\n-----END CERTIFICATE-----\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &garbage_key,
+        b"-----BEGIN PRIVATE KEY-----\nnot a key\n-----END PRIVATE KEY-----\n",
+    )
+    .unwrap();
+    std::fs::write(
+        &garbage_ca,
+        b"-----BEGIN CERTIFICATE-----\nnot a ca\n-----END CERTIFICATE-----\n",
+    )
+    .unwrap();
     let bad_mode = TlsMode::Mtls {
         cert: garbage_cert,
         key: garbage_key,
@@ -643,12 +692,23 @@ async fn rest_reload_failure_keeps_old_cert() {
 
     let tls_cfg_handle = server.tls_cfg.clone().expect("tls config present");
     let outcome = tls::reload_axum_rustls(&tls_cfg_handle, &bad_mode).await;
-    assert!(outcome.is_err(), "garbage PEM must surface as reload Err, got {outcome:?}");
+    assert!(
+        outcome.is_err(),
+        "garbage PEM must surface as reload Err, got {outcome:?}"
+    );
 
     // Old material must still serve. Use a fresh reqwest client so the
     // assertion isn't masked by a kept-alive connection from before.
-    let client_a_after = reqwest_client_mtls(&bundle_a.ca_pem, &bundle_a.client.pem, &bundle_a.client.key_pem);
-    let resp = client_a_after.get(&url).send().await.expect("post-failed-reload GET");
+    let client_a_after = reqwest_client_mtls(
+        &bundle_a.ca_pem,
+        &bundle_a.client.pem,
+        &bundle_a.client.key_pem,
+    );
+    let resp = client_a_after
+        .get(&url)
+        .send()
+        .await
+        .expect("post-failed-reload GET");
     assert_eq!(resp.status(), 200);
 
     server.shutdown().await;

--- a/crates/dp-api/tests/server_boot_tls.rs
+++ b/crates/dp-api/tests/server_boot_tls.rs
@@ -1,0 +1,655 @@
+//! End-to-end TLS / mTLS coverage for the gRPC and REST listeners.
+//!
+//! Each test mints an ephemeral CA + server cert (+ client cert where
+//! the case needs one) via rcgen, wires the real transport stack the
+//! same way `darkpool-server` boots it in `main.rs`, then drives it
+//! with a real tonic or reqwest client. No fixtures are committed —
+//! ~5 ms per mint keeps these tests cheap and free of rot risk.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum_server::tls_rustls::RustlsConfig;
+use dp_api::config::TlsMode;
+use dp_api::handler::ApiHandler;
+use dp_api::pb::dark_pool_service_client::DarkPoolServiceClient;
+use dp_api::pb::dark_pool_service_server::DarkPoolServiceServer;
+use dp_api::pb::GetOrderBookRequest;
+use dp_api::rest;
+use dp_api::tls;
+use dp_engine::Engine;
+use dp_event::MemStore;
+use tempfile::TempDir;
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+use tonic::transport::{Certificate, Channel, ClientTlsConfig, Identity, Server};
+
+// rcgen 0.13 produces both PEMs from the same KeyPair / Certificate
+// types, so we keep them paired in the bundle.
+struct CertMaterial {
+    pem: String,
+    key_pem: String,
+}
+
+struct CertBundle {
+    _dir: TempDir,
+    ca_path: std::path::PathBuf,
+    server_cert_path: std::path::PathBuf,
+    server_key_path: std::path::PathBuf,
+    client: CertMaterial,
+    ca_pem: String,
+}
+
+fn mint_bundle() -> CertBundle {
+    use rcgen::{BasicConstraints, CertificateParams, IsCa, KeyPair};
+
+    let ca_kp = KeyPair::generate().expect("ca keypair");
+    let mut ca_params = CertificateParams::new(vec!["DP Test Root CA".into()]).expect("ca params");
+    ca_params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    let ca_cert = ca_params.self_signed(&ca_kp).expect("ca self_signed");
+
+    let server_kp = KeyPair::generate().expect("server keypair");
+    let server_params =
+        CertificateParams::new(vec!["localhost".into(), "127.0.0.1".into()]).expect("srv params");
+    let server_cert = server_params
+        .signed_by(&server_kp, &ca_cert, &ca_kp)
+        .expect("server signed_by");
+
+    let client_kp = KeyPair::generate().expect("client keypair");
+    let client_params =
+        CertificateParams::new(vec!["dp-test-client".into()]).expect("client params");
+    let client_cert = client_params
+        .signed_by(&client_kp, &ca_cert, &ca_kp)
+        .expect("client signed_by");
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ca_path = dir.path().join("ca.pem");
+    let server_cert_path = dir.path().join("server.pem");
+    let server_key_path = dir.path().join("server.key");
+    let ca_pem = ca_cert.pem();
+    std::fs::write(&ca_path, &ca_pem).unwrap();
+    std::fs::write(&server_cert_path, server_cert.pem()).unwrap();
+    std::fs::write(&server_key_path, server_kp.serialize_pem()).unwrap();
+
+    CertBundle {
+        _dir: dir,
+        ca_path,
+        server_cert_path,
+        server_key_path,
+        client: CertMaterial {
+            pem: client_cert.pem(),
+            key_pem: client_kp.serialize_pem(),
+        },
+        ca_pem,
+    }
+}
+
+fn ensure_crypto_provider() {
+    // rustls 0.23 panics in tests if multiple crates pull in different
+    // providers and none has been installed as the default. Calling
+    // install_default() repeatedly is safe — the second-and-onward
+    // attempts return `Err(...)`, which we deliberately ignore.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+}
+
+fn fresh_handler() -> ApiHandler {
+    let store = Arc::new(MemStore::new());
+    let engine = Engine::new(store, Duration::from_secs(1));
+    engine.register_pair_without_event("ETH/USDC".into(), dp_engine::PairConfig::default());
+    ApiHandler::new(engine)
+}
+
+async fn bind_local() -> (TcpListener, SocketAddr) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("local_addr");
+    (listener, addr)
+}
+
+struct GrpcServer {
+    addr: SocketAddr,
+    cancel: CancellationToken,
+    task: tokio::task::JoinHandle<()>,
+}
+
+impl GrpcServer {
+    async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.task.await;
+    }
+}
+
+async fn start_grpc(mode: &TlsMode) -> GrpcServer {
+    ensure_crypto_provider();
+    let handler = fresh_handler();
+    let (listener, addr) = bind_local().await;
+    let cancel = CancellationToken::new();
+    let server_cancel = cancel.clone();
+    let incoming = tokio_stream::wrappers::TcpListenerStream::new(listener);
+    let tls_cfg = tls::tonic_server_tls(mode).expect("tonic tls config");
+    let task = tokio::spawn(async move {
+        let mut b = Server::builder();
+        if let Some(tls) = tls_cfg {
+            b = b.tls_config(tls).expect("tls_config");
+        }
+        b.add_service(DarkPoolServiceServer::new(handler))
+            .serve_with_incoming_shutdown(incoming, async move { server_cancel.cancelled().await })
+            .await
+            .expect("grpc server");
+    });
+    GrpcServer { addr, cancel, task }
+}
+
+struct RestServer {
+    addr: SocketAddr,
+    cancel: CancellationToken,
+    task: tokio::task::JoinHandle<()>,
+    tls_cfg: Option<RustlsConfig>,
+}
+
+impl RestServer {
+    async fn shutdown(self) {
+        self.cancel.cancel();
+        let _ = self.task.await;
+    }
+}
+
+async fn start_rest(mode: &TlsMode) -> RestServer {
+    ensure_crypto_provider();
+    let handler = Arc::new(fresh_handler());
+    let app = rest::router(handler);
+    let (listener, addr) = bind_local().await;
+    drop(listener); // axum_server::bind takes the addr, re-binds itself.
+    let cancel = CancellationToken::new();
+    let server_handle = axum_server::Handle::new();
+    let shutdown_handle = server_handle.clone();
+    let shutdown_cancel = cancel.clone();
+    let tls_cfg = tls::axum_rustls_config(mode).await.expect("rest tls config");
+    let tls_for_test = tls_cfg.clone();
+    let make_svc = app.into_make_service_with_connect_info::<SocketAddr>();
+    let task = tokio::spawn(async move {
+        tokio::spawn(async move {
+            shutdown_cancel.cancelled().await;
+            shutdown_handle.graceful_shutdown(Some(Duration::from_secs(5)));
+        });
+        let result = match tls_cfg {
+            Some(cfg) => {
+                axum_server::bind_rustls(addr, cfg)
+                    .handle(server_handle)
+                    .serve(make_svc)
+                    .await
+            }
+            None => {
+                axum_server::bind(addr)
+                    .handle(server_handle)
+                    .serve(make_svc)
+                    .await
+            }
+        };
+        if let Err(e) = result {
+            eprintln!("rest server exit: {e}");
+        }
+    });
+    RestServer {
+        addr,
+        cancel,
+        task,
+        tls_cfg: tls_for_test,
+    }
+}
+
+async fn grpc_client(addr: SocketAddr, ca_pem: &str) -> DarkPoolServiceClient<Channel> {
+    let endpoint = format!("https://localhost:{}", addr.port());
+    let tls = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(ca_pem))
+        .domain_name("localhost");
+    let mut last_err = None;
+    for _ in 0..50 {
+        let ch = Channel::from_shared(endpoint.clone())
+            .unwrap()
+            .tls_config(tls.clone())
+            .unwrap()
+            .connect()
+            .await;
+        match ch {
+            Ok(c) => return DarkPoolServiceClient::new(c),
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+    }
+    panic!("grpc client connect failed: {:?}", last_err);
+}
+
+async fn grpc_client_mtls(
+    addr: SocketAddr,
+    ca_pem: &str,
+    client_cert_pem: &str,
+    client_key_pem: &str,
+) -> DarkPoolServiceClient<Channel> {
+    let endpoint = format!("https://localhost:{}", addr.port());
+    let identity = Identity::from_pem(client_cert_pem, client_key_pem);
+    let tls = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(ca_pem))
+        .identity(identity)
+        .domain_name("localhost");
+    let mut last_err = None;
+    for _ in 0..50 {
+        let ch = Channel::from_shared(endpoint.clone())
+            .unwrap()
+            .tls_config(tls.clone())
+            .unwrap()
+            .connect()
+            .await;
+        match ch {
+            Ok(c) => return DarkPoolServiceClient::new(c),
+            Err(e) => {
+                last_err = Some(e);
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        }
+    }
+    panic!("grpc mtls client connect failed: {:?}", last_err);
+}
+
+fn reqwest_client(ca_pem: &str) -> reqwest::Client {
+    reqwest::Client::builder()
+        .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+        .build()
+        .unwrap()
+}
+
+fn reqwest_client_mtls(ca_pem: &str, client_cert_pem: &str, client_key_pem: &str) -> reqwest::Client {
+    let mut bundle = Vec::new();
+    bundle.extend_from_slice(client_cert_pem.as_bytes());
+    bundle.extend_from_slice(client_key_pem.as_bytes());
+    let identity = reqwest::Identity::from_pem(&bundle).unwrap();
+    reqwest::Client::builder()
+        .add_root_certificate(reqwest::Certificate::from_pem(ca_pem.as_bytes()).unwrap())
+        .identity(identity)
+        .build()
+        .unwrap()
+}
+
+async fn wait_rest_ready(client: &reqwest::Client, url: &str) {
+    for _ in 0..100 {
+        if client.get(url).send().await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("rest server never became ready at {url}");
+}
+
+#[tokio::test]
+async fn grpc_serves_over_tls() {
+    let bundle = mint_bundle();
+    let mode = TlsMode::Tls {
+        cert: bundle.server_cert_path.clone(),
+        key: bundle.server_key_path.clone(),
+    };
+    let server = start_grpc(&mode).await;
+    let mut client = grpc_client(server.addr, &bundle.ca_pem).await;
+
+    let resp = client
+        .get_order_book(GetOrderBookRequest {
+            pair: "ETH/USDC".into(),
+        })
+        .await
+        .expect("orderbook over TLS")
+        .into_inner();
+    assert_eq!(resp.pair, "ETH/USDC");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn grpc_rejects_plain_client_when_tls_on() {
+    let bundle = mint_bundle();
+    let mode = TlsMode::Tls {
+        cert: bundle.server_cert_path.clone(),
+        key: bundle.server_key_path.clone(),
+    };
+    let server = start_grpc(&mode).await;
+
+    // Plain h2 client (no TLS) against a TLS listener: connect either
+    // fails outright or the first RPC fails — either is an acceptable
+    // "rejected" outcome. We bound the wait so a hung handshake can't
+    // freeze the test.
+    let endpoint = format!("http://{}", server.addr);
+    let channel = Channel::from_shared(endpoint).unwrap();
+    let outcome = tokio::time::timeout(Duration::from_secs(2), async {
+        match channel.connect().await {
+            Err(_) => true, // connect refused
+            Ok(ch) => {
+                let mut client = DarkPoolServiceClient::new(ch);
+                client
+                    .get_order_book(GetOrderBookRequest {
+                        pair: "ETH/USDC".into(),
+                    })
+                    .await
+                    .is_err()
+            }
+        }
+    })
+    .await
+    .unwrap_or(true);
+    assert!(outcome, "plaintext client must not succeed against TLS server");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn grpc_mtls_accepts_authorized_client() {
+    let bundle = mint_bundle();
+    let mode = TlsMode::Mtls {
+        cert: bundle.server_cert_path.clone(),
+        key: bundle.server_key_path.clone(),
+        client_ca: bundle.ca_path.clone(),
+    };
+    let server = start_grpc(&mode).await;
+    let mut client = grpc_client_mtls(
+        server.addr,
+        &bundle.ca_pem,
+        &bundle.client.pem,
+        &bundle.client.key_pem,
+    )
+    .await;
+
+    let resp = client
+        .get_order_book(GetOrderBookRequest {
+            pair: "ETH/USDC".into(),
+        })
+        .await
+        .expect("mTLS orderbook")
+        .into_inner();
+    assert_eq!(resp.pair, "ETH/USDC");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn grpc_mtls_rejects_missing_client_cert() {
+    let bundle = mint_bundle();
+    let mode = TlsMode::Mtls {
+        cert: bundle.server_cert_path.clone(),
+        key: bundle.server_key_path.clone(),
+        client_ca: bundle.ca_path.clone(),
+    };
+    let server = start_grpc(&mode).await;
+
+    // CA-trusting client *without* an identity: handshake must fail.
+    let endpoint = format!("https://localhost:{}", server.addr.port());
+    let tls = ClientTlsConfig::new()
+        .ca_certificate(Certificate::from_pem(&bundle.ca_pem))
+        .domain_name("localhost");
+
+    let outcome = tokio::time::timeout(Duration::from_secs(3), async {
+        // Try a few times — connect can race the listener.
+        for _ in 0..20 {
+            let r = Channel::from_shared(endpoint.clone())
+                .unwrap()
+                .tls_config(tls.clone())
+                .unwrap()
+                .connect()
+                .await;
+            match r {
+                Err(_) => return true,
+                Ok(ch) => {
+                    let mut c = DarkPoolServiceClient::new(ch);
+                    if c.get_order_book(GetOrderBookRequest {
+                        pair: "ETH/USDC".into(),
+                    })
+                    .await
+                    .is_err()
+                    {
+                        return true;
+                    }
+                }
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        false
+    })
+    .await
+    .unwrap_or(true);
+    assert!(outcome, "mTLS server must reject clients without certs");
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn rest_serves_over_tls() {
+    let bundle = mint_bundle();
+    let mode = TlsMode::Tls {
+        cert: bundle.server_cert_path.clone(),
+        key: bundle.server_key_path.clone(),
+    };
+    let server = start_rest(&mode).await;
+    let client = reqwest_client(&bundle.ca_pem);
+    let url = format!("https://localhost:{}/v1/orderbook?pair=ETH/USDC", server.addr.port());
+    wait_rest_ready(&client, &url).await;
+    let resp = client.get(&url).send().await.expect("rest GET");
+    assert_eq!(resp.status(), 200, "body: {:?}", resp.text().await);
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn rest_mtls_accepts_authorized_client() {
+    let bundle = mint_bundle();
+    let mode = TlsMode::Mtls {
+        cert: bundle.server_cert_path.clone(),
+        key: bundle.server_key_path.clone(),
+        client_ca: bundle.ca_path.clone(),
+    };
+    let server = start_rest(&mode).await;
+    let client = reqwest_client_mtls(&bundle.ca_pem, &bundle.client.pem, &bundle.client.key_pem);
+    let url = format!("https://localhost:{}/v1/orderbook?pair=ETH/USDC", server.addr.port());
+    wait_rest_ready(&client, &url).await;
+    let resp = client.get(&url).send().await.expect("rest mTLS GET");
+    assert_eq!(resp.status(), 200);
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn rest_mtls_rejects_missing_client_cert() {
+    let bundle = mint_bundle();
+    let mode = TlsMode::Mtls {
+        cert: bundle.server_cert_path.clone(),
+        key: bundle.server_key_path.clone(),
+        client_ca: bundle.ca_path.clone(),
+    };
+    let server = start_rest(&mode).await;
+    let url = format!(
+        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
+        server.addr.port()
+    );
+
+    // First wait for the listener to be ready via the mTLS-authorized
+    // client. This separates "server not bound yet" from "TLS rejected
+    // me" — otherwise a connect-refused early on would look identical
+    // to a TLS handshake failure and the assertion would lie.
+    let authed = reqwest_client_mtls(&bundle.ca_pem, &bundle.client.pem, &bundle.client.key_pem);
+    wait_rest_ready(&authed, &url).await;
+
+    // No client identity → the TLS handshake must fail.
+    let anon = reqwest_client(&bundle.ca_pem);
+    let outcome = anon.get(&url).send().await;
+    assert!(
+        outcome.is_err(),
+        "mTLS server must reject reqwest client without identity, got status {:?}",
+        outcome.ok().map(|r| r.status())
+    );
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn rest_reload_swaps_cert_material() {
+    // Boots REST with cert-A, swaps to cert-B via the same reload path
+    // SIGHUP triggers in production, then verifies the new cert is
+    // served on subsequent handshakes. Mirrors the rotation runbook
+    // step without sending an actual signal.
+    let bundle_a = mint_bundle();
+    let bundle_b = mint_bundle();
+
+    let mode_a = TlsMode::Tls {
+        cert: bundle_a.server_cert_path.clone(),
+        key: bundle_a.server_key_path.clone(),
+    };
+    let mode_b = TlsMode::Tls {
+        cert: bundle_b.server_cert_path.clone(),
+        key: bundle_b.server_key_path.clone(),
+    };
+
+    let server = start_rest(&mode_a).await;
+    let url = format!("https://localhost:{}/v1/orderbook?pair=ETH/USDC", server.addr.port());
+
+    let client_a = reqwest_client(&bundle_a.ca_pem);
+    wait_rest_ready(&client_a, &url).await;
+    assert_eq!(client_a.get(&url).send().await.unwrap().status(), 200);
+
+    // Cert-B is signed by a different CA, so a CA-A client should now
+    // fail post-reload, and a CA-B client should succeed. This proves
+    // the swap actually replaced the chain rather than masking the
+    // assertion behind a still-valid old cert.
+    let tls_cfg_handle = server.tls_cfg.clone().expect("tls config present");
+    tls::reload_axum_rustls(&tls_cfg_handle, &mode_b)
+        .await
+        .expect("reload");
+
+    // Reqwest reuses kept-alive connections; force a fresh client so we
+    // exercise a new TLS handshake against the reloaded cert.
+    let client_b = reqwest_client(&bundle_b.ca_pem);
+    let resp = client_b.get(&url).send().await.expect("post-reload GET");
+    assert_eq!(resp.status(), 200);
+
+    let client_a_after = reqwest_client(&bundle_a.ca_pem);
+    let fail = client_a_after.get(&url).send().await;
+    assert!(
+        fail.is_err(),
+        "old-CA client must fail after rotation, got {:?}",
+        fail.ok().map(|r| r.status())
+    );
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn rest_mtls_reload_swaps_cert_material() {
+    // Happy-path twin to rest_reload_swaps_cert_material on the mTLS
+    // arm. Exercises build_mtls_server_config + cfg.reload_from_config,
+    // the path SIGHUP takes when the operator runs mTLS in production.
+    let bundle_a = mint_bundle();
+    let bundle_b = mint_bundle();
+    let mode_a = TlsMode::Mtls {
+        cert: bundle_a.server_cert_path.clone(),
+        key: bundle_a.server_key_path.clone(),
+        client_ca: bundle_a.ca_path.clone(),
+    };
+    let mode_b = TlsMode::Mtls {
+        cert: bundle_b.server_cert_path.clone(),
+        key: bundle_b.server_key_path.clone(),
+        client_ca: bundle_b.ca_path.clone(),
+    };
+
+    let server = start_rest(&mode_a).await;
+    let url = format!(
+        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
+        server.addr.port()
+    );
+
+    let client_a = reqwest_client_mtls(&bundle_a.ca_pem, &bundle_a.client.pem, &bundle_a.client.key_pem);
+    wait_rest_ready(&client_a, &url).await;
+    assert_eq!(client_a.get(&url).send().await.unwrap().status(), 200);
+
+    let tls_cfg_handle = server.tls_cfg.clone().expect("tls config present");
+    tls::reload_axum_rustls(&tls_cfg_handle, &mode_b)
+        .await
+        .expect("mTLS reload");
+
+    let client_b = reqwest_client_mtls(&bundle_b.ca_pem, &bundle_b.client.pem, &bundle_b.client.key_pem);
+    let resp = client_b.get(&url).send().await.expect("post-reload mTLS GET");
+    assert_eq!(resp.status(), 200);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn rest_reload_to_plaintext_errors() {
+    // Downgrading a TLS listener to plaintext via SIGHUP is intentionally
+    // refused — the only safe path is process restart. The function must
+    // surface this as Err so the SIGHUP handler logs and keeps the live
+    // cert serving rather than silently discarding TLS.
+    let bundle = mint_bundle();
+    let mode = TlsMode::Tls {
+        cert: bundle.server_cert_path.clone(),
+        key: bundle.server_key_path.clone(),
+    };
+    let server = start_rest(&mode).await;
+    let url = format!(
+        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
+        server.addr.port()
+    );
+    let client = reqwest_client(&bundle.ca_pem);
+    wait_rest_ready(&client, &url).await;
+
+    let tls_cfg_handle = server.tls_cfg.clone().expect("tls config present");
+    let outcome = tls::reload_axum_rustls(&tls_cfg_handle, &TlsMode::Plaintext).await;
+    assert!(outcome.is_err(), "plaintext reload must Err, got {outcome:?}");
+
+    // Old TLS cert still serving.
+    assert_eq!(client.get(&url).send().await.unwrap().status(), 200);
+
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn rest_reload_failure_keeps_old_cert() {
+    // Failure-soft contract: a SIGHUP reload that hits malformed material
+    // must surface as Err *and* leave the live listener serving the
+    // previous cert. The runbook tells operators to rely on this when a
+    // half-written cert lands on disk; without a test it's just a hope.
+    let bundle_a = mint_bundle();
+    let mode_a = TlsMode::Mtls {
+        cert: bundle_a.server_cert_path.clone(),
+        key: bundle_a.server_key_path.clone(),
+        client_ca: bundle_a.ca_path.clone(),
+    };
+    let server = start_rest(&mode_a).await;
+    let url = format!(
+        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
+        server.addr.port()
+    );
+
+    let client_a = reqwest_client_mtls(&bundle_a.ca_pem, &bundle_a.client.pem, &bundle_a.client.key_pem);
+    wait_rest_ready(&client_a, &url).await;
+    assert_eq!(client_a.get(&url).send().await.unwrap().status(), 200);
+
+    // Stage garbage PEM files and attempt the reload through the same
+    // path SIGHUP triggers in production.
+    let garbage_dir = tempfile::tempdir().unwrap();
+    let garbage_cert = garbage_dir.path().join("cert.pem");
+    let garbage_key = garbage_dir.path().join("key.pem");
+    let garbage_ca = garbage_dir.path().join("ca.pem");
+    std::fs::write(&garbage_cert, b"-----BEGIN CERTIFICATE-----\nnot a cert\n-----END CERTIFICATE-----\n").unwrap();
+    std::fs::write(&garbage_key, b"-----BEGIN PRIVATE KEY-----\nnot a key\n-----END PRIVATE KEY-----\n").unwrap();
+    std::fs::write(&garbage_ca, b"-----BEGIN CERTIFICATE-----\nnot a ca\n-----END CERTIFICATE-----\n").unwrap();
+    let bad_mode = TlsMode::Mtls {
+        cert: garbage_cert,
+        key: garbage_key,
+        client_ca: garbage_ca,
+    };
+
+    let tls_cfg_handle = server.tls_cfg.clone().expect("tls config present");
+    let outcome = tls::reload_axum_rustls(&tls_cfg_handle, &bad_mode).await;
+    assert!(outcome.is_err(), "garbage PEM must surface as reload Err, got {outcome:?}");
+
+    // Old material must still serve. Use a fresh reqwest client so the
+    // assertion isn't masked by a kept-alive connection from before.
+    let client_a_after = reqwest_client_mtls(&bundle_a.ca_pem, &bundle_a.client.pem, &bundle_a.client.key_pem);
+    let resp = client_a_after.get(&url).send().await.expect("post-failed-reload GET");
+    assert_eq!(resp.status(), 200);
+
+    server.shutdown().await;
+}

--- a/docs/operations/key-rotation.md
+++ b/docs/operations/key-rotation.md
@@ -1,5 +1,11 @@
 # Operator key rotation runbook
 
+> 🔐 **Looking for TLS / mTLS cert rotation instead?** See
+> [`docs/operations/tls-setup.md`](./tls-setup.md). That covers the
+> transport-layer material the gRPC and REST listeners present to
+> clients; this runbook covers the ECIES key that decrypts trader
+> order payloads.
+
 A rotation cycles the operator's ECIES decryption key without dropping
 orders that are in-flight at the moment the new key takes effect.
 

--- a/docs/operations/tls-setup.md
+++ b/docs/operations/tls-setup.md
@@ -1,0 +1,230 @@
+# TLS / mTLS for `darkpool-server`
+
+`darkpool-server` terminates TLS in-process for both transports — the
+tonic gRPC listener (default `:9090`) and the axum REST listener
+(default `:8080`). A single cert/key pair covers both ports; mTLS is
+opt-in via a separate client-CA bundle.
+
+> 🔁 **Looking for ECIES decryption key rotation instead?** See
+> [`docs/operations/key-rotation.md`](./key-rotation.md). That runbook
+> rotates the key the operator uses to decrypt trader order payloads.
+> This document is strictly about the transport-layer certificate
+> presented to clients.
+
+---
+
+## Configuration surface
+
+| Flag / env var | Meaning |
+| --- | --- |
+| `--tls-cert` / `DARKPOOL_TLS_CERT` | PEM cert (or chain). When set together with `--tls-key`, TLS is enabled on both listeners. |
+| `--tls-key`  / `DARKPOOL_TLS_KEY`  | PEM private key matching `--tls-cert`. |
+| `--tls-client-ca` / `DARKPOOL_TLS_CLIENT_CA` | PEM CA bundle that signs *client* certificates. Presence enables mTLS — clients without a cert chained to this bundle are rejected at the handshake. |
+
+Validation rules (enforced at boot — invalid combinations exit
+non-zero):
+
+- Both `--tls-cert` and `--tls-key` empty → **plaintext mode**, with a
+  loud `warn!` so it is impossible to ship to prod silently.
+- Exactly one of `--tls-cert` / `--tls-key` set → fatal error.
+- `--tls-client-ca` set without `--tls-cert`/`--tls-key` → fatal
+  error (otherwise mTLS would silently degrade to "no TLS at all").
+
+---
+
+## Generating a dev certificate
+
+Local development uses an ephemeral self-signed cert. The integration
+tests mint these on the fly via `rcgen`; for a manual smoke test:
+
+```sh
+openssl req -x509 -newkey rsa:2048 -nodes \
+  -keyout /tmp/dp.key.pem -out /tmp/dp.cert.pem \
+  -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,DNS:grpc.localhost,DNS:api.localhost,IP:127.0.0.1" \
+  -days 7
+chmod 0400 /tmp/dp.key.pem
+```
+
+Then boot:
+
+```sh
+DARKPOOL_TLS_CERT=/tmp/dp.cert.pem \
+DARKPOOL_TLS_KEY=/tmp/dp.key.pem \
+  cargo run -p dp-api
+```
+
+Smoke-test REST:
+
+```sh
+curl --cacert /tmp/dp.cert.pem https://127.0.0.1:8080/healthz
+```
+
+Smoke-test gRPC with `grpcurl`:
+
+```sh
+grpcurl -cacert /tmp/dp.cert.pem 127.0.0.1:9090 list
+```
+
+---
+
+## Production deploy
+
+1. Issue (or renew) a certificate covering every DNS name clients
+   will dial. A single multi-SAN cert keeps the config surface small:
+
+   ```text
+   CN  = api.dp.example
+   SAN = DNS:api.dp.example, DNS:grpc.dp.example
+   ```
+
+2. Install the material on the operator host with restrictive
+   permissions:
+
+   ```sh
+   install -m 0400 -o dp-api -g dp-api new.cert.pem /etc/darkpool/tls/cert.pem
+   install -m 0400 -o dp-api -g dp-api new.key.pem  /etc/darkpool/tls/key.pem
+   ```
+
+3. Point the service at the paths via `DARKPOOL_TLS_CERT` /
+   `DARKPOOL_TLS_KEY` in `/etc/darkpool/env`.
+
+4. Restart the service once. Subsequent renewals follow the
+   **rotation** procedure below — no restart is required for REST.
+
+---
+
+## Enabling mTLS
+
+Mutual TLS adds **client** cert verification to both listeners. The
+operator runs the client CA; clients enroll by submitting a CSR to
+ops, which signs it with the CA's private key.
+
+1. Generate the client root CA (one-time):
+
+   ```sh
+   openssl req -x509 -newkey rsa:4096 -nodes -days 3650 \
+     -subj "/CN=DarkPool Operator Client CA" \
+     -keyout /etc/darkpool/tls/client-ca.key.pem \
+     -out    /etc/darkpool/tls/client-ca.pem
+   chmod 0400 /etc/darkpool/tls/client-ca.key.pem
+   ```
+
+2. Sign each trader's CSR with the client CA. Distribute the signed
+   cert + the bundle of intermediates back to the trader.
+
+3. Set `DARKPOOL_TLS_CLIENT_CA=/etc/darkpool/tls/client-ca.pem` and
+   restart the service.
+
+4. Validate end-to-end with `curl`:
+
+   ```sh
+   # mTLS-on server rejects anonymous clients.
+   curl --cacert /etc/darkpool/tls/cert.pem \
+     https://api.dp.example/healthz                          # fails
+   # mTLS-on server accepts an enrolled client.
+   curl --cacert /etc/darkpool/tls/cert.pem \
+     --cert /etc/dp-trader/client.pem \
+     --key  /etc/dp-trader/client.key.pem \
+     https://api.dp.example/healthz                          # ok
+   ```
+
+---
+
+## Rotation procedure
+
+Cert rotation is asymmetric between the two listeners — REST hot-swaps,
+gRPC requires a restart:
+
+| Listener | Reload mechanism | Open connections |
+| --- | --- | --- |
+| REST (`:8080`)  | `SIGHUP` → in-place `RustlsConfig::reload_from_pem_file` (or `reload_from_config` for mTLS). | Kept alive on the **old** cert until they close; new handshakes use the **new** cert. |
+| gRPC (`:9090`)  | None — tonic 0.12 exposes no reload API. **Restart the process** to swap the gRPC cert. | Dropped on restart. Clients reconnect transparently. |
+
+### REST hot-reload (most rotations)
+
+1. Atomically write the new material over the existing paths so the
+   listener never observes a half-written file:
+
+   ```sh
+   install -m 0400 -o dp-api -g dp-api new.cert.pem /etc/darkpool/tls/cert.pem
+   install -m 0400 -o dp-api -g dp-api new.key.pem  /etc/darkpool/tls/key.pem
+   ```
+
+2. Tell the running process to re-read them:
+
+   ```sh
+   systemctl reload dp-api      # systemd unit must send SIGHUP
+   # or:
+   kill -HUP "$(pidof darkpool-server)"
+   ```
+
+   Logs should show:
+
+   ```text
+   INFO SIGHUP: REST TLS material reloaded
+   WARN SIGHUP: gRPC listener does not hot-reload TLS — restart the process to rotate the gRPC certificate
+   ```
+
+3. Confirm the new cert is being served:
+
+   ```sh
+   openssl s_client -connect api.dp.example:8080 -servername api.dp.example </dev/null \
+     | openssl x509 -noout -subject -dates
+   ```
+
+### gRPC rotation (≤ quarterly)
+
+Because the gRPC listener cannot hot-reload, schedule a graceful
+restart to pick up the new cert:
+
+```sh
+systemctl restart dp-api
+```
+
+Cap the overall rotation cadence at **≤ 90 days** so Let's Encrypt is a
+valid issuer if you ever stop running a private CA. Restart-windows
+are short (sub-second handover when the upstream LB is configured to
+retry on `UNAVAILABLE`).
+
+### What if the SIGHUP reload fails?
+
+The reload path is failure-soft: a bad cert file is logged and the
+listener **keeps serving the previous certificate**. The relevant log
+line is `WARN SIGHUP: REST TLS reload failed (keeping previous cert):
+<reason>`. Diagnose the bad file, fix it, and re-send `SIGHUP`. No
+service interruption occurs.
+
+---
+
+## Asymmetry — at a glance
+
+```text
+┌──────────┬────────────────────────┬─────────────────────┐
+│ listener │ rotation cadence       │ reload mechanism    │
+├──────────┼────────────────────────┼─────────────────────┤
+│ REST     │ as often as needed     │ SIGHUP, in-place    │
+│ gRPC     │ ≤ quarterly            │ process restart     │
+└──────────┴────────────────────────┴─────────────────────┘
+```
+
+The asymmetry is documented honestly rather than papered over — the
+gRPC side waits on a tonic upstream reload API. Tracking issue is
+linked from the PR introducing this listener.
+
+---
+
+## Why these choices
+
+- **App-native TLS (no sidecar).** Order payloads are decrypted in
+  process; terminating TLS in the same binary keeps the
+  confidentiality boundary co-located with the auth boundary. Ops are
+  still free to front the service with nginx if they want, but the
+  protocol guarantees do not depend on it.
+- **Unified cert.** One cert/key pair covers both ports via SANs.
+  Cuts the cert-issuance surface in half and keeps the env-var shape
+  small (`--tls-cert`, `--tls-key`, `--tls-client-ca`). Per-listener
+  override is a trivial follow-up if ops ever needs split DNS with
+  split CAs.
+- **rustls / ring.** Default crypto provider is `ring`; the same
+  provider backs both the gRPC and REST listeners.


### PR DESCRIPTION
Closes #24

## Summary

App-native TLS termination for both `darkpool-server` transports
(tonic gRPC on `:9090`, axum REST on `:8080`) with optional mTLS via
a client-CA bundle. SIGHUP triggers an in-place REST cert reload;
gRPC asymmetry (restart-only) is documented honestly rather than
papered over.

- `--tls-cert` / `--tls-key` enable TLS on both listeners. Both unset
  → plaintext mode with a loud `warn!` at boot so a prod
  misconfiguration is never silent. Half-configured states fail at
  boot rather than silently degrading.
- `--tls-client-ca` flips both listeners to mTLS. The REST path
  builds a full `rustls::ServerConfig` so the cert can later be
  hot-swapped via `RustlsConfig::reload_from_config`.
- Single loader module `dp_api::tls` is the only place that parses
  PEM material — gRPC and REST cannot drift on trust roots or parse
  rules.
- `axum_server::bind_rustls` replaces the previous
  `tokio::net::TcpListener` + `axum::serve` path. Graceful shutdown
  is driven by `axum_server::Handle`.
- SIGHUP (unix-only) reloads REST in place via
  `tls::reload_axum_rustls`; the same handler emits a warn pointing
  operators at the restart-only flow for the gRPC cert.

## Commits

1. `Bring TLS / mTLS dependencies into the workspace`
2. `Add TlsMode config resolver for TLS / mTLS posture`
3. `Add tls loader module for gRPC and REST listeners`
4. `Wire TLS into gRPC and REST listeners with SIGHUP reload`
5. `Cover TLS, mTLS, and SIGHUP reload paths end-to-end`
6. `Document TLS / mTLS setup and rotation procedure`

## Test plan

- [x] \`cargo test -p dp-api\` — 217 passed, 0 failed
- [x] \`cargo clippy -p dp-api --all-targets -- -D warnings\` — clean
- [x] \`cargo check --workspace --all-targets\` — clean
- [x] TLS unit tests (\`config::\`, \`tls::\`)
- [x] End-to-end TLS / mTLS / reload integration suite
      (\`tests/server_boot_tls.rs\`, 11 cases) — pass serial and parallel
- [ ] Manual smoke against \`openssl req -x509 ...\` + \`grpcurl\` /
      \`curl\` (operator-side verification — see
      \`docs/operations/tls-setup.md\`)
- [ ] Manual SIGHUP rotation against a running instance (operator-side
      verification — see runbook section "REST hot-reload")

## Out of scope (follow-ups)

- gRPC native hot-reload — blocked on tonic upstream
- Per-listener cert override (split DNS / split CA)
- Cert URI schemes (\`file:\`, \`age:\`, \`awskms:\`) shared with
  \`dp-crypto\`'s \`KeySource\` — wait for #28 to land then unify
- OCSP stapling / CRL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TLS and optional mTLS for gRPC and REST listeners with boot-time validation, plaintext warning, and bounded graceful shutdown.
  * REST supports SIGHUP-driven certificate hot-reload and runtime reload behavior that preserves prior certs on reload failure.

* **Documentation**
  * Added TLS setup runbook (dev/prod, mTLS, rotation, expected logs) and linked certificate-rotation guidance in key-rotation doc.

* **Tests**
  * Added end-to-end TLS/mTLS tests covering listeners, client validation, hot-reload, rotation, and failure cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->