### PR TITLE
[CI] Wire npm test into frontend lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,5 @@ jobs:
       - run: npm run lint
       - run: npm run format:check
       - run: npm run build
+      - name: Run vitest unit tests
+        run: npm test -- --reporter=default


### PR DESCRIPTION
Closes #107

## Summary
- Add `npm test -- --reporter=default` step to the `frontend` job in `.github/workflows/ci.yml`, after `npm run build`.
- Step runs inside the same job and reuses the existing `npm ci` install (no duplicate setup).
- `vitest run` exits non-zero on test failures, so a broken test now fails the CI run.
- `--reporter=default` keeps the per-file test list and summary visible in the job log for debugging.

## Test plan
- [x] `cd front && npm ci && npm test -- --reporter=default` → 342 passed (26 files), exit 0.
- [x] Sanity-checked failure path: added a temporary failing test, `npm test -- --reporter=default` exited 1 with the failure rendered in the summary. Temp file removed.
- [x] Verified working tree only touches `.github/workflows/ci.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow with automated unit testing validation in the build process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->