### PR TITLE
[F1.10] My orders panel + cancel (mock)

### DIFF
--- a/front/app/app/trade/_components/Shell.tsx
+++ b/front/app/app/trade/_components/Shell.tsx
@@ -4,6 +4,8 @@ import { type ComponentType, type ReactNode, type SVGProps } from 'react'
 import { ChartGlyph, EntryGlyph, OrderbookGlyph, TapeGlyph } from '@/app/app/_shell/icons'
 import { Sheet, SheetContent, SheetTitle, SheetTrigger } from '@/components/ui/sheet'
 
+import { MyOrdersPanel } from './my-orders'
+
 type Glyph = ComponentType<SVGProps<SVGSVGElement>>
 
 export function Shell() {
@@ -18,21 +20,26 @@ export function Shell() {
 
 function DesktopLayout() {
   return (
-    <div className="hidden lg:grid lg:grid-cols-[1fr_2fr_1fr] lg:min-h-[calc(100vh-4rem)]">
-      <section aria-label="Order book" className="border-r border-brand-border">
-        <OrderbookPanel />
-      </section>
-      <section
-        aria-label="Market chart and order entry"
-        className="grid grid-rows-[2fr_1fr] border-r border-brand-border"
-      >
-        <ChartPanel />
-        <div className="border-t border-brand-border">
-          <OrderEntryPanel />
-        </div>
-      </section>
-      <section aria-label="Auction tape">
-        <TapePanel />
+    <div className="hidden lg:flex lg:min-h-[calc(100vh-4rem)] lg:flex-col">
+      <div className="grid flex-1 grid-cols-[1fr_2fr_1fr]">
+        <section aria-label="Order book" className="border-r border-brand-border">
+          <OrderbookPanel />
+        </section>
+        <section
+          aria-label="Market chart and order entry"
+          className="grid grid-rows-[2fr_1fr] border-r border-brand-border"
+        >
+          <ChartPanel />
+          <div className="border-t border-brand-border">
+            <OrderEntryPanel />
+          </div>
+        </section>
+        <section aria-label="Auction tape">
+          <TapePanel />
+        </section>
+      </div>
+      <section aria-label="My orders" className="border-t border-brand-border">
+        <MyOrdersPanel />
       </section>
     </div>
   )
@@ -47,8 +54,11 @@ function MobileLayout() {
       <section aria-label="Market chart" className="border-b border-brand-border">
         <ChartPanel />
       </section>
-      <section aria-label="Auction tape">
+      <section aria-label="Auction tape" className="border-b border-brand-border">
         <TapePanel />
+      </section>
+      <section aria-label="My orders">
+        <MyOrdersPanel />
       </section>
     </div>
   )

--- a/front/app/app/trade/_components/my-orders/MyOrdersPanel.stories.tsx
+++ b/front/app/app/trade/_components/my-orders/MyOrdersPanel.stories.tsx
@@ -9,6 +9,7 @@
 import * as React from 'react'
 
 import { create } from '@bufbuild/protobuf'
+
 import { Toaster } from '@/components/ui/toaster'
 import { OrderInfoSchema, Side } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
 import type { OrderInfo } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
@@ -16,8 +17,8 @@ import { walletStore } from '@/lib/wallet/mock-store'
 
 import type { UseMyOrdersOptions, UseMyOrdersReturn } from '../../_hooks/my-orders/useMyOrders'
 import type { MyOrderRow } from '../../_lib/my-orders/types'
-import { MyOrdersPanel } from './MyOrdersPanel'
 import { OrderBook } from '../orderbook/OrderBook'
+import { MyOrdersPanel } from './MyOrdersPanel'
 
 function useConnected(connect: boolean) {
   React.useEffect(() => {

--- a/front/app/app/trade/_components/my-orders/MyOrdersPanel.stories.tsx
+++ b/front/app/app/trade/_components/my-orders/MyOrdersPanel.stories.tsx
@@ -1,0 +1,158 @@
+// Ladle preview surface for the My Orders panel.
+//
+// Each story imperatively seeds a fresh mock-store / wallet-store and
+// stubs `useMyOrders` so the visual state can be inspected in isolation
+// of the underlying ticker. The runtime hook is exercised by the
+// auction-tick story, which renders the live store and lets the engine
+// drive transitions.
+
+import * as React from 'react'
+
+import { create } from '@bufbuild/protobuf'
+import { Toaster } from '@/components/ui/toaster'
+import { OrderInfoSchema, Side } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { OrderInfo } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import { walletStore } from '@/lib/wallet/mock-store'
+
+import type { UseMyOrdersOptions, UseMyOrdersReturn } from '../../_hooks/my-orders/useMyOrders'
+import type { MyOrderRow } from '../../_lib/my-orders/types'
+import { MyOrdersPanel } from './MyOrdersPanel'
+import { OrderBook } from '../orderbook/OrderBook'
+
+function useConnected(connect: boolean) {
+  React.useEffect(() => {
+    if (connect) walletStore.connect()
+    else walletStore.disconnect()
+    return () => {
+      walletStore.disconnect()
+    }
+  }, [connect])
+}
+
+const NOW_UNIX = 1700000000n
+
+function mkOrder(overrides: Partial<OrderInfo> = {}): OrderInfo {
+  return create(OrderInfoSchema, {
+    id: 'o-1',
+    pair: 'ETH/USDC',
+    side: Side.BUY,
+    price: '3000',
+    size: '1',
+    remainingSize: '1',
+    commitmentKey: 'mock-k',
+    submittedAtUnix: NOW_UNIX,
+    expiresAtUnix: 0n,
+    ...overrides,
+  })
+}
+
+function staticHook(rows: MyOrderRow[]): (options?: UseMyOrdersOptions) => UseMyOrdersReturn {
+  return () => ({
+    rows,
+    userPrices: new Set(rows.filter((r) => r.status === 'open').map((r) => r.order.price)),
+    cancel: () => true,
+  })
+}
+
+export const Disconnected = () => {
+  useConnected(false)
+  return (
+    <div className="bg-brand-bg p-6">
+      <MyOrdersPanel useOrders={staticHook([])} />
+    </div>
+  )
+}
+
+export const ConnectedNoOrders = () => {
+  useConnected(true)
+  return (
+    <div className="bg-brand-bg p-6">
+      <MyOrdersPanel useOrders={staticHook([])} />
+    </div>
+  )
+}
+
+export const MixedStatuses = () => {
+  useConnected(true)
+  const rows: MyOrderRow[] = [
+    {
+      order: mkOrder({
+        id: 'o-buy-3000',
+        side: Side.BUY,
+        price: '3000',
+        size: '1.25',
+        remainingSize: '1.25',
+        submittedAtUnix: 1700000300n,
+      }),
+      status: 'open',
+    },
+    {
+      order: mkOrder({
+        id: 'o-buy-2995',
+        side: Side.BUY,
+        price: '2995',
+        size: '0.5',
+        remainingSize: '0.5',
+        submittedAtUnix: 1700000180n,
+      }),
+      status: 'open',
+    },
+    {
+      order: mkOrder({
+        id: 'o-sell-3010',
+        side: Side.SELL,
+        price: '3010',
+        size: '0.75',
+        remainingSize: '0.75',
+        submittedAtUnix: 1700000060n,
+      }),
+      status: 'filled',
+    },
+    {
+      order: mkOrder({
+        id: 'o-buy-2990',
+        side: Side.BUY,
+        price: '2990',
+        size: '2',
+        remainingSize: '2',
+        submittedAtUnix: 1699999920n,
+      }),
+      status: 'cancelled',
+    },
+  ]
+  return (
+    <div className="bg-brand-bg p-6">
+      <MyOrdersPanel useOrders={staticHook(rows)} />
+      <Toaster />
+    </div>
+  )
+}
+
+export const OrderbookHighlightIntegration = () => {
+  // Demonstrates the cross-component contract: my-orders exports a set
+  // of user prices, the orderbook marks the matching rows with a 2px
+  // white left edge. The Shell wires the same `userPrices` prop in
+  // production once OrderBook is hoisted out of its placeholder slot.
+  useConnected(true)
+  const rows: MyOrderRow[] = [
+    {
+      order: mkOrder({ id: 'me-2995', side: Side.BUY, price: '2995', remainingSize: '1.5' }),
+      status: 'open',
+    },
+    {
+      order: mkOrder({ id: 'me-3005', side: Side.SELL, price: '3005', remainingSize: '0.8' }),
+      status: 'open',
+    },
+  ]
+  const userPrices = new Set(['2995', '3005'])
+  return (
+    <div className="grid h-[640px] grid-cols-[320px_minmax(0,1fr)] gap-px bg-brand-border">
+      <div className="bg-brand-bg">
+        <OrderBook userPrices={userPrices} refetchIntervalMs={1000} />
+      </div>
+      <div className="bg-brand-bg p-6">
+        <MyOrdersPanel useOrders={staticHook(rows)} />
+      </div>
+    </div>
+  )
+}

--- a/front/app/app/trade/_components/my-orders/MyOrdersPanel.test.tsx
+++ b/front/app/app/trade/_components/my-orders/MyOrdersPanel.test.tsx
@@ -1,0 +1,144 @@
+// Smoke tests for the panel composition. We render to static markup
+// (node-only vitest setup, same pattern as Balances/OrderEntry). These
+// lock the wallet/store-derived states end-to-end at the composition
+// layer; the hook's diffing reducer is covered by afterlife.test.ts.
+
+import { create } from '@bufbuild/protobuf'
+import * as React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { OrderInfoSchema, Side } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { OrderInfo } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import { walletStore } from '@/lib/wallet/mock-store'
+
+import type { UseMyOrdersReturn } from '../../_hooks/my-orders/useMyOrders'
+import type { MyOrderRow } from '../../_lib/my-orders/types'
+import { MyOrdersPanel } from './MyOrdersPanel'
+
+function mkOrder(overrides: Partial<OrderInfo> = {}): OrderInfo {
+  return create(OrderInfoSchema, {
+    id: 'o-1',
+    pair: 'ETH/USDC',
+    side: Side.BUY,
+    price: '3000',
+    size: '1',
+    remainingSize: '1',
+    commitmentKey: 'mock-k',
+    submittedAtUnix: 1700000000n,
+    expiresAtUnix: 0n,
+    ...overrides,
+  })
+}
+
+function stubHook(rows: MyOrderRow[]): () => UseMyOrdersReturn {
+  return () => ({
+    rows,
+    userPrices: new Set(rows.filter((r) => r.status === 'open').map((r) => r.order.price)),
+    cancel: () => true,
+  })
+}
+
+function renderPanel(rows: MyOrderRow[] = []): string {
+  return renderToStaticMarkup(<MyOrdersPanel useOrders={stubHook(rows)} />)
+}
+
+describe('MyOrdersPanel', () => {
+  beforeEach(() => {
+    walletStore.disconnect()
+  })
+  afterEach(() => {
+    walletStore.disconnect()
+  })
+
+  it('renders the bracketed-tag header in every state', () => {
+    expect(renderPanel()).toContain('[ MY ORDERS ]')
+  })
+
+  it('renders the connect-wallet empty state when disconnected', () => {
+    const html = renderPanel([{ order: mkOrder(), status: 'open' }])
+    expect(html).toContain('[ CONNECT WALLET ]')
+    // Column headers do not surface when disconnected.
+    expect(html).not.toContain('>TIME<')
+  })
+
+  it('renders the no-orders empty state when connected with no rows', () => {
+    walletStore.connect()
+    const html = renderPanel([])
+    expect(html).toContain('[ NO ORDERS YET ]')
+    expect(html).not.toContain('>TIME<')
+  })
+
+  it('renders column headers and one row per order when connected', () => {
+    walletStore.connect()
+    const html = renderPanel([
+      { order: mkOrder({ id: 'o-buy', side: Side.BUY, price: '3000' }), status: 'open' },
+      {
+        order: mkOrder({ id: 'o-sell', side: Side.SELL, price: '3010', remainingSize: '0.5' }),
+        status: 'open',
+      },
+    ])
+    expect(html).toContain('>TIME<')
+    expect(html).toContain('>SIDE<')
+    expect(html).toContain('>PRICE<')
+    expect(html).toContain('>SIZE<')
+    expect(html).toContain('>STATUS<')
+    expect(html).toContain('[ BUY ]')
+    expect(html).toContain('[ SELL ]')
+    expect(html).toContain('Cancel order o-buy')
+    expect(html).toContain('Cancel order o-sell')
+  })
+
+  it('renders all three status labels', () => {
+    walletStore.connect()
+    const html = renderPanel([
+      { order: mkOrder({ id: 'a' }), status: 'open' },
+      { order: mkOrder({ id: 'b' }), status: 'filled' },
+      { order: mkOrder({ id: 'c' }), status: 'cancelled' },
+    ])
+    expect(html).toContain('[ OPEN ]')
+    expect(html).toContain('[ FILLED ]')
+    expect(html).toContain('[ CANCELLED ]')
+  })
+
+  it('disables the cancel button for filled and cancelled rows', () => {
+    walletStore.connect()
+    const html = renderPanel([
+      { order: mkOrder({ id: 'open-a' }), status: 'open' },
+      { order: mkOrder({ id: 'filled-b' }), status: 'filled' },
+      { order: mkOrder({ id: 'cxl-c' }), status: 'cancelled' },
+    ])
+    // We check for the `disabled=""` attribute string that ReactDOM
+    // emits for boolean attributes — Tailwind's `disabled:` class
+    // variants would otherwise false-match on the substring `disabled`.
+    function buttonHasDisabledAttr(id: string): boolean {
+      const re = new RegExp(`<button[^>]*aria-label="Cancel order ${id}"[^>]*disabled=""`)
+      const reFlipped = new RegExp(`<button[^>]*disabled=""[^>]*aria-label="Cancel order ${id}"`)
+      return re.test(html) || reFlipped.test(html)
+    }
+    expect(buttonHasDisabledAttr('open-a')).toBe(false)
+    expect(buttonHasDisabledAttr('filled-b')).toBe(true)
+    expect(buttonHasDisabledAttr('cxl-c')).toBe(true)
+  })
+
+  it('does not introduce a lime accent on the panel surface', () => {
+    walletStore.connect()
+    const html = renderPanel([
+      { order: mkOrder({ id: 'a' }), status: 'open' },
+      { order: mkOrder({ id: 'b' }), status: 'cancelled' },
+    ])
+    // The /trade lime budget belongs to the auction countdown — this
+    // panel must not claim it via text/background/border/ring/shadow.
+    // The focus-visible outline on cancel may carry the colour, but it
+    // only paints when the element has keyboard focus, so we whitelist
+    // that token by name.
+    const matches = html.match(/brand-accent/g) ?? []
+    for (const m of matches) {
+      expect(m).toBe('brand-accent')
+    }
+    // None of the always-painted surfaces (bg/text) should reference it.
+    expect(html).not.toMatch(/bg-brand-accent/)
+    expect(html).not.toMatch(/text-brand-accent/)
+    expect(html).not.toMatch(/accent-glow/)
+  })
+})

--- a/front/app/app/trade/_components/my-orders/MyOrdersPanel.tsx
+++ b/front/app/app/trade/_components/my-orders/MyOrdersPanel.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+// Composition root for the My Orders panel.
+//
+// Reads (rows, cancel) from useMyOrders, fires a toast on cancel, and
+// renders three states:
+//   - Disconnected (mock wallet not connected) → empty hint.
+//   - Connected + no rows → "[ NO ORDERS YET ]".
+//   - Connected + rows → header row + ordered row list.
+//
+// The hook is injectable so the test surface can drive the panel from
+// a fresh mock-store without touching the runtime singleton.
+
+import * as React from 'react'
+
+import { useToast } from '@/components/ui/use-toast'
+import { useWallet } from '@/lib/wallet/hooks'
+
+import {
+  useMyOrders,
+  type UseMyOrdersOptions,
+  type UseMyOrdersReturn,
+} from '../../_hooks/my-orders/useMyOrders'
+import { OrderRow } from './OrderRow'
+
+export interface MyOrdersPanelProps {
+  /**
+   * Override the hook used to source rows. Tests pass a controlled
+   * implementation; production code lets the default singleton hook run.
+   */
+  useOrders?: (options?: UseMyOrdersOptions) => UseMyOrdersReturn
+}
+
+export function MyOrdersPanel({ useOrders = useMyOrders }: MyOrdersPanelProps = {}): JSX.Element {
+  const { isConnected } = useWallet()
+  const { rows, cancel } = useOrders()
+  const { toast } = useToast()
+  const headerId = React.useId()
+
+  const handleCancel = React.useCallback(
+    (orderId: string) => {
+      const ok = cancel(orderId)
+      if (!ok) return
+      toast({ title: 'Order cancelled', description: 'Removed from the open book.' })
+    },
+    [cancel, toast]
+  )
+
+  return (
+    <section
+      aria-labelledby={headerId}
+      className="flex h-full min-h-[160px] flex-col border border-brand-border bg-brand-surface"
+    >
+      <Header id={headerId} />
+      {!isConnected ? (
+        <EmptyState label="[ CONNECT WALLET ]" />
+      ) : rows.length === 0 ? (
+        <EmptyState label="[ NO ORDERS YET ]" />
+      ) : (
+        <div className="flex flex-1 flex-col overflow-y-auto">
+          <ColumnHeader />
+          <div role="rowgroup">
+            {rows.map((row) => (
+              <OrderRow key={row.order.id} row={row} onCancel={handleCancel} />
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  )
+}
+
+function Header({ id }: { id: string }): JSX.Element {
+  return (
+    <header className="flex h-9 items-center border-b border-brand-border px-4">
+      <span
+        id={id}
+        className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
+      >
+        [ MY ORDERS ]
+      </span>
+    </header>
+  )
+}
+
+function ColumnHeader(): JSX.Element {
+  return (
+    <div
+      role="row"
+      className="grid grid-cols-[4.5rem_3.5rem_minmax(0,1fr)_minmax(0,1fr)_6rem_5.5rem] gap-3 border-b border-brand-border bg-brand-surface px-4 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
+    >
+      <span>TIME</span>
+      <span>SIDE</span>
+      <span className="text-right">PRICE</span>
+      <span className="text-right">SIZE</span>
+      <span>STATUS</span>
+      <span className="text-right" aria-hidden="true">
+        {/* cancel column header is intentionally blank — action, not data */}
+      </span>
+    </div>
+  )
+}
+
+function EmptyState({ label }: { label: string }): JSX.Element {
+  return (
+    <div className="flex flex-1 items-center justify-center p-6">
+      <p
+        role="status"
+        className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
+      >
+        {label}
+      </p>
+    </div>
+  )
+}

--- a/front/app/app/trade/_components/my-orders/OrderRow.tsx
+++ b/front/app/app/trade/_components/my-orders/OrderRow.tsx
@@ -22,7 +22,6 @@ const COLS = 'grid-cols-[4.5rem_3.5rem_minmax(0,1fr)_minmax(0,1fr)_6rem_5.5rem]'
 export function OrderRow({ row, onCancel }: OrderRowProps): JSX.Element {
   const { order, status } = row
   const cancellable = status === 'open'
-  const dimmed = status !== 'open'
 
   return (
     <div
@@ -30,7 +29,7 @@ export function OrderRow({ row, onCancel }: OrderRowProps): JSX.Element {
       data-testid="my-order-row"
       data-status={status}
       className={`grid ${COLS} items-center gap-3 border-b border-brand-border px-4 py-3 font-mono text-body-sm tabular-nums ${
-        dimmed ? 'opacity-60' : ''
+        status !== 'open' ? 'opacity-60' : ''
       }`}
     >
       <span className="uppercase tracking-label text-brand-muted">

--- a/front/app/app/trade/_components/my-orders/OrderRow.tsx
+++ b/front/app/app/trade/_components/my-orders/OrderRow.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import * as React from 'react'
+
+import { NumericText } from '@/components/NumericText'
+
+import { formatSubmittedAt, sideLabel } from '../../_lib/my-orders/format'
+import type { MyOrderRow } from '../../_lib/my-orders/types'
+import { StatusPill } from './StatusPill'
+
+export interface OrderRowProps {
+  row: MyOrderRow
+  /** Invoked when the trader clicks Cancel on an open row. */
+  onCancel: (orderId: string) => void
+}
+
+// Six-column layout matching DESIGN-INSPIRATIONS §My orders:
+// time · side · price · size · status · cancel. Numerics align right
+// with tabular figures so they read like a Bloomberg blotter.
+const COLS = 'grid-cols-[4.5rem_3.5rem_minmax(0,1fr)_minmax(0,1fr)_6rem_5.5rem]'
+
+export function OrderRow({ row, onCancel }: OrderRowProps): JSX.Element {
+  const { order, status } = row
+  const cancellable = status === 'open'
+  const dimmed = status !== 'open'
+
+  return (
+    <div
+      role="row"
+      data-testid="my-order-row"
+      data-status={status}
+      className={`grid ${COLS} items-center gap-3 border-b border-brand-border px-4 py-3 font-mono text-body-sm tabular-nums ${
+        dimmed ? 'opacity-60' : ''
+      }`}
+    >
+      <span className="uppercase tracking-label text-brand-muted">
+        {formatSubmittedAt(order.submittedAtUnix)}
+      </span>
+      <span className="uppercase tracking-label text-brand-fg">{sideLabel(order.side)}</span>
+      <NumericText value={order.price} kind="price" align="right" className="text-brand-fg" />
+      <NumericText
+        value={order.remainingSize}
+        kind="size"
+        align="right"
+        className="text-brand-fg"
+      />
+      <span className="flex justify-start">
+        <StatusPill status={status} />
+      </span>
+      <div className="flex justify-end">
+        <button
+          type="button"
+          disabled={!cancellable}
+          onClick={cancellable ? () => onCancel(order.id) : undefined}
+          aria-label={`Cancel order ${order.id}`}
+          className="inline-flex h-9 min-w-[3.5rem] items-center justify-end font-mono text-label-md uppercase tracking-labelWide text-brand-muted transition-colors hover:text-brand-fg focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-brand-accent disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-brand-muted"
+        >
+          [ CANCEL ]
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/front/app/app/trade/_components/my-orders/StatusPill.tsx
+++ b/front/app/app/trade/_components/my-orders/StatusPill.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import * as React from 'react'
+
+import { statusLabel } from '../../_lib/my-orders/format'
+import type { MyOrderStatus } from '../../_lib/my-orders/types'
+
+export interface StatusPillProps {
+  status: MyOrderStatus
+}
+
+// Mirrors `status-pill-live` / `status-pill-offline` from DESIGN.md:
+// a 6×6 square (`borderRadius: 0` is mandatory) paired with a bracketed
+// mono label. Open blinks at 1 Hz; the other states are static so the
+// trader's eye lands on whatever just changed.
+//
+// Per DESIGN-INSPIRATIONS §"Accent budget per view", the /app/trade
+// surface gives the lime accent to the auction countdown — not here.
+// The OPEN affordance reads as "live" through shape + motion (square,
+// blinking) rather than colour.
+const SQUARE_BASE = 'inline-block h-1.5 w-1.5 align-middle [border-radius:0px]'
+
+const SQUARE_CLASS: Record<MyOrderStatus, string> = {
+  open: `${SQUARE_BASE} bg-brand-fg animate-blink motion-reduce:animate-none`,
+  filled: `${SQUARE_BASE} bg-brand-fg`,
+  cancelled: `${SQUARE_BASE} bg-brand-muted`,
+}
+
+const TEXT_CLASS: Record<MyOrderStatus, string> = {
+  open: 'text-brand-fg',
+  filled: 'text-brand-fg',
+  cancelled: 'text-brand-muted',
+}
+
+export function StatusPill({ status }: StatusPillProps): JSX.Element {
+  return (
+    <span className="inline-flex items-center gap-2 font-mono text-body-sm">
+      <span aria-hidden="true" className={SQUARE_CLASS[status]} />
+      <span className={`uppercase tracking-label ${TEXT_CLASS[status]}`}>
+        {statusLabel(status)}
+      </span>
+    </span>
+  )
+}

--- a/front/app/app/trade/_components/my-orders/index.ts
+++ b/front/app/app/trade/_components/my-orders/index.ts
@@ -1,0 +1,2 @@
+export { MyOrdersPanel } from './MyOrdersPanel'
+export type { MyOrdersPanelProps } from './MyOrdersPanel'

--- a/front/app/app/trade/_components/orderbook/DepthRow.tsx
+++ b/front/app/app/trade/_components/orderbook/DepthRow.tsx
@@ -11,6 +11,12 @@ export interface DepthRowProps {
   side: Side.BUY | Side.SELL
   /** Best-of-book row gets one typography step up. */
   emphasized?: boolean
+  /**
+   * Marks the row as belonging to the connected trader — adds a 2px white
+   * left edge so the user can spot their resting orders inside the book.
+   * Driven by F1.10 (#77) via the `userPrices` prop chain on OrderBook.
+   */
+  mine?: boolean
   onSelect?: (price: string, side: Side.BUY | Side.SELL) => void
 }
 
@@ -20,7 +26,7 @@ export interface DepthRowProps {
  * use `secondary` at 20% (per DESIGN-INSPIRATIONS bid/ask tension table).
  * No semantic color anywhere.
  */
-export function DepthRow({ row, side, emphasized = false, onSelect }: DepthRowProps) {
+export function DepthRow({ row, side, emphasized = false, mine = false, onSelect }: DepthRowProps) {
   const isBid = side === Side.BUY
   const bar = isBid ? 'bg-brand-fg/[0.08]' : 'bg-brand-muted/20'
   const sizeClass = emphasized ? 'text-body-md' : 'text-body-sm'
@@ -34,12 +40,19 @@ export function DepthRow({ row, side, emphasized = false, onSelect }: DepthRowPr
       onClick={handleClick}
       className={`relative grid w-full grid-cols-3 items-center gap-2 px-4 py-1 text-left font-mono transition-colors duration-100 hover:bg-brand-surface focus-visible:bg-brand-surface focus-visible:outline focus-visible:outline-1 focus-visible:outline-brand-accent focus-visible:outline-offset-[-1px] ${sizeClass}`}
       aria-label={clickable ? `${isBid ? 'Bid' : 'Ask'} ${row.level.price}` : undefined}
+      data-mine={mine || undefined}
     >
       <span
         aria-hidden="true"
         className={`pointer-events-none absolute inset-y-0 right-0 ${bar}`}
         style={{ width: `${Math.min(100, Math.max(0, row.barFraction * 100))}%` }}
       />
+      {mine && (
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 left-0 w-0.5 bg-brand-fg"
+        />
+      )}
       <NumericText
         value={row.level.price}
         kind="price"

--- a/front/app/app/trade/_components/orderbook/DepthTable.tsx
+++ b/front/app/app/trade/_components/orderbook/DepthTable.tsx
@@ -17,6 +17,12 @@ export interface DepthTableProps {
    * best→worst.
    */
   reverse?: boolean
+  /**
+   * Distinct prices the connected trader has open orders at. Forwarded
+   * from F1.10 (#77) so the book can mark "your levels" with a white
+   * left edge — see `DepthRow.mine`.
+   */
+  userPrices?: ReadonlySet<string>
   onSelect?: (price: string, side: DepthTableSide) => void
 }
 
@@ -25,7 +31,7 @@ export interface DepthTableProps {
  * the side closest to the spread — gets one typography step up so the
  * top of book reads with hierarchy.
  */
-export function DepthTable({ rows, side, reverse = false, onSelect }: DepthTableProps) {
+export function DepthTable({ rows, side, reverse = false, userPrices, onSelect }: DepthTableProps) {
   const ordered = reverse ? [...rows].reverse() : rows
   const isBid = side === Side.BUY
   const bestIndex = reverse ? ordered.length - 1 : 0
@@ -40,7 +46,13 @@ export function DepthTable({ rows, side, reverse = false, onSelect }: DepthTable
       <ul className="flex flex-col">
         {ordered.map((row, i) => (
           <li key={row.level.price}>
-            <DepthRow row={row} side={side} emphasized={i === bestIndex} onSelect={onSelect} />
+            <DepthRow
+              row={row}
+              side={side}
+              emphasized={i === bestIndex}
+              mine={userPrices?.has(row.level.price) ?? false}
+              onSelect={onSelect}
+            />
           </li>
         ))}
       </ul>

--- a/front/app/app/trade/_components/orderbook/OrderBook.tsx
+++ b/front/app/app/trade/_components/orderbook/OrderBook.tsx
@@ -21,6 +21,12 @@ export interface OrderBookProps {
    * its hover/focus affordances but is otherwise a no-op.
    */
   onPriceSelect?: (price: string, side: Side.BUY | Side.SELL) => void
+  /**
+   * Prices the connected trader has open orders at. F1.10 (#77) sources
+   * this from the my-orders panel so the book can mark the trader's own
+   * levels with a hairline edge marker on the matching row.
+   */
+  userPrices?: ReadonlySet<string>
   /** Override polling cadence for Storybook / tests. */
   refetchIntervalMs?: number
 }
@@ -34,12 +40,13 @@ export interface OrderBookProps {
  * with a `QueryClientProvider` should render `OrderBookContent` directly
  * — it sees the ancestor's client and uses the shared cache.
  */
-export function OrderBook({ pair, onPriceSelect, refetchIntervalMs }: OrderBookProps) {
+export function OrderBook({ pair, onPriceSelect, userPrices, refetchIntervalMs }: OrderBookProps) {
   return (
     <QueryClientProvider client={getScopedClient()}>
       <OrderBookContent
         pair={pair}
         onPriceSelect={onPriceSelect}
+        userPrices={userPrices}
         refetchIntervalMs={refetchIntervalMs}
       />
     </QueryClientProvider>
@@ -54,6 +61,7 @@ export function OrderBook({ pair, onPriceSelect, refetchIntervalMs }: OrderBookP
 export function OrderBookContent({
   pair,
   onPriceSelect,
+  userPrices,
   refetchIntervalMs,
 }: OrderBookProps): JSX.Element {
   const effectivePair = pair ?? DEFAULT_PAIR
@@ -96,9 +104,20 @@ export function OrderBookContent({
     body = (
       <div className="flex flex-col">
         <ColumnHeader />
-        <DepthTable rows={depth.asks} side={Side.SELL} reverse onSelect={handleSelect} />
+        <DepthTable
+          rows={depth.asks}
+          side={Side.SELL}
+          reverse
+          userPrices={userPrices}
+          onSelect={handleSelect}
+        />
         <SpreadRow bestBid={bestBid} bestAsk={bestAsk} />
-        <DepthTable rows={depth.bids} side={Side.BUY} onSelect={handleSelect} />
+        <DepthTable
+          rows={depth.bids}
+          side={Side.BUY}
+          userPrices={userPrices}
+          onSelect={handleSelect}
+        />
       </div>
     )
   }

--- a/front/app/app/trade/_hooks/my-orders/useMyOrders.test.tsx
+++ b/front/app/app/trade/_hooks/my-orders/useMyOrders.test.tsx
@@ -1,0 +1,94 @@
+// Drives `useMyOrders` end-to-end against a real `createMockStore`
+// instance, so the contract between the diffing reducer and the
+// underlying zustand store is locked at the integration seam.
+//
+// renderToStaticMarkup runs only the initial commit (no effects), so to
+// observe the hook's post-effect state we render the wrapper twice
+// across mutations.
+
+import * as React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it } from 'vitest'
+
+import { createMockStore, type MockStore } from '@/lib/mock-store'
+import { Side } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { StoreApi } from 'zustand/vanilla'
+
+import { useMyOrders, type UseMyOrdersOptions } from './useMyOrders'
+
+const FROZEN_NOW_SECONDS = 1_700_000_000
+
+function freshStore(): StoreApi<MockStore> {
+  return createMockStore({ seed: 7, now: () => FROZEN_NOW_SECONDS, mid: '3000', depth: 6 })
+}
+
+function Probe({ options }: { options: UseMyOrdersOptions }): JSX.Element {
+  const { rows, userPrices } = useMyOrders(options)
+  return (
+    <div>
+      <ul>
+        {rows.map((r) => (
+          <li key={r.order.id}>{`${r.order.id}:${r.status}:${r.order.price}`}</li>
+        ))}
+      </ul>
+      <span data-testid="prices">{Array.from(userPrices).sort().join(',')}</span>
+    </div>
+  )
+}
+
+describe('useMyOrders', () => {
+  it('surfaces open orders sourced from the store', () => {
+    const store = freshStore()
+    store.getState().placeOrder({ side: Side.BUY, price: '2995', size: '1' })
+    store.getState().placeOrder({ side: Side.SELL, price: '3005', size: '0.5' })
+
+    const html = renderToStaticMarkup(<Probe options={{ store }} />)
+
+    expect(html).toMatch(/:open:2995/)
+    expect(html).toMatch(/:open:3005/)
+  })
+
+  it('exposes the distinct set of user prices for orderbook highlighting', () => {
+    const store = freshStore()
+    store.getState().placeOrder({ side: Side.BUY, price: '2995', size: '1' })
+    store.getState().placeOrder({ side: Side.BUY, price: '2995', size: '0.25' })
+    store.getState().placeOrder({ side: Side.SELL, price: '3010', size: '0.5' })
+
+    const html = renderToStaticMarkup(<Probe options={{ store }} />)
+
+    expect(html).toContain('>2995,3010<')
+  })
+
+  it('drops cancelled orders from open status when the cancel() action runs', () => {
+    const store = freshStore()
+    const order = store.getState().placeOrder({ side: Side.BUY, price: '2995', size: '1' })
+
+    // The hook's cancel() requires a host component. Render once to get
+    // a handle into the hook (via a ref) and then call cancel().
+    let cancelFn: ((id: string) => boolean) | null = null
+
+    function Harness(): JSX.Element {
+      const { cancel } = useMyOrders({ store, now: () => 1000 })
+      cancelFn = cancel
+      return <span />
+    }
+    renderToStaticMarkup(<Harness />)
+
+    expect(cancelFn).not.toBeNull()
+    const ok = cancelFn!(order.id)
+    expect(ok).toBe(true)
+    expect(store.getState().openOrders.find((o) => o.id === order.id)).toBeUndefined()
+  })
+
+  it('returns false when cancel() is called with an unknown id', () => {
+    const store = freshStore()
+    let cancelFn: ((id: string) => boolean) | null = null
+    function Harness(): JSX.Element {
+      const { cancel } = useMyOrders({ store, now: () => 1000 })
+      cancelFn = cancel
+      return <span />
+    }
+    renderToStaticMarkup(<Harness />)
+    expect(cancelFn!('nope-not-here')).toBe(false)
+  })
+})

--- a/front/app/app/trade/_hooks/my-orders/useMyOrders.ts
+++ b/front/app/app/trade/_hooks/my-orders/useMyOrders.ts
@@ -96,28 +96,41 @@ export function useMyOrders(options: UseMyOrdersOptions = {}): UseMyOrdersReturn
   const [afterlife, dispatch] = useReducer(reducer, undefined, emptyAfterlifeState)
 
   // Snapshot held across renders so the SYNC dispatch can diff prev→next.
-  const prevRef = useRef<ReadonlyMap<string, OrderInfo>>(new Map(openOrders.map((o) => [o.id, o])))
+  // Lazy-init: the initializer arg is only used on the very first render,
+  // so eager allocation here would build (then discard) a fresh Map on
+  // every subsequent render.
+  const prevRef = useRef<ReadonlyMap<string, OrderInfo> | null>(null)
+  if (prevRef.current === null) {
+    prevRef.current = new Map(openOrders.map((o) => [o.id, o]))
+  }
 
   useEffect(() => {
     const next = new Map(openOrders.map((o) => [o.id, o]))
-    if (sameIdSet(prevRef.current, next)) return
-    dispatch({ type: 'SYNC', prev: prevRef.current, next, nowMs: now(), ttlMs })
+    if (sameIdSet(prevRef.current!, next)) return
+    dispatch({ type: 'SYNC', prev: prevRef.current!, next, nowMs: now(), ttlMs })
     prevRef.current = next
   }, [openOrders, now, ttlMs])
 
   // Heartbeat prune so cancelled/filled rows fade out even when the
-  // mock store is otherwise quiet. The interval is short enough that
-  // expiry feels punctual without being noisy.
+  // mock store is otherwise quiet. Gated on `afterlife.size` so the
+  // timer doesn't run forever when there's nothing to expire.
+  const afterlifeSize = afterlife.afterlife.size
   useEffect(() => {
+    if (afterlifeSize === 0) return
     const id = setInterval(() => dispatch({ type: 'PRUNE', nowMs: now(), ttlMs }), 1000)
     return () => clearInterval(id)
-  }, [now, ttlMs])
+  }, [afterlifeSize, now, ttlMs])
 
   const cancel = useCallback(
     (orderId: string): boolean => {
       const state = store.getState()
       const order = state.openOrders.find((o) => o.id === orderId)
       if (!order) return false
+      // Invariant: `cancelOrder` finds by the same id we just resolved
+      // from `openOrders.find`, and the store mutation is synchronous,
+      // so the call below cannot fail to remove the row. Dispatching
+      // CANCEL up-front keeps the row in `cancelled` state the moment
+      // the diff effect observes the removal.
       dispatch({ type: 'CANCEL', order, nowMs: now() })
       return state.cancelOrder(orderId)
     },

--- a/front/app/app/trade/_hooks/my-orders/useMyOrders.ts
+++ b/front/app/app/trade/_hooks/my-orders/useMyOrders.ts
@@ -1,0 +1,140 @@
+'use client'
+
+// React shell over the pure afterlife reducer in _lib/my-orders/afterlife.ts.
+//
+// The hook fuses two state sources:
+//   1. mockStore.openOrders, subscribed via useSyncExternalStore.
+//   2. A local "afterlife" map that keeps cancelled/filled rows on screen
+//      for `ttlMs` after the underlying store has dropped them.
+//
+// On every change to openOrders the hook diffs against the previous
+// snapshot and writes a `filled` tombstone for any id that left without
+// a prior `cancelled` marker. `cancel()` writes the tombstone *before*
+// calling `store.cancelOrder` so the order is captured at the source
+// rather than reconstructed after the fact.
+//
+// All the algebra lives in `_lib/my-orders/afterlife.ts`; this file is
+// glue.
+
+import { useCallback, useEffect, useMemo, useReducer, useRef, useSyncExternalStore } from 'react'
+import type { StoreApi } from 'zustand/vanilla'
+
+import { mockStore as defaultMockStore } from '@/lib/mock-store'
+import type { MockStore } from '@/lib/mock-store'
+import type { OrderInfo } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import {
+  appendFilled,
+  composeRows,
+  DEFAULT_AFTERLIFE_TTL_MS,
+  emptyAfterlifeState,
+  markCancelled,
+  pruneAfterlife,
+  userPriceLevels,
+  type AfterlifeState,
+} from '../../_lib/my-orders/afterlife'
+import type { MyOrderRow } from '../../_lib/my-orders/types'
+
+type Action =
+  | {
+      type: 'SYNC'
+      prev: ReadonlyMap<string, OrderInfo>
+      next: ReadonlyMap<string, OrderInfo>
+      nowMs: number
+      ttlMs: number
+    }
+  | { type: 'CANCEL'; order: OrderInfo; nowMs: number }
+  | { type: 'PRUNE'; nowMs: number; ttlMs: number }
+
+function reducer(state: AfterlifeState, action: Action): AfterlifeState {
+  switch (action.type) {
+    case 'SYNC': {
+      const withFills = appendFilled(state, {
+        prevOpenOrders: action.prev,
+        nextOpenOrders: action.next,
+        nowMs: action.nowMs,
+      })
+      return pruneAfterlife(withFills, action.nowMs, action.ttlMs)
+    }
+    case 'CANCEL':
+      return markCancelled(state, action.order, action.nowMs)
+    case 'PRUNE':
+      return pruneAfterlife(state, action.nowMs, action.ttlMs)
+  }
+}
+
+// Hoisted so the default identity is stable across renders and we don't
+// thrash effect dependencies.
+const wallClock = (): number => Date.now()
+
+export interface UseMyOrdersOptions {
+  /** Injectable store handle. Defaults to the runtime singleton. */
+  store?: StoreApi<MockStore>
+  /** Afterlife TTL in ms. Defaults to 5000 (matches the design spec). */
+  ttlMs?: number
+  /** Injectable clock so tests can pin removal timestamps. */
+  now?: () => number
+}
+
+export interface UseMyOrdersReturn {
+  rows: MyOrderRow[]
+  /** Distinct prices the user has open orders at — used by the orderbook to mark the level. */
+  userPrices: Set<string>
+  /** Trigger a cancel. Returns true iff the order was found and removed. */
+  cancel: (orderId: string) => boolean
+}
+
+export function useMyOrders(options: UseMyOrdersOptions = {}): UseMyOrdersReturn {
+  const store = options.store ?? defaultMockStore
+  const ttlMs = options.ttlMs ?? DEFAULT_AFTERLIFE_TTL_MS
+  const now = options.now ?? wallClock
+
+  const subscribe = useCallback((listener: () => void) => store.subscribe(listener), [store])
+  const getSnapshot = useCallback(() => store.getState().openOrders, [store])
+  const openOrders = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  const [afterlife, dispatch] = useReducer(reducer, undefined, emptyAfterlifeState)
+
+  // Snapshot held across renders so the SYNC dispatch can diff prev→next.
+  const prevRef = useRef<ReadonlyMap<string, OrderInfo>>(new Map(openOrders.map((o) => [o.id, o])))
+
+  useEffect(() => {
+    const next = new Map(openOrders.map((o) => [o.id, o]))
+    if (sameIdSet(prevRef.current, next)) return
+    dispatch({ type: 'SYNC', prev: prevRef.current, next, nowMs: now(), ttlMs })
+    prevRef.current = next
+  }, [openOrders, now, ttlMs])
+
+  // Heartbeat prune so cancelled/filled rows fade out even when the
+  // mock store is otherwise quiet. The interval is short enough that
+  // expiry feels punctual without being noisy.
+  useEffect(() => {
+    const id = setInterval(() => dispatch({ type: 'PRUNE', nowMs: now(), ttlMs }), 1000)
+    return () => clearInterval(id)
+  }, [now, ttlMs])
+
+  const cancel = useCallback(
+    (orderId: string): boolean => {
+      const state = store.getState()
+      const order = state.openOrders.find((o) => o.id === orderId)
+      if (!order) return false
+      dispatch({ type: 'CANCEL', order, nowMs: now() })
+      return state.cancelOrder(orderId)
+    },
+    [store, now]
+  )
+
+  const rows = useMemo(
+    () => composeRows(openOrders, afterlife.afterlife),
+    [openOrders, afterlife.afterlife]
+  )
+  const userPrices = useMemo(() => userPriceLevels(openOrders), [openOrders])
+
+  return { rows, userPrices, cancel }
+}
+
+function sameIdSet(a: ReadonlyMap<string, OrderInfo>, b: ReadonlyMap<string, OrderInfo>): boolean {
+  if (a.size !== b.size) return false
+  for (const id of a.keys()) if (!b.has(id)) return false
+  return true
+}

--- a/front/app/app/trade/_lib/my-orders/afterlife.test.ts
+++ b/front/app/app/trade/_lib/my-orders/afterlife.test.ts
@@ -1,0 +1,190 @@
+// The "afterlife" reducer keeps cancelled/filled rows on screen for a
+// short TTL after the underlying store has dropped them, so the trader
+// can see *what just happened*. These tests pin the diff semantics:
+// removals are inferred from openOrders snapshots; cancels are signalled
+// explicitly so we don't mis-classify a user-initiated cancel as a fill.
+
+import { create } from '@bufbuild/protobuf'
+import { describe, expect, it } from 'vitest'
+
+import { OrderInfoSchema, Side } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { OrderInfo } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import {
+  appendFilled,
+  composeRows,
+  emptyAfterlifeState,
+  markCancelled,
+  pruneAfterlife,
+  userPriceLevels,
+} from './afterlife'
+
+function mkOrder(overrides: Partial<OrderInfo> = {}): OrderInfo {
+  return create(OrderInfoSchema, {
+    id: 'o-1',
+    pair: 'ETH/USDC',
+    side: Side.BUY,
+    price: '3000',
+    size: '1',
+    remainingSize: '1',
+    commitmentKey: 'mock-k',
+    submittedAtUnix: 1700000000n,
+    expiresAtUnix: 0n,
+    ...overrides,
+  })
+}
+
+describe('appendFilled', () => {
+  it('records orders that left openOrders without a cancel marker as filled', () => {
+    const a = mkOrder({ id: 'a' })
+    const b = mkOrder({ id: 'b' })
+    const prev = new Map([
+      ['a', a],
+      ['b', b],
+    ])
+    const next = new Map([['b', b]])
+
+    const out = appendFilled(emptyAfterlifeState(), {
+      prevOpenOrders: prev,
+      nextOpenOrders: next,
+      nowMs: 1000,
+    })
+
+    expect(out.afterlife.size).toBe(1)
+    const entry = out.afterlife.get('a')
+    expect(entry).toBeDefined()
+    expect(entry!.status).toBe('filled')
+    expect(entry!.removedAtMs).toBe(1000)
+    expect(entry!.order.id).toBe('a')
+  })
+
+  it('skips orders that already have a cancelled marker', () => {
+    const a = mkOrder({ id: 'a' })
+    const initial = markCancelled(emptyAfterlifeState(), a, 100)
+
+    const out = appendFilled(initial, {
+      prevOpenOrders: new Map([['a', a]]),
+      nextOpenOrders: new Map(),
+      nowMs: 200,
+    })
+
+    const entry = out.afterlife.get('a')
+    expect(entry).toBeDefined()
+    expect(entry!.status).toBe('cancelled')
+    // removedAtMs unchanged — the cancel marker wins.
+    expect(entry!.removedAtMs).toBe(100)
+  })
+
+  it('returns the input state unchanged when nothing was removed', () => {
+    const a = mkOrder({ id: 'a' })
+    const same = new Map([['a', a]])
+    const state = emptyAfterlifeState()
+
+    const out = appendFilled(state, {
+      prevOpenOrders: same,
+      nextOpenOrders: same,
+      nowMs: 1,
+    })
+
+    expect(out).toBe(state)
+  })
+})
+
+describe('markCancelled', () => {
+  it('captures the order snapshot at cancel time', () => {
+    const o = mkOrder({ id: 'a', price: '3010' })
+
+    const out = markCancelled(emptyAfterlifeState(), o, 500)
+
+    const entry = out.afterlife.get('a')
+    expect(entry).toBeDefined()
+    expect(entry!.status).toBe('cancelled')
+    expect(entry!.removedAtMs).toBe(500)
+    expect(entry!.order.price).toBe('3010')
+  })
+
+  it('replaces an earlier filled marker for the same id', () => {
+    // Edge case: a previous afterlife entry exists (e.g. user re-uses a
+    // synthetic id). Cancel should win because it carries the user's
+    // explicit intent.
+    const o = mkOrder({ id: 'a' })
+    const filled = appendFilled(emptyAfterlifeState(), {
+      prevOpenOrders: new Map([['a', o]]),
+      nextOpenOrders: new Map(),
+      nowMs: 100,
+    })
+
+    const out = markCancelled(filled, o, 200)
+
+    expect(out.afterlife.get('a')!.status).toBe('cancelled')
+    expect(out.afterlife.get('a')!.removedAtMs).toBe(200)
+  })
+})
+
+describe('pruneAfterlife', () => {
+  it('drops entries older than ttlMs', () => {
+    const a = mkOrder({ id: 'a' })
+    const b = mkOrder({ id: 'b' })
+    const state = markCancelled(markCancelled(emptyAfterlifeState(), a, 1000), b, 5000)
+
+    const out = pruneAfterlife(state, /* nowMs */ 6500, /* ttlMs */ 5000)
+
+    expect(out.afterlife.has('a')).toBe(false) // 6500 - 1000 = 5500 ≥ 5000
+    expect(out.afterlife.has('b')).toBe(true) // 6500 - 5000 = 1500 < 5000
+  })
+
+  it('returns the input state unchanged when nothing expired', () => {
+    const a = mkOrder({ id: 'a' })
+    const state = markCancelled(emptyAfterlifeState(), a, 1000)
+
+    const out = pruneAfterlife(state, 1500, 5000)
+
+    expect(out).toBe(state)
+  })
+})
+
+describe('composeRows', () => {
+  it('places open rows first, then afterlife rows, newest first within each group', () => {
+    const open1 = mkOrder({ id: 'open-1', submittedAtUnix: 100n })
+    const open2 = mkOrder({ id: 'open-2', submittedAtUnix: 200n })
+    const filled = mkOrder({ id: 'filled-1', submittedAtUnix: 50n })
+
+    const afterlife = markCancelled(emptyAfterlifeState(), filled, 999).afterlife
+
+    // openOrders are passed in store order (newest-first per mock-store contract).
+    const rows = composeRows([open2, open1], afterlife)
+
+    expect(rows.map((r) => r.order.id)).toEqual(['open-2', 'open-1', 'filled-1'])
+    expect(rows.map((r) => r.status)).toEqual(['open', 'open', 'cancelled'])
+  })
+
+  it('sorts multiple afterlife entries by removedAtMs descending', () => {
+    const a = mkOrder({ id: 'a' })
+    const b = mkOrder({ id: 'b' })
+    let s = emptyAfterlifeState()
+    s = markCancelled(s, a, 1000)
+    s = markCancelled(s, b, 2000)
+
+    const rows = composeRows([], s.afterlife)
+
+    expect(rows.map((r) => r.order.id)).toEqual(['b', 'a'])
+  })
+})
+
+describe('userPriceLevels', () => {
+  it('returns the set of distinct prices across openOrders', () => {
+    const orders = [
+      mkOrder({ id: 'a', price: '3000' }),
+      mkOrder({ id: 'b', price: '3001' }),
+      mkOrder({ id: 'c', price: '3000' }),
+    ]
+    const set = userPriceLevels(orders)
+    expect(set.has('3000')).toBe(true)
+    expect(set.has('3001')).toBe(true)
+    expect(set.size).toBe(2)
+  })
+
+  it('is empty when there are no orders', () => {
+    expect(userPriceLevels([]).size).toBe(0)
+  })
+})

--- a/front/app/app/trade/_lib/my-orders/afterlife.ts
+++ b/front/app/app/trade/_lib/my-orders/afterlife.ts
@@ -51,9 +51,10 @@ export function appendFilled(state: AfterlifeState, input: AppendFilledInput): A
   let next: Map<string, AfterlifeEntry> | null = null
   for (const [id, prevOrder] of input.prevOpenOrders) {
     if (input.nextOpenOrders.has(id)) continue
-    const existing = state.afterlife.get(id)
-    if (existing && existing.status === 'cancelled') continue
-    if (existing && existing.status === 'filled') continue
+    // Any pre-existing tombstone — cancelled (user) or filled (earlier
+    // diff) — wins over the one we'd write here, so we don't overwrite
+    // its `removedAtMs` and bump the row back into the active window.
+    if (state.afterlife.has(id)) continue
     if (!next) next = new Map(state.afterlife)
     next.set(id, { order: prevOrder, status: 'filled', removedAtMs: input.nowMs })
   }

--- a/front/app/app/trade/_lib/my-orders/afterlife.ts
+++ b/front/app/app/trade/_lib/my-orders/afterlife.ts
@@ -1,0 +1,106 @@
+// "Afterlife" bookkeeping: the My Orders panel needs to surface orders
+// that have *just* left the engine's openOrders so the trader sees their
+// cancel/fill happen. The mock-store doesn't carry that information —
+// once an order is gone, it's gone — so this module diffs successive
+// openOrders snapshots and keeps a short-lived tombstone for each
+// departed id.
+//
+// The semantics are:
+//   • A user-initiated cancel calls `markCancelled` *before* the store
+//     drops the order, so the snapshot is captured at the source.
+//   • Everything else that leaves openOrders is attributed to a fill
+//     by the auction tick. `appendFilled` runs after every store
+//     change and writes a `filled` tombstone for ids that left without
+//     a pre-existing `cancelled` marker.
+//   • `pruneAfterlife` drops tombstones once their age exceeds the TTL.
+//
+// All functions are pure; the hook layer owns the mutable refs and
+// timers that drive them.
+
+import type { OrderInfo } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import type { MyOrderRow, MyOrderStatus } from './types'
+
+export type AfterlifeStatus = Extract<MyOrderStatus, 'filled' | 'cancelled'>
+
+export interface AfterlifeEntry {
+  order: OrderInfo
+  status: AfterlifeStatus
+  /** ms-precision timestamp the entry first entered its current status. */
+  removedAtMs: number
+}
+
+export interface AfterlifeState {
+  afterlife: ReadonlyMap<string, AfterlifeEntry>
+}
+
+/** TTL the panel uses when no override is supplied — matches DESIGN-INSPIRATIONS §My orders. */
+export const DEFAULT_AFTERLIFE_TTL_MS = 5000
+
+export function emptyAfterlifeState(): AfterlifeState {
+  return { afterlife: new Map() }
+}
+
+export interface AppendFilledInput {
+  prevOpenOrders: ReadonlyMap<string, OrderInfo>
+  nextOpenOrders: ReadonlyMap<string, OrderInfo>
+  nowMs: number
+}
+
+export function appendFilled(state: AfterlifeState, input: AppendFilledInput): AfterlifeState {
+  let next: Map<string, AfterlifeEntry> | null = null
+  for (const [id, prevOrder] of input.prevOpenOrders) {
+    if (input.nextOpenOrders.has(id)) continue
+    const existing = state.afterlife.get(id)
+    if (existing && existing.status === 'cancelled') continue
+    if (existing && existing.status === 'filled') continue
+    if (!next) next = new Map(state.afterlife)
+    next.set(id, { order: prevOrder, status: 'filled', removedAtMs: input.nowMs })
+  }
+  return next ? { afterlife: next } : state
+}
+
+export function markCancelled(
+  state: AfterlifeState,
+  order: OrderInfo,
+  nowMs: number
+): AfterlifeState {
+  const next = new Map(state.afterlife)
+  next.set(order.id, { order, status: 'cancelled', removedAtMs: nowMs })
+  return { afterlife: next }
+}
+
+export function pruneAfterlife(
+  state: AfterlifeState,
+  nowMs: number,
+  ttlMs: number
+): AfterlifeState {
+  let next: Map<string, AfterlifeEntry> | null = null
+  for (const [id, entry] of state.afterlife) {
+    if (nowMs - entry.removedAtMs < ttlMs) continue
+    if (!next) next = new Map(state.afterlife)
+    next.delete(id)
+  }
+  return next ? { afterlife: next } : state
+}
+
+export function composeRows(
+  openOrders: readonly OrderInfo[],
+  afterlife: ReadonlyMap<string, AfterlifeEntry>
+): MyOrderRow[] {
+  const rows: MyOrderRow[] = openOrders.map((order) => ({ order, status: 'open' as const }))
+
+  const afterlifeEntries = Array.from(afterlife.values()).sort(
+    (a, b) => b.removedAtMs - a.removedAtMs
+  )
+  for (const entry of afterlifeEntries) {
+    rows.push({ order: entry.order, status: entry.status })
+  }
+  return rows
+}
+
+export function userPriceLevels(openOrders: readonly OrderInfo[]): Set<string> {
+  const set = new Set<string>()
+  for (const o of openOrders) set.add(o.price)
+  return set
+}

--- a/front/app/app/trade/_lib/my-orders/format.test.ts
+++ b/front/app/app/trade/_lib/my-orders/format.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { Side } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import { formatSubmittedAt, sideLabel, statusLabel } from './format'
+
+describe('formatSubmittedAt', () => {
+  it('renders a UNIX-second timestamp as HH:MM:SS in UTC', () => {
+    // 2023-11-14T22:13:20Z
+    expect(formatSubmittedAt(1700000000n)).toBe('22:13:20')
+  })
+
+  it('zero-pads single-digit components', () => {
+    // 1970-01-01T00:05:09Z
+    expect(formatSubmittedAt(309n)).toBe('00:05:09')
+  })
+
+  it('treats 0n as the unix epoch', () => {
+    expect(formatSubmittedAt(0n)).toBe('00:00:00')
+  })
+})
+
+describe('sideLabel', () => {
+  it('renders BUY as a bracketed tag', () => {
+    expect(sideLabel(Side.BUY)).toBe('[ BUY ]')
+  })
+
+  it('renders SELL as a bracketed tag', () => {
+    expect(sideLabel(Side.SELL)).toBe('[ SELL ]')
+  })
+})
+
+describe('statusLabel', () => {
+  it('renders each status as a bracketed uppercase tag', () => {
+    expect(statusLabel('open')).toBe('[ OPEN ]')
+    expect(statusLabel('filled')).toBe('[ FILLED ]')
+    expect(statusLabel('cancelled')).toBe('[ CANCELLED ]')
+  })
+})

--- a/front/app/app/trade/_lib/my-orders/format.ts
+++ b/front/app/app/trade/_lib/my-orders/format.ts
@@ -1,0 +1,31 @@
+import { Side } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+import type { MyOrderStatus } from './types'
+
+/**
+ * Render a UNIX-second timestamp as `HH:MM:SS` in UTC. The mock-store
+ * stamps `submittedAtUnix` from the injectable clock, so a UTC render
+ * keeps tests reproducible regardless of the runner's locale.
+ */
+export function formatSubmittedAt(unixSec: bigint): string {
+  const ms = Number(unixSec) * 1000
+  const d = new Date(ms)
+  const hh = String(d.getUTCHours()).padStart(2, '0')
+  const mm = String(d.getUTCMinutes()).padStart(2, '0')
+  const ss = String(d.getUTCSeconds()).padStart(2, '0')
+  return `${hh}:${mm}:${ss}`
+}
+
+export function sideLabel(side: Side): string {
+  return side === Side.BUY ? '[ BUY ]' : '[ SELL ]'
+}
+
+const STATUS_LABEL: Record<MyOrderStatus, string> = {
+  open: '[ OPEN ]',
+  filled: '[ FILLED ]',
+  cancelled: '[ CANCELLED ]',
+}
+
+export function statusLabel(status: MyOrderStatus): string {
+  return STATUS_LABEL[status]
+}

--- a/front/app/app/trade/_lib/my-orders/types.ts
+++ b/front/app/app/trade/_lib/my-orders/types.ts
@@ -1,0 +1,18 @@
+import type { OrderInfo } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+
+/**
+ * The three states a trader-facing order can occupy in the panel.
+ *
+ *   - `open`:      still resting in the engine's openOrders.
+ *   - `filled`:    consumed by an auction; the row lingers for the
+ *                  afterlife TTL so the trader sees the fill happen.
+ *   - `cancelled`: removed by the trader; the row lingers for the
+ *                  afterlife TTL with an undo affordance.
+ */
+export type MyOrderStatus = 'open' | 'filled' | 'cancelled'
+
+/** A row rendered by the My Orders panel. */
+export interface MyOrderRow {
+  order: OrderInfo
+  status: MyOrderStatus
+}


### PR DESCRIPTION
Closes #77

## Summary
- Adds the brutalist **My Orders** table panel: time · side · price · size · status · cancel. Status pills are `[ OPEN ]` (square, blinks at 1 Hz, white — accent budget stays with the auction countdown), `[ FILLED ]` and `[ CANCELLED ]` (static). Cancel is disabled for non-open statuses and toasts confirmation on success.
- Introduces an **afterlife reducer** (`_lib/my-orders/afterlife.ts`) that keeps cancelled/filled rows on screen for a 5 s TTL after the mock store has dropped them, so the trader sees the transition. The reducer diffs successive `openOrders` snapshots: user-initiated cancels are captured at the source via `markCancelled`, everything else that leaves is attributed to a fill.
- Adds an **additive `userPrices` prop chain** to `OrderBook → DepthTable → DepthRow`. When a row's price is in the trader's set, the row gets a 2 px white left edge — the orderbook half of the "highlight my level" acceptance criterion. The prop is optional and defaults to no-op, so this is a non-breaking change for #73's existing call-sites.
- Slots `[ MY ORDERS ]` into the Shell as a full-width row beneath the existing 3-column grid (desktop) and at the bottom of the stack (mobile). Existing placeholder panels are left untouched — wiring the real `OrderBook` into the Shell is a separate concern owned by a Shell-integration follow-up.

## Notes
- The runtime `OrderBook` is still rendered as a Shell placeholder today, so the `userPrices` highlight only paints end-to-end inside the `OrderbookHighlightIntegration` Ladle story (which composes both real components). The data flow is fully wired and the prop chain is type-checked; the Shell-side hook-up lands when whichever PR replaces the placeholder pulls `useMyOrders().userPrices` and passes it down.
- Undo affordance (`[ CANCELLED · UNDO ]` from `DESIGN-INSPIRATIONS.md`) is intentionally out of scope for this PR — not in the acceptance criteria, and re-placing produces a new id which would mislead the relationship.

## Test plan
- [x] `npm test` — 370/370 pass (28 new across `afterlife.test.ts`, `format.test.ts`, `useMyOrders.test.tsx`, `MyOrdersPanel.test.tsx`).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm run format:check` — clean.
- [ ] Visual review of the four Ladle stories (`Disconnected`, `ConnectedNoOrders`, `MixedStatuses`, `OrderbookHighlightIntegration`).
- [ ] Manual: connect mock wallet → place an order from the entry form → confirm it surfaces in the panel and toggles to `[ FILLED ]` after the next auction → cancel one → confirm toast + 5 s `[ CANCELLED ]` linger before the row disappears.