### PR TITLE
feat: Event log snapshotting and compaction for fast engine recovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,6 +2221,7 @@ dependencies = [
  "chrono",
  "dp-types",
  "rust_decimal",
+ "serde",
  "uuid",
 ]
 
@@ -2234,6 +2235,7 @@ dependencies = [
  "dp-types",
  "parking_lot",
  "rust_decimal",
+ "serde",
  "serde_json",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,6 +1637,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1690,6 +1702,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1873,6 +1912,42 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
 
 [[package]]
 name = "critical-section"
@@ -2278,6 +2353,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "bincode",
  "chrono",
+ "criterion",
  "dp-aggregator",
  "dp-auction",
  "dp-book",
@@ -2293,6 +2369,7 @@ dependencies = [
  "k256",
  "metrics",
  "parking_lot",
+ "proptest",
  "rand 0.8.6",
  "rust_decimal",
  "serde",
@@ -2951,6 +3028,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3484,6 +3572,17 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4068,6 +4167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4336,6 +4441,34 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "poly1305"
@@ -6220,6 +6353,16 @@ dependencies = [
  "displaydoc",
  "serde_core",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -409,11 +409,7 @@ mod tests {
 
     #[test]
     fn snapshot_dir_path_set_returns_some() {
-        let cfg = Config::parse_from([
-            "darkpool-server",
-            "--snapshot-dir",
-            "/var/dp/snaps",
-        ]);
+        let cfg = Config::parse_from(["darkpool-server", "--snapshot-dir", "/var/dp/snaps"]);
         assert_eq!(cfg.snapshot_dir_path(), Some("/var/dp/snaps"));
     }
 }

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -400,4 +400,20 @@ mod tests {
         let err = cfg.tls_mode().unwrap_err();
         assert!(err.contains("tls-client-ca"), "msg: {err}");
     }
+
+    #[test]
+    fn snapshot_dir_path_empty_is_none() {
+        let cfg = cfg_with_tls("", "", "");
+        assert!(cfg.snapshot_dir_path().is_none());
+    }
+
+    #[test]
+    fn snapshot_dir_path_set_returns_some() {
+        let cfg = Config::parse_from([
+            "darkpool-server",
+            "--snapshot-dir",
+            "/var/dp/snaps",
+        ]);
+        assert_eq!(cfg.snapshot_dir_path(), Some("/var/dp/snaps"));
+    }
 }

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -70,6 +70,44 @@ pub struct Config {
     #[arg(long, env = "DARKPOOL_EVENT_DB", default_value = "")]
     pub event_db: String,
 
+    /// Enable / disable the periodic state-snapshot task. Enabled by
+    /// default — disable only when the operator wants a pure
+    /// event-replay recovery path (e.g. for forensic reproduction of
+    /// historical state).
+    #[arg(long, env = "DARKPOOL_SNAPSHOT_ENABLED", default_value = "true")]
+    pub snapshot_enabled: bool,
+
+    /// Directory (file backend) or empty (DB backend / memory) for the
+    /// snapshot store. Required when `--event-log` is in use and
+    /// snapshots are enabled. Ignored for the postgres backend, which
+    /// stores snapshots in the same DB as events.
+    #[arg(long, env = "DARKPOOL_SNAPSHOT_DIR", default_value = "")]
+    pub snapshot_dir: String,
+
+    /// Snapshot whenever this many events have accrued since the last
+    /// snapshot. Lower values shorten replay time at the cost of more
+    /// writes; defaults to 10k which keeps cold-start under a second
+    /// for the in-memory engine.
+    #[arg(long, env = "DARKPOOL_SNAPSHOT_EVERY_EVENTS", default_value = "10000")]
+    pub snapshot_every_events: u64,
+
+    /// Force a snapshot if this long has elapsed even when the
+    /// event-count threshold has not been crossed.
+    #[arg(long, env = "DARKPOOL_SNAPSHOT_INTERVAL", default_value = "300s", value_parser = parse_duration)]
+    pub snapshot_interval: Duration,
+
+    /// After a snapshot is written, compact event-log entries whose
+    /// seq is at least this far behind the new snapshot's seq. Keeping
+    /// a tail buys forensic visibility into the most recent activity
+    /// even after compaction.
+    #[arg(long, env = "DARKPOOL_SNAPSHOT_RETAIN_EVENTS", default_value = "1024")]
+    pub snapshot_retain_events: u64,
+
+    /// Number of snapshot envelopes to keep in the store. Older
+    /// snapshots are pruned via `SnapshotStore::delete_before`.
+    #[arg(long, env = "DARKPOOL_SNAPSHOT_RETAIN_COUNT", default_value = "3")]
+    pub snapshot_retain_count: usize,
+
     #[arg(long, env = "DARKPOOL_OPERATOR_KEY", default_value = "")]
     pub operator_key: String,
 
@@ -149,6 +187,10 @@ impl Config {
 
     pub fn event_log_path(&self) -> Option<&str> {
         opt(&self.event_log)
+    }
+
+    pub fn snapshot_dir_path(&self) -> Option<&str> {
+        opt(&self.snapshot_dir)
     }
 
     pub fn operator_key_path(&self) -> Option<&str> {

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -17,8 +17,11 @@ use dp_api::tls;
 use dp_crypto::{
     decrypter_from_uri, validate_key_id, EciesDecrypter, KeyEntry, KeyStatus, MultiKeyDecrypter,
 };
-use dp_engine::{Engine, PairConfig, PairStatus};
-use dp_event::{FileStore, MemStore, PgStore, Store};
+use dp_engine::{Engine, PairConfig, PairStatus, SnapshotConfig};
+use dp_event::{
+    FileSnapshotStore, FileStore, MemSnapshotStore, MemStore, PgSnapshotStore, PgStore,
+    SnapshotStore, Store,
+};
 use rust_decimal::Decimal;
 use serde::Deserialize;
 use std::str::FromStr;
@@ -64,7 +67,33 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         Arc::new(MemStore::new())
     };
 
+    // Snapshot backend selection mirrors the event-log backend. The
+    // postgres store keeps snapshots in the same database so a single
+    // backup-and-restore captures both; file mode writes envelopes to
+    // a dedicated directory; in-memory mode falls back to an in-memory
+    // snapshot store (useful for tests, no durability).
+    let snapshot_store: Option<Arc<dyn SnapshotStore>> = if !cfg.snapshot_enabled {
+        info!("snapshots disabled — recover() will always do full event replay");
+        None
+    } else if let Some(url) = cfg.event_db_url() {
+        info!(url = %sanitize_db_url(url), "snapshot store: postgres");
+        Some(Arc::new(PgSnapshotStore::connect(url).await?))
+    } else if let Some(dir) = cfg.snapshot_dir_path() {
+        info!(dir = %dir, "snapshot store: file");
+        Some(Arc::new(FileSnapshotStore::open(dir)?))
+    } else if cfg.event_log_path().is_some() {
+        warn!(
+            "DARKPOOL_EVENT_LOG is set but DARKPOOL_SNAPSHOT_DIR is empty — \
+             snapshots disabled. Set --snapshot-dir for periodic checkpoints."
+        );
+        None
+    } else {
+        info!("snapshot store: in-memory (not durable)");
+        Some(Arc::new(MemSnapshotStore::new()))
+    };
+
     let engine = Engine::new(store.clone(), cfg.auction_interval);
+    engine.set_snapshot_store(snapshot_store.clone());
 
     // Always construct a MultiKeyDecrypter and wire it to the engine
     // so admin-time rotation does not require restarting the process.
@@ -223,6 +252,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let engine_handle = tokio::spawn(async move {
         engine_tick.start(tick_cancel).await;
     });
+
+    // Spawn the periodic state snapshotter when a SnapshotStore is wired.
+    // The task owns its own `tokio::time::interval`; cancellation flows
+    // through the shared `CancellationToken` so shutdown is in lockstep
+    // with the auction tick and REST/gRPC servers.
+    // `snapshot_store` is None whenever `cfg.snapshot_enabled` is false
+    // (see the construction block above), so `is_some()` is the only
+    // check needed here.
+    let snapshot_handle = if snapshot_store.is_some() {
+        let snapshot_cfg = SnapshotConfig {
+            enabled: true,
+            every_events: cfg.snapshot_every_events,
+            interval: cfg.snapshot_interval,
+            retain_events: cfg.snapshot_retain_events,
+            retain_count: cfg.snapshot_retain_count,
+        };
+        let engine_snap = engine.clone();
+        let snap_cancel = cancel.clone();
+        Some(tokio::spawn(async move {
+            engine_snap.run_snapshotter(snapshot_cfg, snap_cancel).await;
+        }))
+    } else {
+        None
+    };
 
     let auth_core = AuthCore::new(cfg.api_keys());
     let operator_keys = cfg.operator_api_keys();
@@ -434,6 +487,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let _ = grpc_handle.await;
     let _ = rest_handle.await;
     let _ = gauge_handle.await;
+    if let Some(h) = snapshot_handle {
+        // Surface task panics — silently dropping the JoinError would
+        // hide a snapshotter crash from the operator.
+        if let Err(e) = h.await {
+            if e.is_panic() {
+                tracing::error!(error = ?e, "snapshotter task panicked");
+            } else {
+                tracing::warn!(error = ?e, "snapshotter task join error");
+            }
+        }
+    }
     #[cfg(unix)]
     let _ = reload_handle.await;
 

--- a/crates/dp-auction/Cargo.toml
+++ b/crates/dp-auction/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 dp-types = { path = "../dp-types" }
 uuid = { workspace = true }
 rust_decimal = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true }

--- a/crates/dp-auction/src/lib.rs
+++ b/crates/dp-auction/src/lib.rs
@@ -2,9 +2,10 @@ use std::collections::BTreeSet;
 
 use dp_types::{Fill, Order};
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuctionResult {
     pub auction_id: Uuid,
     pub pair: String,
@@ -13,7 +14,7 @@ pub struct AuctionResult {
     pub matches: Vec<Match>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Match {
     pub bid: Fill,
     pub ask: Fill,

--- a/crates/dp-book/Cargo.toml
+++ b/crates/dp-book/Cargo.toml
@@ -10,6 +10,7 @@ uuid = { workspace = true }
 rust_decimal = { workspace = true }
 chrono = { workspace = true }
 parking_lot = { workspace = true }
+serde = { workspace = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true }

--- a/crates/dp-book/src/book.rs
+++ b/crates/dp-book/src/book.rs
@@ -5,9 +5,10 @@ use dp_event::{Event, EventData, EventError, Store};
 use dp_types::{Fill, Order, Side};
 use parking_lot::RwLock;
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-#[derive(Default)]
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
 struct PerPairBook {
     bids: HashMap<Uuid, Order>,
     asks: HashMap<Uuid, Order>,
@@ -19,9 +20,21 @@ impl PerPairBook {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct Inner {
     books: HashMap<String, PerPairBook>,
     seq: u64,
+}
+
+/// Persistable snapshot of the order book — every per-pair sub-book plus
+/// the highest event-sequence number applied. The engine writes this
+/// inside its periodic snapshot envelope and restores it on boot before
+/// replaying events past `seq`. Public so the engine crate can wrap it
+/// in [`SerializableState`], but the fields themselves are
+/// implementation detail.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BookSnapshot {
+    inner: Inner,
 }
 
 pub struct OrderBook {
@@ -51,6 +64,31 @@ impl OrderBook {
             }
         }
         Ok(())
+    }
+
+    /// Clone the current book state into a serialisable snapshot. Holds
+    /// the read lock only for the clone — the snapshot is independent
+    /// of the live book after this returns.
+    pub fn to_snapshot(&self) -> BookSnapshot {
+        BookSnapshot {
+            inner: self.inner.read().clone(),
+        }
+    }
+
+    /// Replace the live book state with `snap`. Takes the write lock for
+    /// the swap; subsequent applies / inserts pick up the restored
+    /// state. Used by the engine's recover path immediately after
+    /// loading a snapshot, before replaying events past `applied_seq`.
+    pub fn restore_from(&self, snap: BookSnapshot) {
+        let mut inner = self.inner.write();
+        *inner = snap.inner;
+    }
+
+    /// Highest event sequence number applied to the book. Used by the
+    /// recover path to choose the starting seq for the post-snapshot
+    /// event replay.
+    pub fn applied_seq(&self) -> u64 {
+        self.inner.read().seq
     }
 
     pub fn apply(&self, event: &Event) {

--- a/crates/dp-book/src/book.rs
+++ b/crates/dp-book/src/book.rs
@@ -30,8 +30,8 @@ struct Inner {
 /// the highest event-sequence number applied. The engine writes this
 /// inside its periodic snapshot envelope and restores it on boot before
 /// replaying events past `seq`. Public so the engine crate can wrap it
-/// in [`SerializableState`], but the fields themselves are
-/// implementation detail.
+/// inside its serializable engine-state struct, but the fields themselves
+/// are implementation detail.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct BookSnapshot {
     inner: Inner,

--- a/crates/dp-book/src/book.rs
+++ b/crates/dp-book/src/book.rs
@@ -547,4 +547,33 @@ mod tests {
         assert!(ids.contains(&a.id));
         assert!(ids.contains(&b.id));
     }
+
+    #[test]
+    fn snapshot_round_trip_preserves_orders() {
+        let book = OrderBook::new();
+        let bid = make_order(Side::Buy, 100, 3);
+        let ask = make_order(Side::Sell, 100, 2);
+        let bid_id = bid.id;
+        let ask_id = ask.id;
+        book.insert_order(bid);
+        book.insert_order(ask);
+
+        let snap = book.to_snapshot();
+
+        let restored = OrderBook::new();
+        restored.restore_from(snap);
+
+        assert!(restored.has_order(bid_id));
+        assert!(restored.has_order(ask_id));
+        assert_eq!(restored.active_order_count(), 2);
+    }
+
+    #[test]
+    fn snapshot_empty_book_round_trips() {
+        let book = OrderBook::new();
+        let snap = book.to_snapshot();
+        let restored = OrderBook::new();
+        restored.restore_from(snap);
+        assert_eq!(restored.active_order_count(), 0);
+    }
 }

--- a/crates/dp-book/src/lib.rs
+++ b/crates/dp-book/src/lib.rs
@@ -1,3 +1,3 @@
 mod book;
 
-pub use book::OrderBook;
+pub use book::{BookSnapshot, OrderBook};

--- a/crates/dp-engine/Cargo.toml
+++ b/crates/dp-engine/Cargo.toml
@@ -28,6 +28,7 @@ metrics = { workspace = true }
 futures-util = "0.3"
 sha2 = { workspace = true }
 hex = { workspace = true }
+bincode = { workspace = true }
 rand = "0.8"
 zeroize = { version = "1", features = ["derive"] }
 ark-ff = { workspace = true, features = ["std"] }
@@ -39,7 +40,6 @@ tempfile = "3"
 ecies = { workspace = true }
 k256 = "0.13"
 rand = "0.8"
-bincode = { workspace = true }
 alloy-provider = { workspace = true }
 alloy-rpc-types = { workspace = true }
 alloy-sol-types = { workspace = true }

--- a/crates/dp-engine/Cargo.toml
+++ b/crates/dp-engine/Cargo.toml
@@ -45,3 +45,9 @@ alloy-rpc-types = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-transport = { workspace = true }
 tracing-subscriber = { workspace = true }
+criterion = { version = "0.5", features = ["html_reports"] }
+proptest = "1"
+
+[[bench]]
+name = "recover"
+harness = false

--- a/crates/dp-engine/benches/recover.rs
+++ b/crates/dp-engine/benches/recover.rs
@@ -1,0 +1,191 @@
+//! Cold-start `recover()` benchmark — measures replay time with and
+//! without a snapshot, then compares.
+//!
+//! Run a single configuration:
+//!
+//! ```ignore
+//! cargo bench -p dp-engine -- recover
+//! ```
+//!
+//! The default workload is 1 000 synthetic `OrderPlaced` events. The
+//! `place_encrypted_order` setup path Poseidon-hashes every order so a
+//! 100k-event run is measured in cold minutes wall-clock — issue #25
+//! acceptance criteria call out the 100k figure, set `BENCH_EVENTS` to
+//! reproduce it:
+//!
+//! ```ignore
+//! BENCH_EVENTS=100000 cargo bench -p dp-engine -- recover
+//! ```
+//!
+//! Bench setup dominates wall time at that scale; the recover() arms
+//! themselves remain the meaningful comparison.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use alloy_primitives::Address;
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use dp_crypto::{CryptoError, DecryptedOrder, Decrypter};
+use dp_engine::{Engine, SnapshotConfig};
+use dp_event::{Event, MemSnapshotStore, MemStore, SnapshotStore, Store};
+use dp_types::Side;
+use rust_decimal::Decimal;
+
+const DEFAULT_EVENTS: usize = 1_000;
+
+fn bench_events() -> usize {
+    std::env::var("BENCH_EVENTS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(DEFAULT_EVENTS)
+}
+
+struct JsonDecrypter;
+
+impl Decrypter for JsonDecrypter {
+    fn decrypt<'a>(
+        &'a self,
+        ciphertext: &'a [u8],
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<DecryptedOrder, CryptoError>> + Send + 'a>,
+    > {
+        Box::pin(async move { serde_json::from_slice(ciphertext).map_err(CryptoError::from) })
+    }
+}
+
+fn build_engine(store: Arc<dyn Store>) -> Engine {
+    let engine = Engine::new(store, Duration::from_secs(60));
+    engine.set_decrypter(Arc::new(JsonDecrypter));
+    engine.register_pair_without_event(
+        "BTC-USD".into(),
+        dp_engine::PairConfig::new(Address::repeat_byte(1), Address::repeat_byte(2)),
+    );
+    engine
+}
+
+async fn populate_store(engine: &Engine, n: usize) {
+    for i in 0..n {
+        let order = DecryptedOrder {
+            trader: Address::ZERO,
+            pair: "BTC-USD".into(),
+            side: if i % 2 == 0 { Side::Buy } else { Side::Sell },
+            price: Decimal::new(100 + (i as i64 % 7), 0),
+            size: Decimal::new(1, 0),
+            commitment_key: format!("ck-{i}"),
+            ttl: 60_000_000_000,
+        };
+        let ct = serde_json::to_vec(&order).unwrap();
+        // Engine recomputes the commitment internally; supplying an
+        // empty placeholder here is allowed by `place_encrypted_order`.
+        engine
+            .place_encrypted_order(vec![0u8; 32], vec![], ct)
+            .await
+            .expect("place");
+    }
+}
+
+/// Clone every event out of a MemStore. Used so a single populated
+/// store can be re-seeded into a fresh MemStore per iteration without
+/// re-running the slower `populate_store` path each time.
+fn dump_events(store: &dyn Store) -> Vec<Event> {
+    let mut out = Vec::new();
+    let mut after = 0u64;
+    loop {
+        let events = store.read_from(after, 4096).expect("read");
+        if events.is_empty() {
+            break;
+        }
+        after = events.last().unwrap().seq;
+        out.extend(events);
+    }
+    out
+}
+
+fn seed_store_from(events: &[Event]) -> Arc<MemStore> {
+    let store = Arc::new(MemStore::new());
+    let mut owned: Vec<Event> = events.to_vec();
+    store.append(&mut owned).expect("seed");
+    store
+}
+
+fn bench_recover(c: &mut Criterion) {
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // One-time setup: build a canonical event stream + a snapshot
+    // envelope that recovery can re-use across every iteration.
+    let events_n = bench_events();
+    let (canonical_events, snapshot_envelope, snapshot_seq) = rt.block_on(async {
+        let seed_store: Arc<dyn Store> = Arc::new(MemStore::new());
+        let engine = build_engine(seed_store.clone());
+        populate_store(&engine, events_n).await;
+        let events = dump_events(seed_store.as_ref());
+
+        // Capture a snapshot from this populated engine, covering the
+        // whole event set. The captured envelope is what each
+        // `from_snapshot` iteration will plant into a fresh MemSnapshot.
+        let snap_store = Arc::new(MemSnapshotStore::new());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+        let snapshot_seq = engine.store_last_seq();
+        dp_engine::take_snapshot_for_bench(
+            &engine,
+            snap_store.as_ref(),
+            &SnapshotConfig::default(),
+            snapshot_seq,
+        )
+        .expect("snapshot");
+        let (seq, envelope) = snap_store
+            .read_latest()
+            .expect("read snap")
+            .expect("snapshot present");
+        assert_eq!(seq, snapshot_seq);
+        (events, envelope, snapshot_seq)
+    });
+
+    let mut group = c.benchmark_group("recover");
+    group.sample_size(10);
+
+    group.bench_function("full_replay", |b| {
+        b.iter_batched(
+            || seed_store_from(&canonical_events),
+            |store| {
+                rt.block_on(async move {
+                    let engine = build_engine(store);
+                    engine.recover().await.unwrap();
+                });
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("from_snapshot", |b| {
+        b.iter_batched(
+            || {
+                let store = seed_store_from(&canonical_events);
+                let snap_store = Arc::new(MemSnapshotStore::new());
+                <MemSnapshotStore as SnapshotStore>::write(
+                    snap_store.as_ref(),
+                    snapshot_seq,
+                    &snapshot_envelope,
+                )
+                .unwrap();
+                (store, snap_store)
+            },
+            |(store, snap_store)| {
+                rt.block_on(async move {
+                    let engine = build_engine(store);
+                    engine.set_snapshot_store(Some(snap_store));
+                    engine.recover().await.unwrap();
+                });
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_recover);
+criterion_main!(benches);

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use chrono::Utc;
 use dp_aggregator::{NoopAggregator, ProofAggregator};
 use dp_crypto::{Decrypter, NoopDecrypter};
-use dp_event::{Event, EventData, Store};
+use dp_event::{Event, EventData, EventError, SnapshotStore, Store};
 use dp_settlement::{NoopSubmitter, Submitter};
 use dp_types::metrics::M_ORDERS_PLACED;
 use dp_types::{DarkPoolError, EventType, Order, Side};
@@ -89,6 +89,10 @@ pub(crate) struct Inner {
     pub(crate) auction_interval: Duration,
     pub(crate) salt_nonce: [u8; 32],
     pub(crate) batch_size: usize,
+    /// Persistent home for periodic state snapshots. `None` disables
+    /// the snapshot pipeline — recover then always falls back to full
+    /// event replay. Set at boot via [`Engine::set_snapshot_store`].
+    pub(crate) snapshot_store: RwLock<Option<Arc<dyn SnapshotStore>>>,
 }
 
 #[derive(Clone)]
@@ -119,6 +123,7 @@ impl Engine {
                 auction_interval: interval,
                 salt_nonce,
                 batch_size: 8,
+                snapshot_store: RwLock::new(None),
             }),
         };
         // Suppress the boot warning under `cfg(test)` — every engine test
@@ -146,6 +151,84 @@ impl Engine {
 
     pub fn set_submitter(&self, s: Arc<dyn Submitter>) {
         *self.inner.submitter.write() = s;
+    }
+
+    /// Wire a persistent [`SnapshotStore`]. Subsequent calls to
+    /// [`Engine::recover`] consult it for a starting point before
+    /// touching the event log, and the periodic snapshotter task spawned
+    /// from `main` writes new envelopes into it. Calling this with
+    /// `None` disables snapshot-based recovery without resetting the
+    /// in-memory state.
+    ///
+    /// Note: a `None` set mid-flight does NOT stop a snapshotter task
+    /// already running — `run_snapshotter` clones the `Arc` at startup,
+    /// so the running task keeps the previous store alive until the
+    /// `CancellationToken` fires. Production callers wire the store
+    /// once at boot, so this is purely a footgun for tests / integration
+    /// fixtures that want to swap stores live.
+    pub fn set_snapshot_store(&self, store: Option<Arc<dyn SnapshotStore>>) {
+        *self.inner.snapshot_store.write() = store;
+    }
+
+    /// Clone of the active [`SnapshotStore`], if one is installed. Used
+    /// by the snapshotter task at boot and the recover path when
+    /// loading the latest envelope.
+    pub fn snapshot_store_clone(&self) -> Option<Arc<dyn SnapshotStore>> {
+        self.inner.snapshot_store.read().clone()
+    }
+
+    /// Highest event sequence number observed by the underlying event
+    /// store. Used by the snapshotter to decide when to checkpoint.
+    pub fn store_last_seq(&self) -> u64 {
+        self.inner.store.last_seq()
+    }
+
+    /// Capture the persistable state under the engine's state mutex.
+    /// Returns the cloned subset plus the seq it was captured at
+    /// (the lesser of `seq_hint` and `store.last_seq()` to guarantee
+    /// the snapshot never claims to cover an unwritten event).
+    pub(crate) fn capture_snapshot_state(
+        &self,
+        seq_hint: u64,
+    ) -> (crate::state::SerializableState, u64) {
+        let state = self.inner.state.lock();
+        let snap = state.to_serializable();
+        // last_seq under the lock — pairing the clone with a watermark
+        // outside the lock would race against an `append` landing just
+        // after the clone but before we read last_seq.
+        let store_seq = self.inner.store.last_seq();
+        let seq = seq_hint.min(store_seq);
+        (snap, seq)
+    }
+
+    /// Forward a compaction request to the active event store. Pulled
+    /// onto `Engine` so the snapshotter does not need a borrow into
+    /// `Inner`.
+    pub fn compact_events_before(&self, before_seq: u64) -> Result<(), EventError> {
+        self.inner.store.compact_before(before_seq)
+    }
+
+    /// Replace projection-derived state with `snap`. Locks
+    /// `state.book` (write) under the engine mutex; concurrent reads
+    /// will block briefly. Caller is responsible for ensuring no other
+    /// task is mid-write to the same state (the recover path runs
+    /// before the auction tick / API are spawned, which satisfies this
+    /// today).
+    pub(crate) fn apply_snapshot_state(&self, snap: crate::state::SerializableState) {
+        let mut state = self.inner.state.lock();
+        state.restore_from_serializable(snap);
+    }
+
+    /// Spawn the periodic snapshotter as a background task. Lives in
+    /// `main` alongside the auction tick; cancellation comes from the
+    /// shared [`tokio_util::sync::CancellationToken`]. A no-op when
+    /// `config.enabled` is `false` or no [`SnapshotStore`] is wired.
+    pub async fn run_snapshotter(
+        &self,
+        config: crate::snapshot::SnapshotConfig,
+        cancel: tokio_util::sync::CancellationToken,
+    ) {
+        crate::snapshot::run_snapshotter(self.clone(), config, cancel).await;
     }
 
     pub fn set_submit_timeout(&self, d: Duration) {

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -184,12 +184,15 @@ impl Engine {
     }
 
     /// Capture the persistable state under the engine's state mutex.
-    /// Returns the cloned subset plus the seq it was captured at
-    /// (the lesser of `seq_hint` and `store.last_seq()` to guarantee
-    /// the snapshot never claims to cover an unwritten event).
+    /// Returns the cloned subset plus the seq watermark read from the
+    /// store under the same lock. Reading `store.last_seq()` under the
+    /// state lock ensures the watermark cannot undercount the snapshot:
+    /// any append that races with the capture either lands before the
+    /// lock (and is included in `snap`) or after (and is excluded), so
+    /// `store_seq` always matches exactly what was serialised.
     pub(crate) fn capture_snapshot_state(
         &self,
-        seq_hint: u64,
+        _seq_hint: u64,
     ) -> (crate::state::SerializableState, u64) {
         let state = self.inner.state.lock();
         let snap = state.to_serializable();
@@ -197,8 +200,7 @@ impl Engine {
         // outside the lock would race against an `append` landing just
         // after the clone but before we read last_seq.
         let store_seq = self.inner.store.last_seq();
-        let seq = seq_hint.min(store_seq);
-        (snap, seq)
+        (snap, store_seq)
     }
 
     /// Forward a compaction request to the active event store. Pulled

--- a/crates/dp-engine/src/error.rs
+++ b/crates/dp-engine/src/error.rs
@@ -59,4 +59,11 @@ pub enum EngineError {
          batch is poisoned and will not be retried automatically. Manual replay required."
     )]
     RecoveredBatchPublicInputsMissing { batch_id: uuid::Uuid },
+
+    #[error(
+        "recover: every retained snapshot failed to decode and the event log cannot reproduce history from seq 1 \
+         (compacted or empty); booting would silently rebuild contradictory state. \
+         Restore a known-good snapshot or wipe state."
+    )]
+    SnapshotsCorruptAndLogTruncated,
 }

--- a/crates/dp-engine/src/lib.rs
+++ b/crates/dp-engine/src/lib.rs
@@ -2,6 +2,7 @@ mod batch;
 mod engine;
 mod error;
 mod recover;
+mod snapshot;
 mod state;
 mod subscribe;
 mod tick;
@@ -14,6 +15,7 @@ mod tests;
 
 pub use engine::Engine;
 pub use error::EngineError;
+pub use snapshot::{SnapshotConfig, SnapshotError};
 pub use state::{PairConfig, PairStatus, PendingBatch};
 pub use subscribe::AuctionNotification;
 

--- a/crates/dp-engine/src/lib.rs
+++ b/crates/dp-engine/src/lib.rs
@@ -19,6 +19,21 @@ pub use snapshot::{SnapshotConfig, SnapshotError};
 pub use state::{PairConfig, PairStatus, PendingBatch};
 pub use subscribe::AuctionNotification;
 
+/// Drive a single snapshot capture against an external [`SnapshotStore`].
+/// Exposed for the recovery benchmark in `benches/recover.rs` so it
+/// can plant a snapshot without spinning up the periodic task. Not
+/// part of the supported runtime API — production callers go through
+/// [`Engine::run_snapshotter`].
+#[doc(hidden)]
+pub fn take_snapshot_for_bench(
+    engine: &Engine,
+    snapshot_store: &dyn dp_event::SnapshotStore,
+    config: &SnapshotConfig,
+    seq_hint: u64,
+) -> Result<u64, SnapshotError> {
+    snapshot::take_snapshot(engine, snapshot_store, config, seq_hint)
+}
+
 pub const DEFAULT_AUCTION_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 pub const DEFAULT_ORDER_TTL: std::time::Duration = std::time::Duration::from_secs(600);
 pub const DEFAULT_SUBMIT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);

--- a/crates/dp-engine/src/recover.rs
+++ b/crates/dp-engine/src/recover.rs
@@ -4,14 +4,112 @@ use std::time::Duration;
 use alloy_primitives::U256;
 use chrono::{DateTime, Utc};
 use dp_crypto::Decrypter;
-use dp_event::{Event, EventData};
+use dp_event::{Event, EventData, EventError, SnapshotStore, Store};
 use dp_types::{EventType, Order, Pair};
 use rust_decimal::Decimal;
 use uuid::Uuid;
 
 use crate::engine::Engine;
 use crate::error::EngineError;
+use crate::snapshot::decode_envelope;
 use crate::state::{try_build_settlement_row, AuctionExecutedRecord, PairConfig, PendingBatch};
+
+/// Result of the snapshot recovery probe. Drives the recover() control
+/// flow without leaking the multi-arm match through the caller.
+enum SnapshotRecoveryOutcome {
+    /// One of the envelopes decoded cleanly; `after_seq` is set to its
+    /// covered sequence.
+    Restored(u64),
+    /// `list_seqs` is empty — there is no snapshot to try.
+    NoneAvailable,
+    /// Every envelope on the store failed to decode. Caller must check
+    /// whether the event log is still complete before falling back to a
+    /// full replay.
+    AllCorrupt,
+    /// The store itself errored (I/O, db). Caller logs and falls back
+    /// to a full replay, mirroring pre-hardening behaviour.
+    StoreError(EventError),
+}
+
+/// Probe the snapshot store for the most-recent decodable envelope.
+/// Walks `list_seqs` descending so a single corrupt latest does not
+/// strand recovery when older envelopes are retained.
+fn try_restore_from_snapshots(
+    engine: &Engine,
+    snap_store: &dyn SnapshotStore,
+    placed_orders: &mut HashMap<Uuid, Order>,
+) -> SnapshotRecoveryOutcome {
+    let seqs = match snap_store.list_seqs() {
+        Ok(s) => s,
+        Err(e) => return SnapshotRecoveryOutcome::StoreError(e),
+    };
+    if seqs.is_empty() {
+        return SnapshotRecoveryOutcome::NoneAvailable;
+    }
+    let mut attempts = 0usize;
+    for &seq in seqs.iter().rev() {
+        let bytes = match snap_store.read_at(seq) {
+            Ok(Some(b)) => b,
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::warn!(error = ?e, seq, "snapshot read_at failed; trying older envelope");
+                continue;
+            }
+        };
+        attempts += 1;
+        match decode_envelope(&bytes) {
+            Ok((decoded_seq, snap_state)) => {
+                engine.apply_snapshot_state(snap_state);
+                for o in engine.inner.state.lock().book.iter_all() {
+                    placed_orders.insert(o.id, o);
+                }
+                if attempts == 1 {
+                    tracing::info!(seq = decoded_seq, "recovered from snapshot");
+                } else {
+                    tracing::warn!(
+                        seq = decoded_seq,
+                        attempts,
+                        "recovered from older snapshot — newer envelopes were corrupt"
+                    );
+                }
+                if decoded_seq != seq {
+                    tracing::warn!(
+                        envelope_seq = decoded_seq,
+                        store_key = seq,
+                        "snapshot envelope seq disagrees with store key — \
+                         trusting envelope (checksum-covered)"
+                    );
+                }
+                return SnapshotRecoveryOutcome::Restored(decoded_seq);
+            }
+            Err(e) => {
+                tracing::warn!(error = ?e, seq, "snapshot envelope corrupt; trying older");
+                // `decode_envelope` is pure and runs before
+                // `apply_snapshot_state`, so the engine's state was never
+                // touched on this iteration. No reset needed — `placed_orders`
+                // is also untouched on this branch for the same reason.
+            }
+        }
+    }
+    SnapshotRecoveryOutcome::AllCorrupt
+}
+
+/// True iff the event log can produce a complete from-scratch replay —
+/// i.e. its first event has seq 1. False if the log was compacted
+/// (first seq > 1) OR is entirely empty while snapshots claim history
+/// existed. Both cases are unsafe to silently boot from when every
+/// snapshot envelope is corrupt: the empty-log case would yield an
+/// empty engine that contradicts the (now-unreadable) snapshot
+/// history, and the compacted case would rebuild a partial book.
+///
+/// Couples to [`dp_event::assign_seq_and_timestamp`], which increments
+/// from 0 → 1 on the first write. If that ever changes, this check
+/// must move in lockstep — searching for `e.seq == 1` finds both
+/// sites.
+fn event_log_covers_seq_one(store: &dyn Store) -> Result<bool, EngineError> {
+    let first = store.read_from(0, 1)?;
+    Ok(first.first().is_some_and(|e| e.seq == 1))
+}
 
 const RECOVER_BATCH: usize = 1024;
 
@@ -57,6 +155,52 @@ impl Engine {
         let mut matches_by_auction: HashMap<Uuid, Vec<OrphanMatch>> = HashMap::new();
         let mut auction_timestamps: HashMap<Uuid, DateTime<Utc>> = HashMap::new();
         let mut placed_orders: HashMap<Uuid, Order> = HashMap::new();
+
+        // Snapshot fast-path. When a snapshot store is installed and an
+        // envelope decodes cleanly, restore the projection-derived state
+        // and skip the event-replay loop ahead to its sequence.
+        //
+        // Corruption is handled in layers:
+        //   1. `read_latest` decode failure → walk `list_seqs` descending
+        //      and try each older envelope. The periodic snapshotter
+        //      keeps `retain_count` (default 3) envelopes precisely so a
+        //      bad latest does not strand recovery — without this walk
+        //      the older envelopes were dead weight.
+        //   2. If every snapshot fails AND the event log cannot
+        //      reproduce history from seq 1 (compacted past it, or
+        //      entirely empty while snapshots existed), refuse to boot.
+        //      Either case would silently boot state that contradicts
+        //      the (now-unreadable) snapshot history — exactly the
+        //      "wrong state on restart" failure mode the snapshotter
+        //      is supposed to prevent.
+        //   3. Only when the event log still starts at seq 1 do we fall
+        //      back to a full replay.
+        if let Some(snap_store) = self.inner.snapshot_store.read().clone() {
+            let restored =
+                try_restore_from_snapshots(self, snap_store.as_ref(), &mut placed_orders);
+            match restored {
+                SnapshotRecoveryOutcome::Restored(seq) => after_seq = seq,
+                SnapshotRecoveryOutcome::NoneAvailable => {
+                    tracing::info!("no snapshot present, full replay");
+                }
+                SnapshotRecoveryOutcome::AllCorrupt => {
+                    // Every envelope on the store failed to decode.
+                    // Full replay is only safe when the event log can
+                    // genuinely reproduce history from seq 1 onward —
+                    // otherwise we'd silently boot wrong state.
+                    if !event_log_covers_seq_one(store.as_ref())? {
+                        return Err(EngineError::SnapshotsCorruptAndLogTruncated);
+                    }
+                    tracing::warn!(
+                        "every snapshot envelope corrupt; event log intact from seq 1 — full replay"
+                    );
+                    self.inner.state.lock().reset_projection();
+                }
+                SnapshotRecoveryOutcome::StoreError(e) => {
+                    tracing::warn!(error = ?e, "snapshot store read failed, full replay");
+                }
+            }
+        }
 
         loop {
             let events = store.read_from(after_seq, RECOVER_BATCH)?;
@@ -307,6 +451,19 @@ impl Engine {
                     .collect();
                 let mut state = self.inner.state.lock();
                 state.book.apply(ev);
+
+                // Snapshot-aware insert: if recovery loaded a snapshot
+                // that already carried this batch, do not overwrite it
+                // with a freshly-rebuilt one. The snapshot's record has
+                // the original `matches` / `settlement_matches` /
+                // `public_inputs`; rebuilding from a post-snapshot
+                // replay can only produce empty matches (the
+                // corresponding OrderMatched events were
+                // pre-snapshot), which would defeat the purpose of
+                // keeping the snapshot in the first place.
+                if state.pending_batches.contains_key(batch_id) {
+                    return Ok(());
+                }
 
                 let settlement_matches =
                     build_recovery_settlement_matches(&matches, placed_orders, &state.pair_tokens);

--- a/crates/dp-engine/src/recover.rs
+++ b/crates/dp-engine/src/recover.rs
@@ -111,6 +111,20 @@ fn event_log_covers_seq_one(store: &dyn Store) -> Result<bool, EngineError> {
     Ok(first.first().is_some_and(|e| e.seq == 1))
 }
 
+/// True iff the event log has no gap immediately after `after_seq`.
+/// After a successful snapshot restore, tail events must form a
+/// continuous run: the first readable event must be `after_seq + 1`
+/// or the log must be empty past that point (nothing to replay).
+/// A gap means compaction removed events that are not covered by the
+/// snapshot, which would produce a partial projection on boot.
+fn event_log_continuous_after(store: &dyn Store, after_seq: u64) -> Result<bool, EngineError> {
+    let next = store.read_from(after_seq, 1)?;
+    Ok(match next.first() {
+        Some(e) => e.seq == after_seq + 1,
+        None => true,
+    })
+}
+
 const RECOVER_BATCH: usize = 1024;
 
 #[derive(Clone)]
@@ -179,7 +193,12 @@ impl Engine {
             let restored =
                 try_restore_from_snapshots(self, snap_store.as_ref(), &mut placed_orders);
             match restored {
-                SnapshotRecoveryOutcome::Restored(seq) => after_seq = seq,
+                SnapshotRecoveryOutcome::Restored(seq) => {
+                    if !event_log_continuous_after(store.as_ref(), seq)? {
+                        return Err(EngineError::SnapshotsCorruptAndLogTruncated);
+                    }
+                    after_seq = seq;
+                }
                 SnapshotRecoveryOutcome::NoneAvailable => {
                     tracing::info!("no snapshot present, full replay");
                 }
@@ -197,7 +216,11 @@ impl Engine {
                     self.inner.state.lock().reset_projection();
                 }
                 SnapshotRecoveryOutcome::StoreError(e) => {
-                    tracing::warn!(error = ?e, "snapshot store read failed, full replay");
+                    tracing::warn!(error = ?e, "snapshot store read failed; falling back to full replay");
+                    if !event_log_covers_seq_one(store.as_ref())? {
+                        return Err(EngineError::SnapshotsCorruptAndLogTruncated);
+                    }
+                    self.inner.state.lock().reset_projection();
                 }
             }
         }

--- a/crates/dp-engine/src/recover.rs
+++ b/crates/dp-engine/src/recover.rs
@@ -31,6 +31,41 @@ enum SnapshotRecoveryOutcome {
     StoreError(EventError),
 }
 
+/// Apply a decoded snapshot and populate `placed_orders` from the restored
+/// book. Logs whether this was a first-attempt or fallback recovery, and
+/// warns when the envelope's self-reported seq disagrees with the store key
+/// (the envelope value is authoritative because it is checksum-covered).
+fn apply_and_log_snapshot(
+    engine: &Engine,
+    placed_orders: &mut HashMap<Uuid, Order>,
+    snap_state: crate::state::SerializableState,
+    decoded_seq: u64,
+    store_key: u64,
+    attempts: usize,
+) {
+    engine.apply_snapshot_state(snap_state);
+    for o in engine.inner.state.lock().book.iter_all() {
+        placed_orders.insert(o.id, o);
+    }
+    if attempts == 1 {
+        tracing::info!(seq = decoded_seq, "recovered from snapshot");
+    } else {
+        tracing::warn!(
+            seq = decoded_seq,
+            attempts,
+            "recovered from older snapshot — newer envelopes were corrupt"
+        );
+    }
+    if decoded_seq != store_key {
+        tracing::warn!(
+            envelope_seq = decoded_seq,
+            store_key,
+            "snapshot envelope seq disagrees with store key — \
+             trusting envelope (checksum-covered)"
+        );
+    }
+}
+
 /// Probe the snapshot store for the most-recent decodable envelope.
 /// Walks `list_seqs` descending so a single corrupt latest does not
 /// strand recovery when older envelopes are retained.
@@ -59,27 +94,14 @@ fn try_restore_from_snapshots(
         attempts += 1;
         match decode_envelope(&bytes) {
             Ok((decoded_seq, snap_state)) => {
-                engine.apply_snapshot_state(snap_state);
-                for o in engine.inner.state.lock().book.iter_all() {
-                    placed_orders.insert(o.id, o);
-                }
-                if attempts == 1 {
-                    tracing::info!(seq = decoded_seq, "recovered from snapshot");
-                } else {
-                    tracing::warn!(
-                        seq = decoded_seq,
-                        attempts,
-                        "recovered from older snapshot — newer envelopes were corrupt"
-                    );
-                }
-                if decoded_seq != seq {
-                    tracing::warn!(
-                        envelope_seq = decoded_seq,
-                        store_key = seq,
-                        "snapshot envelope seq disagrees with store key — \
-                         trusting envelope (checksum-covered)"
-                    );
-                }
+                apply_and_log_snapshot(
+                    engine,
+                    placed_orders,
+                    snap_state,
+                    decoded_seq,
+                    seq,
+                    attempts,
+                );
                 return SnapshotRecoveryOutcome::Restored(decoded_seq);
             }
             Err(e) => {

--- a/crates/dp-engine/src/recover.rs
+++ b/crates/dp-engine/src/recover.rs
@@ -675,7 +675,8 @@ fn finalize_public_inputs<T>(
 mod tests {
     use alloy_primitives::Address;
     use chrono::Utc;
-    use dp_types::{Fill, Order, Side};
+    use dp_event::{EventData, MemStore};
+    use dp_types::{EventType, Fill, Order, Side};
     use rust_decimal::Decimal;
 
     use super::*;
@@ -887,5 +888,53 @@ mod tests {
         }];
         let out = build_recovery_settlement_matches(&matches, &placed, &pair_tokens);
         assert_eq!(out.len(), 1, "snapshot must survive book removal");
+    }
+
+    fn placed_event(seq: u64) -> dp_event::Event {
+        dp_event::Event {
+            seq,
+            event_type: EventType::OrderPlaced,
+            timestamp: Utc::now(),
+            data: EventData::OrderPlaced {
+                order_id: Uuid::new_v4(),
+                commitment: vec![],
+                proof: vec![],
+                ciphertext: vec![],
+                salt_nonce: vec![0u8; 32],
+            },
+        }
+    }
+
+    #[test]
+    fn continuous_after_empty_tail_is_ok() {
+        let store = MemStore::new();
+        // No events at all — nothing to replay, continuity holds.
+        assert!(event_log_continuous_after(&store, 0).unwrap());
+        assert!(event_log_continuous_after(&store, 99).unwrap());
+    }
+
+    #[test]
+    fn continuous_after_next_is_exactly_seq_plus_one() {
+        let store = MemStore::new();
+        let mut evs = vec![placed_event(0), placed_event(0), placed_event(0)];
+        store.append(&mut evs).unwrap(); // gets seq 1, 2, 3
+        // after_seq=2 → first event after is seq 3 = 2+1 → continuous
+        assert!(event_log_continuous_after(&store, 2).unwrap());
+    }
+
+    #[test]
+    fn continuous_after_detects_gap() {
+        let store = MemStore::new();
+        let mut evs = vec![
+            placed_event(0),
+            placed_event(0),
+            placed_event(0),
+            placed_event(0),
+        ];
+        store.append(&mut evs).unwrap(); // seq 1..4
+        // Compact away seq 1 and 2 (remove seq < 3).
+        store.compact_before(3).unwrap();
+        // after_seq=1 → first retained event is seq 3, not 2 → gap
+        assert!(!event_log_continuous_after(&store, 1).unwrap());
     }
 }

--- a/crates/dp-engine/src/recover.rs
+++ b/crates/dp-engine/src/recover.rs
@@ -918,7 +918,7 @@ mod tests {
         let store = MemStore::new();
         let mut evs = vec![placed_event(0), placed_event(0), placed_event(0)];
         store.append(&mut evs).unwrap(); // gets seq 1, 2, 3
-        // after_seq=2 → first event after is seq 3 = 2+1 → continuous
+                                         // after_seq=2 → first event after is seq 3 = 2+1 → continuous
         assert!(event_log_continuous_after(&store, 2).unwrap());
     }
 
@@ -932,7 +932,7 @@ mod tests {
             placed_event(0),
         ];
         store.append(&mut evs).unwrap(); // seq 1..4
-        // Compact away seq 1 and 2 (remove seq < 3).
+                                         // Compact away seq 1 and 2 (remove seq < 3).
         store.compact_before(3).unwrap();
         // after_seq=1 → first retained event is seq 3, not 2 → gap
         assert!(!event_log_continuous_after(&store, 1).unwrap());

--- a/crates/dp-engine/src/snapshot.rs
+++ b/crates/dp-engine/src/snapshot.rs
@@ -257,6 +257,7 @@ mod tests {
     use std::time::Duration;
 
     use dp_event::{MemSnapshotStore, MemStore};
+    use tokio_util::sync::CancellationToken;
 
     use super::*;
     use crate::state::SerializableState;
@@ -369,5 +370,78 @@ mod tests {
         // Result: [2, 3, 4].
         take_snapshot(&engine, &snap_store, &cfg, 0).unwrap();
         assert_eq!(snap_store.list_seqs().unwrap(), vec![2, 3, 4]);
+    }
+
+    #[tokio::test]
+    async fn run_snapshotter_writes_snapshot_on_event_trigger() {
+        let engine = bare_engine();
+        let snap_store = Arc::new(MemSnapshotStore::new());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+
+        let cfg = SnapshotConfig {
+            enabled: true,
+            // Fire on every event (0 means always ≥ threshold).
+            every_events: 0,
+            // Long interval so only event_trigger drives the first fire.
+            interval: Duration::from_secs(300),
+            retain_events: 0,
+            retain_count: 10,
+        };
+
+        let cancel = CancellationToken::new();
+        let cancel2 = cancel.clone();
+        let engine_clone = engine.clone();
+
+        let handle = tokio::spawn(async move {
+            run_snapshotter(engine_clone, cfg, cancel2).await;
+        });
+
+        // Allow up to 500 ms for at least one snapshot to land.
+        let deadline = tokio::time::Instant::now() + Duration::from_millis(500);
+        while snap_store.list_seqs().unwrap().is_empty() {
+            if tokio::time::Instant::now() >= deadline {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        cancel.cancel();
+        let _ = tokio::time::timeout(Duration::from_millis(200), handle).await;
+
+        assert!(
+            !snap_store.list_seqs().unwrap().is_empty(),
+            "run_snapshotter must write at least one snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_snapshotter_exits_immediately_when_disabled() {
+        let engine = bare_engine();
+        let cfg = SnapshotConfig {
+            enabled: false,
+            ..SnapshotConfig::default()
+        };
+        let cancel = CancellationToken::new();
+        // Should return promptly without hanging.
+        tokio::time::timeout(
+            Duration::from_millis(200),
+            run_snapshotter(engine, cfg, cancel),
+        )
+        .await
+        .expect("disabled snapshotter must return immediately");
+    }
+
+    #[tokio::test]
+    async fn run_snapshotter_exits_when_no_snapshot_store() {
+        let engine = bare_engine();
+        // No snapshot store set — task must exit cleanly.
+        let cfg = SnapshotConfig::default();
+        let cancel = CancellationToken::new();
+        tokio::time::timeout(
+            Duration::from_millis(200),
+            run_snapshotter(engine, cfg, cancel),
+        )
+        .await
+        .expect("snapshotter without store must return immediately");
     }
 }

--- a/crates/dp-engine/src/snapshot.rs
+++ b/crates/dp-engine/src/snapshot.rs
@@ -76,7 +76,7 @@ impl Default for SnapshotConfig {
 /// Encode a [`SerializableState`] + its watermark `seq` into the
 /// on-disk envelope. The blob carries its own SHA-256 so the recover
 /// path can drop corrupted snapshots and fall back to event replay.
-pub fn encode_envelope(state: &SerializableState, seq: u64) -> Result<Vec<u8>, SnapshotError> {
+pub(crate) fn encode_envelope(state: &SerializableState, seq: u64) -> Result<Vec<u8>, SnapshotError> {
     let blob = bincode::serialize(state)?;
     let blob_len = u32::try_from(blob.len()).map_err(|_| SnapshotError::LengthMismatch {
         declared: u32::MAX as usize,
@@ -96,7 +96,7 @@ pub fn encode_envelope(state: &SerializableState, seq: u64) -> Result<Vec<u8>, S
 
 /// Decode an envelope produced by [`encode_envelope`], verifying the
 /// magic, version, declared length, and SHA-256 checksum.
-pub fn decode_envelope(bytes: &[u8]) -> Result<(u64, SerializableState), SnapshotError> {
+pub(crate) fn decode_envelope(bytes: &[u8]) -> Result<(u64, SerializableState), SnapshotError> {
     if bytes.len() < HEADER_LEN {
         return Err(SnapshotError::Truncated { len: bytes.len() });
     }

--- a/crates/dp-engine/src/snapshot.rs
+++ b/crates/dp-engine/src/snapshot.rs
@@ -76,7 +76,10 @@ impl Default for SnapshotConfig {
 /// Encode a [`SerializableState`] + its watermark `seq` into the
 /// on-disk envelope. The blob carries its own SHA-256 so the recover
 /// path can drop corrupted snapshots and fall back to event replay.
-pub(crate) fn encode_envelope(state: &SerializableState, seq: u64) -> Result<Vec<u8>, SnapshotError> {
+pub(crate) fn encode_envelope(
+    state: &SerializableState,
+    seq: u64,
+) -> Result<Vec<u8>, SnapshotError> {
     let blob = bincode::serialize(state)?;
     let blob_len = u32::try_from(blob.len()).map_err(|_| SnapshotError::LengthMismatch {
         declared: u32::MAX as usize,

--- a/crates/dp-engine/src/snapshot.rs
+++ b/crates/dp-engine/src/snapshot.rs
@@ -187,7 +187,7 @@ pub(crate) async fn run_snapshotter(
                 let elapsed = last_snapshot_at.elapsed();
                 let event_trigger = now_seq.saturating_sub(last_snapshot_seq) >= config.every_events;
                 let time_trigger = elapsed >= config.interval;
-                if now_seq <= last_snapshot_seq {
+                if now_seq < last_snapshot_seq {
                     continue;
                 }
                 if !event_trigger && !time_trigger {

--- a/crates/dp-engine/src/snapshot.rs
+++ b/crates/dp-engine/src/snapshot.rs
@@ -1,0 +1,313 @@
+use std::time::{Duration, Instant};
+
+use dp_event::{EventError, SnapshotStore};
+use sha2::{Digest, Sha256};
+use tokio_util::sync::CancellationToken;
+use tracing::{info, warn};
+
+use crate::engine::Engine;
+use crate::state::SerializableState;
+
+/// Magic bytes that prefix every snapshot envelope. Bumping the suffix
+/// (e.g. `DPS2`) reserves space for a format break later — current
+/// readers reject any non-`DPS1` magic with [`SnapshotError::BadMagic`].
+const MAGIC: &[u8; 4] = b"DPS1";
+const ENVELOPE_VERSION: u32 = 1;
+const HEADER_LEN: usize = 4 /* magic */ + 4 /* version */ + 8 /* seq */ + 4 /* blob_len */ + 32 /* sha256 */;
+
+/// Errors raised while encoding / decoding a snapshot envelope. The
+/// recover path catches all of these and falls back to a full event
+/// replay — these are operational hiccups, not engine bugs.
+#[derive(Debug, thiserror::Error)]
+pub enum SnapshotError {
+    #[error("snapshot envelope too small: {len} bytes (need at least {HEADER_LEN})")]
+    Truncated { len: usize },
+    #[error("bad snapshot magic: expected DPS1")]
+    BadMagic,
+    #[error("unsupported snapshot envelope version: {0}")]
+    UnsupportedVersion(u32),
+    #[error("snapshot blob_len {declared} does not match payload {actual}")]
+    LengthMismatch { declared: usize, actual: usize },
+    #[error("snapshot checksum mismatch — payload corrupt or truncated")]
+    ChecksumMismatch,
+    #[error(transparent)]
+    Bincode(#[from] bincode::Error),
+    #[error(transparent)]
+    Store(#[from] EventError),
+}
+
+/// Operator-tunable knobs for the periodic snapshotter. The defaults
+/// favour reliability over disk savings: snapshots run on a 5-minute
+/// fallback even when event throughput is low, the event log keeps a
+/// 1024-event tail for forensic queries, and three snapshots are
+/// retained so a corrupt latest does not strand recovery.
+#[derive(Clone, Debug)]
+pub struct SnapshotConfig {
+    pub enabled: bool,
+    /// Snapshot whenever the event count since the last snapshot crosses
+    /// this many events, even if [`Self::interval`] has not elapsed.
+    pub every_events: u64,
+    /// Force a snapshot if this long has elapsed since the last one,
+    /// even if no events have accumulated. Useful for low-throughput
+    /// deploys where the event-delta trigger would never fire.
+    pub interval: Duration,
+    /// Compact event-log entries whose seq is at least this far behind
+    /// the snapshot we just wrote. Keeping a tail buys forensics: if a
+    /// snapshot turns out to be wrong, the operator can still replay
+    /// from raw events for the last `retain_events` worth of activity.
+    pub retain_events: u64,
+    /// Number of snapshot envelopes to keep on the store. Older
+    /// snapshots are pruned via [`SnapshotStore::delete_before`].
+    pub retain_count: usize,
+}
+
+impl Default for SnapshotConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            every_events: 10_000,
+            interval: Duration::from_secs(300),
+            retain_events: 1024,
+            retain_count: 3,
+        }
+    }
+}
+
+/// Encode a [`SerializableState`] + its watermark `seq` into the
+/// on-disk envelope. The blob carries its own SHA-256 so the recover
+/// path can drop corrupted snapshots and fall back to event replay.
+pub fn encode_envelope(state: &SerializableState, seq: u64) -> Result<Vec<u8>, SnapshotError> {
+    let blob = bincode::serialize(state)?;
+    let blob_len = u32::try_from(blob.len()).map_err(|_| SnapshotError::LengthMismatch {
+        declared: u32::MAX as usize,
+        actual: blob.len(),
+    })?;
+    let digest = Sha256::digest(&blob);
+
+    let mut out = Vec::with_capacity(HEADER_LEN + blob.len());
+    out.extend_from_slice(MAGIC);
+    out.extend_from_slice(&ENVELOPE_VERSION.to_be_bytes());
+    out.extend_from_slice(&seq.to_be_bytes());
+    out.extend_from_slice(&blob_len.to_be_bytes());
+    out.extend_from_slice(&digest);
+    out.extend_from_slice(&blob);
+    Ok(out)
+}
+
+/// Decode an envelope produced by [`encode_envelope`], verifying the
+/// magic, version, declared length, and SHA-256 checksum.
+pub fn decode_envelope(bytes: &[u8]) -> Result<(u64, SerializableState), SnapshotError> {
+    if bytes.len() < HEADER_LEN {
+        return Err(SnapshotError::Truncated { len: bytes.len() });
+    }
+    if &bytes[0..4] != MAGIC {
+        return Err(SnapshotError::BadMagic);
+    }
+    let version = u32::from_be_bytes(bytes[4..8].try_into().unwrap());
+    if version != ENVELOPE_VERSION {
+        return Err(SnapshotError::UnsupportedVersion(version));
+    }
+    let seq = u64::from_be_bytes(bytes[8..16].try_into().unwrap());
+    let blob_len = u32::from_be_bytes(bytes[16..20].try_into().unwrap()) as usize;
+    let checksum = &bytes[20..52];
+    let payload = &bytes[HEADER_LEN..];
+    if payload.len() != blob_len {
+        return Err(SnapshotError::LengthMismatch {
+            declared: blob_len,
+            actual: payload.len(),
+        });
+    }
+    let digest = Sha256::digest(payload);
+    if &digest[..] != checksum {
+        return Err(SnapshotError::ChecksumMismatch);
+    }
+    let state: SerializableState = bincode::deserialize(payload)?;
+    Ok((seq, state))
+}
+
+/// Periodic snapshotter task. Lives next to the auction tick: every
+/// `min(interval, 1s)` wake-up, the task asks the engine whether a
+/// snapshot is due based on event-count delta or wall-clock elapsed,
+/// captures one if so, then compacts events and old snapshots behind
+/// the new watermark. Errors are logged at `warn!` — a missed snapshot
+/// is recoverable, so the task never panics or aborts on its own.
+pub(crate) async fn run_snapshotter(
+    engine: Engine,
+    config: SnapshotConfig,
+    cancel: CancellationToken,
+) {
+    if !config.enabled {
+        info!("snapshotter disabled — periodic snapshots will NOT run");
+        return;
+    }
+    let Some(snapshot_store) = engine.snapshot_store_clone() else {
+        info!("snapshotter started without a SnapshotStore — task exiting");
+        return;
+    };
+
+    // Sub-tick at the smaller of (interval, 1s) so the event-delta
+    // trigger can fire promptly for high-throughput deploys without
+    // demanding a tight per-call latency budget.
+    let sub_tick = config
+        .interval
+        .min(Duration::from_secs(1))
+        .max(Duration::from_millis(100));
+    let mut interval = tokio::time::interval(sub_tick);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
+    // Seed the trigger watermark from the most recent envelope on disk
+    // so a restart on a populated store does not immediately re-emit a
+    // redundant snapshot (the event-delta trigger would otherwise fire
+    // on the very first sub-tick whenever `store.last_seq() >= every_events`).
+    let mut last_snapshot_seq: u64 = match snapshot_store.read_latest() {
+        Ok(Some((seq, _))) => seq,
+        Ok(None) => 0,
+        Err(e) => {
+            warn!(error = ?e, "could not read latest snapshot seq at boot; starting from 0");
+            0
+        }
+    };
+    let mut last_snapshot_at = Instant::now();
+    info!(
+        every_events = config.every_events,
+        interval_secs = config.interval.as_secs(),
+        retain_events = config.retain_events,
+        retain_count = config.retain_count,
+        "snapshotter started"
+    );
+
+    loop {
+        tokio::select! {
+            _ = cancel.cancelled() => {
+                info!("snapshotter cancelled");
+                return;
+            }
+            _ = interval.tick() => {
+                let now_seq = engine.store_last_seq();
+                let elapsed = last_snapshot_at.elapsed();
+                let event_trigger = now_seq.saturating_sub(last_snapshot_seq) >= config.every_events;
+                let time_trigger = elapsed >= config.interval;
+                if now_seq <= last_snapshot_seq {
+                    continue;
+                }
+                if !event_trigger && !time_trigger {
+                    continue;
+                }
+                match take_snapshot(&engine, snapshot_store.as_ref(), &config, now_seq) {
+                    Ok(written_seq) => {
+                        last_snapshot_seq = written_seq;
+                        last_snapshot_at = Instant::now();
+                    }
+                    Err(e) => warn!(error = ?e, "snapshot tick failed; will retry next tick"),
+                }
+            }
+        }
+    }
+}
+
+/// Capture, write, compact, prune. Returns the seq the snapshot was
+/// keyed under so the loop can drive its trigger logic. Pulled out of
+/// [`run_snapshotter`] so unit tests can drive a snapshot without a
+/// running async task.
+pub(crate) fn take_snapshot(
+    engine: &Engine,
+    snapshot_store: &dyn SnapshotStore,
+    config: &SnapshotConfig,
+    seq_hint: u64,
+) -> Result<u64, SnapshotError> {
+    // Capture under lock — clone the persistable subset and pick a seq
+    // *while holding the lock* so the snapshot reflects exactly the
+    // event the engine had observed at capture time.
+    let (state, seq) = engine.capture_snapshot_state(seq_hint);
+
+    let envelope = encode_envelope(&state, seq)?;
+    snapshot_store.write(seq, &envelope)?;
+
+    // Compact the event log behind the new watermark. `retain_events`
+    // is the tail kept for forensics; underflow is fine because
+    // `compact_before(0)` is a no-op in every backend.
+    let compact_floor = seq.saturating_sub(config.retain_events);
+    if compact_floor > 0 {
+        if let Err(e) = engine.compact_events_before(compact_floor) {
+            warn!(error = ?e, seq, "event-log compaction failed (snapshot already written)");
+        }
+    }
+
+    // Retention sweep on the snapshot store. Keep the latest
+    // `retain_count` envelopes including the one we just wrote.
+    if config.retain_count > 0 {
+        if let Ok(seqs) = snapshot_store.list_seqs() {
+            if seqs.len() > config.retain_count {
+                let cutoff_idx = seqs.len() - config.retain_count;
+                let cutoff_seq = seqs[cutoff_idx];
+                if let Err(e) = snapshot_store.delete_before(cutoff_seq) {
+                    warn!(error = ?e, "snapshot retention prune failed");
+                }
+            }
+        }
+    }
+    info!(seq, "snapshot written");
+    Ok(seq)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+    use crate::state::SerializableState;
+    use dp_book::OrderBook;
+
+    fn empty_state() -> SerializableState {
+        SerializableState {
+            book: OrderBook::new().to_snapshot(),
+            pair_tokens: HashMap::new(),
+            auction_log: Vec::new(),
+            pending_batches: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn envelope_round_trip() {
+        let s = empty_state();
+        let env = encode_envelope(&s, 1234).unwrap();
+        let (seq, _back) = decode_envelope(&env).unwrap();
+        assert_eq!(seq, 1234);
+    }
+
+    #[test]
+    fn detects_truncation() {
+        let env = encode_envelope(&empty_state(), 1).unwrap();
+        let half = &env[..env.len() / 2];
+        let err = decode_envelope(half).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                SnapshotError::LengthMismatch { .. } | SnapshotError::Truncated { .. }
+            ),
+            "got {err:?}",
+        );
+    }
+
+    #[test]
+    fn detects_bad_magic() {
+        let mut env = encode_envelope(&empty_state(), 1).unwrap();
+        env[0] = b'X';
+        let err = decode_envelope(&env).unwrap_err();
+        assert!(matches!(err, SnapshotError::BadMagic), "got {err:?}");
+    }
+
+    #[test]
+    fn detects_corruption_in_payload() {
+        let mut env = encode_envelope(&empty_state(), 1).unwrap();
+        // Mid-payload flip — outside the header, so length and magic
+        // still look OK; only the checksum catches it.
+        let last = env.len() - 1;
+        env[last] ^= 0xFF;
+        let err = decode_envelope(&env).unwrap_err();
+        assert!(
+            matches!(err, SnapshotError::ChecksumMismatch),
+            "got {err:?}"
+        );
+    }
+}

--- a/crates/dp-engine/src/snapshot.rs
+++ b/crates/dp-engine/src/snapshot.rs
@@ -253,6 +253,10 @@ pub(crate) fn take_snapshot(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use dp_event::{MemSnapshotStore, MemStore};
 
     use super::*;
     use crate::state::SerializableState;
@@ -265,6 +269,11 @@ mod tests {
             auction_log: Vec::new(),
             pending_batches: HashMap::new(),
         }
+    }
+
+    fn bare_engine() -> crate::engine::Engine {
+        let store = Arc::new(MemStore::new());
+        crate::engine::Engine::new(store, Duration::from_millis(50))
     }
 
     #[test]
@@ -298,6 +307,19 @@ mod tests {
     }
 
     #[test]
+    fn detects_unsupported_version() {
+        let mut env = encode_envelope(&empty_state(), 1).unwrap();
+        // Version sits at bytes 4..8 in big-endian.
+        let bad_ver: u32 = 0xDEAD;
+        env[4..8].copy_from_slice(&bad_ver.to_be_bytes());
+        let err = decode_envelope(&env).unwrap_err();
+        assert!(
+            matches!(err, SnapshotError::UnsupportedVersion(v) if v == bad_ver),
+            "got {err:?}",
+        );
+    }
+
+    #[test]
     fn detects_corruption_in_payload() {
         let mut env = encode_envelope(&empty_state(), 1).unwrap();
         // Mid-payload flip — outside the header, so length and magic
@@ -309,5 +331,43 @@ mod tests {
             matches!(err, SnapshotError::ChecksumMismatch),
             "got {err:?}"
         );
+    }
+
+    #[test]
+    fn take_snapshot_writes_and_returns_seq() {
+        let engine = bare_engine();
+        let snap_store = MemSnapshotStore::new();
+        let cfg = SnapshotConfig {
+            enabled: true,
+            every_events: 100,
+            interval: Duration::from_secs(300),
+            retain_events: 0,
+            retain_count: 5,
+        };
+        let seq = take_snapshot(&engine, &snap_store, &cfg, 0).unwrap();
+        assert_eq!(seq, 0);
+        assert_eq!(snap_store.list_seqs().unwrap(), vec![0]);
+    }
+
+    #[test]
+    fn take_snapshot_prunes_old_envelopes_beyond_retain_count() {
+        let engine = bare_engine();
+        let snap_store = MemSnapshotStore::new();
+        // Pre-populate 4 old envelopes at seqs 1..4.
+        for s in [1u64, 2, 3, 4] {
+            let env = encode_envelope(&empty_state(), s).unwrap();
+            snap_store.write(s, &env).unwrap();
+        }
+        let cfg = SnapshotConfig {
+            retain_count: 3,
+            retain_events: 0,
+            ..SnapshotConfig::default()
+        };
+        // The bare engine has no events so take_snapshot captures seq=0.
+        // After the write, the store holds seqs [0,1,2,3,4] (5 entries).
+        // retain_count=3 → keep the 3 highest, delete before seqs[2]=2.
+        // Result: [2, 3, 4].
+        take_snapshot(&engine, &snap_store, &cfg, 0).unwrap();
+        assert_eq!(snap_store.list_seqs().unwrap(), vec![2, 3, 4]);
     }
 }

--- a/crates/dp-engine/src/state.rs
+++ b/crates/dp-engine/src/state.rs
@@ -191,7 +191,7 @@ impl EngineState {
     }
 
     /// Capture the persistable subset of state into a [`SerializableState`].
-    /// Holds no locks of its own (caller owns the [`Mutex<EngineState>`]
+    /// Holds no locks of its own (caller owns the `Mutex<EngineState>`
     /// guard); clones every contained collection so the resulting value
     /// is independent of the live state.
     pub(crate) fn to_serializable(&self) -> SerializableState {

--- a/crates/dp-engine/src/state.rs
+++ b/crates/dp-engine/src/state.rs
@@ -3,10 +3,11 @@ use std::time::{Duration, Instant};
 
 use alloy_primitives::{Address, U256};
 use dp_auction::Match;
-use dp_book::OrderBook;
+use dp_book::{BookSnapshot, OrderBook};
 use dp_settlement::SettlementMatch;
 use dp_types::Order;
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::{DEFAULT_MAX_BACKOFF, DEFAULT_MIN_BACKOFF, DEFAULT_ORDER_TTL, DEFAULT_SUBMIT_TIMEOUT};
@@ -50,7 +51,7 @@ pub(crate) fn try_build_settlement_row(
     })
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PairStatus {
     Active,
     Suspended,
@@ -63,7 +64,7 @@ impl PairStatus {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PairConfig {
     pub base_token: Address,
     pub quote_token: Address,
@@ -100,7 +101,7 @@ impl Default for PairConfig {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PendingBatch {
     pub batch_id: Uuid,
     pub auction_id: Uuid,
@@ -109,11 +110,21 @@ pub struct PendingBatch {
     pub proof: Vec<u8>,
     pub public_inputs: [U256; 6],
     pub attempts: u32,
+    /// `Instant` has no stable serialised representation; the retry
+    /// scheduler will compute a fresh attempt time the next time the
+    /// batch is considered, so we drop the wall-clock pointer on
+    /// snapshot round-trip and let the recover path fall back to the
+    /// default `None`.
+    #[serde(skip)]
     pub next_attempt: Option<Instant>,
+    /// In-flight submission flag is a transient runtime guard — after a
+    /// snapshot-and-restart there is no in-flight work, so reset to
+    /// `false` instead of trying to round-trip it.
+    #[serde(skip)]
     pub submitting: bool,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct AuctionExecutedRecord {
     pub auction_id: Uuid,
     pub pair: String,
@@ -121,6 +132,20 @@ pub(crate) struct AuctionExecutedRecord {
     pub matched_volume: rust_decimal::Decimal,
     pub match_count: u32,
     pub timestamp: chrono::DateTime<chrono::Utc>,
+}
+
+/// Persistable subset of [`EngineState`]. Captures every piece of state
+/// that recovery rebuilds from the event stream so a snapshot + the
+/// event tail past `applied_seq` is equivalent to a full replay. The
+/// runtime-only fields (`submit_timeout`, backoff bounds, `recovered`
+/// flag) are intentionally excluded — they come from `Config`, not the
+/// event log.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct SerializableState {
+    pub book: BookSnapshot,
+    pub pair_tokens: HashMap<String, PairConfig>,
+    pub auction_log: Vec<AuctionExecutedRecord>,
+    pub pending_batches: HashMap<Uuid, PendingBatch>,
 }
 
 pub(crate) struct EngineState {
@@ -163,6 +188,29 @@ impl EngineState {
 
     pub fn pair_config(&self, pair: &str) -> Option<&PairConfig> {
         self.pair_tokens.get(pair)
+    }
+
+    /// Capture the persistable subset of state into a [`SerializableState`].
+    /// Holds no locks of its own (caller owns the [`Mutex<EngineState>`]
+    /// guard); clones every contained collection so the resulting value
+    /// is independent of the live state.
+    pub(crate) fn to_serializable(&self) -> SerializableState {
+        SerializableState {
+            book: self.book.to_snapshot(),
+            pair_tokens: self.pair_tokens.clone(),
+            auction_log: self.auction_log.clone(),
+            pending_batches: self.pending_batches.clone(),
+        }
+    }
+
+    /// Replace the projection-derived fields with the contents of
+    /// `snap`. The runtime-only fields (timeouts, backoff, `recovered`)
+    /// are untouched so the engine's `Config`-supplied values win.
+    pub(crate) fn restore_from_serializable(&mut self, snap: SerializableState) {
+        self.book.restore_from(snap.book);
+        self.pair_tokens = snap.pair_tokens;
+        self.auction_log = snap.auction_log;
+        self.pending_batches = snap.pending_batches;
     }
 }
 

--- a/crates/dp-engine/src/state.rs
+++ b/crates/dp-engine/src/state.rs
@@ -269,4 +269,43 @@ mod tests {
         assert!(!PairStatus::Suspended.is_active());
         assert!(!PairStatus::Delisted.is_active());
     }
+
+    #[test]
+    fn to_serializable_captures_pair_tokens() {
+        let mut state = EngineState::new();
+        let base = alloy_primitives::Address::repeat_byte(1);
+        let quote = alloy_primitives::Address::repeat_byte(2);
+        state
+            .pair_tokens
+            .insert("ETH/USDC".into(), PairConfig::new(base, quote));
+
+        let snap = state.to_serializable();
+        assert!(snap.pair_tokens.contains_key("ETH/USDC"));
+        assert_eq!(snap.pair_tokens["ETH/USDC"].base_token, base);
+    }
+
+    #[test]
+    fn restore_from_serializable_overwrites_pair_tokens() {
+        let mut state = EngineState::new();
+        let base = alloy_primitives::Address::repeat_byte(0xAA);
+        let quote = alloy_primitives::Address::repeat_byte(0xBB);
+        state
+            .pair_tokens
+            .insert("BTC/USDC".into(), PairConfig::new(base, quote));
+
+        // Build a snap with a different pair registry.
+        let mut other = EngineState::new();
+        other.pair_tokens.insert(
+            "SOL/USDC".into(),
+            PairConfig::new(
+                alloy_primitives::Address::repeat_byte(0xCC),
+                alloy_primitives::Address::repeat_byte(0xDD),
+            ),
+        );
+        let snap = other.to_serializable();
+
+        state.restore_from_serializable(snap);
+        assert!(!state.pair_tokens.contains_key("BTC/USDC"));
+        assert!(state.pair_tokens.contains_key("SOL/USDC"));
+    }
 }

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -445,6 +445,54 @@ async fn recover_from_mem_store() {
 }
 
 #[tokio::test]
+async fn recover_preserves_pair_suspended_status() {
+    let store = Arc::new(MemStore::new());
+    let engine1 = Engine::new(store.clone(), Duration::from_millis(50));
+    engine1
+        .register_pair_with_event("BTC-USD", crate::state::PairConfig::default())
+        .expect("register");
+    engine1.suspend_pair("BTC-USD").expect("suspend");
+
+    let engine2 = Engine::new(store.clone(), Duration::from_millis(50));
+    engine2.recover().await.unwrap();
+
+    let pairs = engine2.list_pairs();
+    let status = pairs
+        .iter()
+        .find(|(p, _)| p == "BTC-USD")
+        .map(|(_, c)| c.status)
+        .expect("pair must exist after recovery");
+    assert!(
+        matches!(status, crate::state::PairStatus::Suspended),
+        "recovered pair status must be Suspended, got {status:?}",
+    );
+}
+
+#[tokio::test]
+async fn recover_preserves_pair_delisted_status() {
+    let store = Arc::new(MemStore::new());
+    let engine1 = Engine::new(store.clone(), Duration::from_millis(50));
+    engine1
+        .register_pair_with_event("BTC-USD", crate::state::PairConfig::default())
+        .expect("register");
+    engine1.delist_pair("BTC-USD").expect("delist");
+
+    let engine2 = Engine::new(store.clone(), Duration::from_millis(50));
+    engine2.recover().await.unwrap();
+
+    let pairs = engine2.list_pairs();
+    let status = pairs
+        .iter()
+        .find(|(p, _)| p == "BTC-USD")
+        .map(|(_, c)| c.status)
+        .expect("pair must exist after recovery");
+    assert!(
+        matches!(status, crate::state::PairStatus::Delisted),
+        "recovered pair status must be Delisted, got {status:?}",
+    );
+}
+
+#[tokio::test]
 async fn recover_from_file_store() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("events.bin");
@@ -1053,6 +1101,18 @@ async fn event_log_size_bytes_routes_to_store() {
     // MemStore inherits the default Store::size_bytes which returns 0,
     // so the engine method should pass that through unchanged.
     assert_eq!(engine.event_log_size_bytes().unwrap(), 0);
+}
+
+#[test]
+fn take_snapshot_for_bench_delegates_to_take_snapshot() {
+    use dp_event::{MemSnapshotStore, SnapshotStore};
+    use crate::snapshot::SnapshotConfig;
+    let (engine, _) = make_engine();
+    let snap_store = MemSnapshotStore::new();
+    let seq = crate::take_snapshot_for_bench(&engine, &snap_store, &SnapshotConfig::default(), 0)
+        .expect("bench snapshot must succeed");
+    assert_eq!(seq, 0);
+    assert!(!snap_store.list_seqs().unwrap().is_empty());
 }
 
 mod snapshot_recover {

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -1105,8 +1105,8 @@ async fn event_log_size_bytes_routes_to_store() {
 
 #[test]
 fn take_snapshot_for_bench_delegates_to_take_snapshot() {
-    use dp_event::{MemSnapshotStore, SnapshotStore};
     use crate::snapshot::SnapshotConfig;
+    use dp_event::{MemSnapshotStore, SnapshotStore};
     let (engine, _) = make_engine();
     let snap_store = MemSnapshotStore::new();
     let seq = crate::take_snapshot_for_bench(&engine, &snap_store, &SnapshotConfig::default(), 0)
@@ -1458,8 +1458,13 @@ mod snapshot_recover {
         drive_scenario(&engine).await;
 
         let snap_seq = engine.store_last_seq();
-        take_snapshot(&engine, snap_store.as_ref(), &SnapshotConfig::default(), snap_seq)
-            .expect("take snapshot");
+        take_snapshot(
+            &engine,
+            snap_store.as_ref(),
+            &SnapshotConfig::default(),
+            snap_seq,
+        )
+        .expect("take snapshot");
 
         // Add two more events (tail) then compact the first tail event,
         // creating a gap: snap_seq+1 is missing, snap_seq+2 is present.
@@ -1532,7 +1537,10 @@ mod snapshot_recover {
 
         let restored = wire_engine(store.clone());
         restored.set_snapshot_store(Some(Arc::new(AlwaysFailSnapshotStore)));
-        restored.recover().await.expect("intact log must allow full replay");
+        restored
+            .recover()
+            .await
+            .expect("intact log must allow full replay");
         assert_eq!(public_state_fingerprint(&restored), truth);
     }
 

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -1365,6 +1365,117 @@ mod snapshot_recover {
         );
     }
 
+    /// A SnapshotStore that always errors on `list_seqs`, triggering the
+    /// `StoreError` branch of `recover()`.
+    struct AlwaysFailSnapshotStore;
+    impl dp_event::SnapshotStore for AlwaysFailSnapshotStore {
+        fn write(&self, _seq: u64, _envelope: &[u8]) -> Result<(), dp_event::EventError> {
+            Ok(())
+        }
+        fn read_latest(&self) -> Result<Option<(u64, Vec<u8>)>, dp_event::EventError> {
+            Err(dp_event::EventError::Io(std::io::Error::other("injected")))
+        }
+        fn read_at(&self, _seq: u64) -> Result<Option<Vec<u8>>, dp_event::EventError> {
+            Ok(None)
+        }
+        fn list_seqs(&self) -> Result<Vec<u64>, dp_event::EventError> {
+            Err(dp_event::EventError::Io(std::io::Error::other("injected")))
+        }
+        fn delete_before(&self, _before_seq: u64) -> Result<(), dp_event::EventError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn restored_snapshot_with_tail_gap_refuses_boot() {
+        // Build an engine, place events, take a snapshot, then compact
+        // the first tail event to manufacture a gap between the snapshot
+        // watermark and the retained log.
+        let store = Arc::new(MemStore::new());
+        let snap_store: Arc<dyn SnapshotStore> = Arc::new(MemSnapshotStore::new());
+        let engine = wire_engine(store.clone());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+        drive_scenario(&engine).await;
+
+        let snap_seq = engine.store_last_seq();
+        take_snapshot(&engine, snap_store.as_ref(), &SnapshotConfig::default(), snap_seq)
+            .expect("take snapshot");
+
+        // Add two more events (tail) then compact the first tail event,
+        // creating a gap: snap_seq+1 is missing, snap_seq+2 is present.
+        engine
+            .register_pair_with_event(
+                "ETH-USDC",
+                crate::state::PairConfig::new(
+                    alloy_primitives::Address::repeat_byte(0xAA),
+                    alloy_primitives::Address::repeat_byte(0xBB),
+                ),
+            )
+            .unwrap();
+        engine
+            .register_pair_with_event(
+                "SOL-USDC",
+                crate::state::PairConfig::new(
+                    alloy_primitives::Address::repeat_byte(0xCC),
+                    alloy_primitives::Address::repeat_byte(0xDD),
+                ),
+            )
+            .unwrap();
+
+        let gap_before = snap_seq + 2; // removes snap_seq+1, keeps snap_seq+2
+        engine.compact_events_before(gap_before).expect("compact");
+
+        let restored = wire_engine(store.clone());
+        restored.set_snapshot_store(Some(snap_store.clone()));
+        let err = restored
+            .recover()
+            .await
+            .expect_err("gap in tail must refuse boot");
+        assert!(
+            matches!(err, crate::EngineError::SnapshotsCorruptAndLogTruncated),
+            "expected SnapshotsCorruptAndLogTruncated, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn store_error_with_compacted_log_refuses_boot() {
+        // snapshot store always errors; event log has been compacted so
+        // full replay from seq 1 is impossible → must refuse.
+        let store = Arc::new(MemStore::new());
+        let engine = wire_engine(store.clone());
+        engine.set_snapshot_store(Some(Arc::new(AlwaysFailSnapshotStore)));
+        drive_scenario(&engine).await;
+
+        let last = engine.store_last_seq();
+        engine.compact_events_before(last).expect("compact");
+
+        let restored = wire_engine(store.clone());
+        restored.set_snapshot_store(Some(Arc::new(AlwaysFailSnapshotStore)));
+        let err = restored
+            .recover()
+            .await
+            .expect_err("store error + compacted log must refuse boot");
+        assert!(
+            matches!(err, crate::EngineError::SnapshotsCorruptAndLogTruncated),
+            "expected SnapshotsCorruptAndLogTruncated, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn store_error_with_intact_log_falls_back_to_full_replay() {
+        // snapshot store always errors; event log starts at seq 1 →
+        // full replay is safe, recover() must succeed.
+        let store = Arc::new(MemStore::new());
+        let engine = wire_engine(store.clone());
+        drive_scenario(&engine).await;
+        let truth = public_state_fingerprint(&engine);
+
+        let restored = wire_engine(store.clone());
+        restored.set_snapshot_store(Some(Arc::new(AlwaysFailSnapshotStore)));
+        restored.recover().await.expect("intact log must allow full replay");
+        assert_eq!(public_state_fingerprint(&restored), truth);
+    }
+
     #[tokio::test]
     async fn all_corrupt_and_empty_log_refuses_boot() {
         // Pathological variant of the above: the event log is entirely

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -1054,3 +1054,563 @@ async fn event_log_size_bytes_routes_to_store() {
     // so the engine method should pass that through unchanged.
     assert_eq!(engine.event_log_size_bytes().unwrap(), 0);
 }
+
+mod snapshot_recover {
+    //! Verifies that `recover()` produces the same projection state when
+    //! starting from a snapshot+tail as it does when replaying every
+    //! event from seq 0. Drives a deterministic mini-scenario (register
+    //! pair → place orders → tick → snapshot mid-flight → more orders +
+    //! ticks) on two stores, then compares the public-facing engine
+    //! state.
+
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use alloy_primitives::Address;
+    use dp_event::{MemSnapshotStore, MemStore, SnapshotStore};
+    use dp_types::Side;
+    use rust_decimal::Decimal;
+
+    use crate::snapshot::{take_snapshot, SnapshotConfig};
+    use crate::test_helpers::{place_plaintext_order, StubAggregator, StubSubmitter};
+    use crate::Engine;
+
+    fn dec(n: i64) -> Decimal {
+        Decimal::new(n, 0)
+    }
+
+    fn wire_engine(store: Arc<MemStore>) -> Engine {
+        // Engine::new already installs a NoopDecrypter that parses the
+        // JSON-encoded plaintext payload `place_plaintext_order` builds
+        // — installing a real decrypter here would lose that round-trip.
+        let engine = Engine::new(store, Duration::from_millis(50));
+        engine.set_aggregator(Arc::new(StubAggregator::new(vec![0u8; 32])));
+        engine.set_submitter(Arc::new(StubSubmitter::new()));
+        engine
+    }
+
+    async fn drive_scenario(engine: &Engine) {
+        engine
+            .register_pair_with_event(
+                "BTC-USD",
+                crate::state::PairConfig::new(Address::repeat_byte(1), Address::repeat_byte(2)),
+            )
+            .expect("register pair");
+        for i in 0..5 {
+            place_plaintext_order(
+                engine,
+                "BTC-USD",
+                Side::Buy,
+                dec(100),
+                dec(1),
+                &format!("bid-{i}"),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap();
+            place_plaintext_order(
+                engine,
+                "BTC-USD",
+                Side::Sell,
+                dec(100),
+                dec(1),
+                &format!("ask-{i}"),
+                Duration::from_secs(60),
+            )
+            .await
+            .unwrap();
+        }
+        // First tick: matches a few orders, surfaces AuctionExecuted +
+        // OrderMatched + BatchSubmitted + BatchConfirmed events.
+        engine.run_auction_tick().await;
+    }
+
+    fn public_state_fingerprint(engine: &Engine) -> Fingerprint {
+        let (bids, asks) = engine.get_order_book("BTC-USD");
+        let pairs = engine
+            .list_pairs()
+            .into_iter()
+            .map(|(p, c)| (p, c.status, c.base_token, c.quote_token))
+            .collect::<Vec<_>>();
+        let auction_log_len = engine
+            .get_auction_history(Some("BTC-USD"), 100)
+            .map(|v| v.len())
+            .unwrap_or(0);
+        Fingerprint {
+            active_orders: engine.active_order_count(),
+            pending_batches: engine.pending_batch_count(),
+            bid_ids: bids.iter().map(|o| o.id).collect(),
+            ask_ids: asks.iter().map(|o| o.id).collect(),
+            pairs,
+            auction_log_len,
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Fingerprint {
+        active_orders: usize,
+        pending_batches: usize,
+        bid_ids: Vec<uuid::Uuid>,
+        ask_ids: Vec<uuid::Uuid>,
+        pairs: Vec<(String, crate::state::PairStatus, Address, Address)>,
+        auction_log_len: usize,
+    }
+
+    #[tokio::test]
+    async fn snapshot_and_replay_yield_identical_state() {
+        // Drive the same scenario in two parallel-but-independent worlds:
+        // (A) plain event-replay, (B) snapshot + post-snapshot tail replay.
+        // The post-tick engines are the "ground truth"; the test then
+        // restores fresh engines from the same stores and asserts both
+        // recovery paths converge to the same observable state.
+
+        let store_a = Arc::new(MemStore::new());
+        let engine_a = wire_engine(store_a.clone());
+        drive_scenario(&engine_a).await;
+        let ground_truth = public_state_fingerprint(&engine_a);
+
+        let store_b = Arc::new(MemStore::new());
+        let snap_store_b: Arc<dyn SnapshotStore> = Arc::new(MemSnapshotStore::new());
+        let engine_b = wire_engine(store_b.clone());
+        engine_b.set_snapshot_store(Some(snap_store_b.clone()));
+        drive_scenario(&engine_b).await;
+        // Snapshot at "quiescence" — after the tick + all async finalize
+        // calls have returned. take_snapshot uses the engine's current
+        // store_last_seq as the watermark cap.
+        let now_seq = engine_b.store_last_seq();
+        take_snapshot(
+            &engine_b,
+            snap_store_b.as_ref(),
+            &SnapshotConfig::default(),
+            now_seq,
+        )
+        .expect("take snapshot");
+
+        // Apply additional events post-snapshot so the post-snapshot tail
+        // is non-empty — exercises the replay-past-snapshot path.
+        place_plaintext_order(
+            &engine_b,
+            "BTC-USD",
+            Side::Buy,
+            dec(95),
+            dec(2),
+            "tail-bid",
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        place_plaintext_order(
+            &engine_b,
+            "BTC-USD",
+            Side::Sell,
+            dec(95),
+            dec(2),
+            "tail-ask",
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        engine_b.run_auction_tick().await;
+        let tail_truth = public_state_fingerprint(&engine_b);
+
+        // Sanity check: the post-snapshot run should differ from the
+        // first scenario's fingerprint (more orders + another tick).
+        assert_ne!(
+            ground_truth, tail_truth,
+            "scenario b should have applied more events than a",
+        );
+
+        // Restore from snapshot + replay tail.
+        let store_b_restore = store_b.clone();
+        let snap_store_b_restore = snap_store_b.clone();
+        let engine_b_restored = wire_engine(store_b_restore);
+        engine_b_restored.set_snapshot_store(Some(snap_store_b_restore));
+        engine_b_restored.recover().await.expect("recover b");
+        let restored_fp = public_state_fingerprint(&engine_b_restored);
+        assert_eq!(
+            restored_fp, tail_truth,
+            "snapshot-based recovery must reproduce post-tail state",
+        );
+
+        // Restore from full event replay (no snapshot store wired).
+        let engine_b_full = wire_engine(store_b.clone());
+        // intentionally NO snapshot store, so recover() falls back to
+        // event-only replay.
+        engine_b_full.recover().await.expect("recover full");
+        let full_fp = public_state_fingerprint(&engine_b_full);
+        assert_eq!(
+            full_fp, tail_truth,
+            "full-replay recovery must match the live engine's state",
+        );
+    }
+
+    #[tokio::test]
+    async fn corrupt_snapshot_falls_back_to_full_replay() {
+        let store = Arc::new(MemStore::new());
+        let snap_store: Arc<dyn SnapshotStore> = Arc::new(MemSnapshotStore::new());
+        let engine = wire_engine(store.clone());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+        drive_scenario(&engine).await;
+        let truth = public_state_fingerprint(&engine);
+
+        // Write a *deliberately garbage* envelope at a sensible seq —
+        // recover() should drop it and replay the full event log
+        // instead of bricking on the bad bytes.
+        snap_store
+            .write(engine.store_last_seq(), b"not a real envelope, just trash")
+            .unwrap();
+
+        let restored = wire_engine(store.clone());
+        restored.set_snapshot_store(Some(snap_store.clone()));
+        restored.recover().await.expect("recover with bad snap");
+        let restored_fp = public_state_fingerprint(&restored);
+        assert_eq!(
+            restored_fp, truth,
+            "corrupt snapshot must fall back transparently to full replay",
+        );
+    }
+
+    #[tokio::test]
+    async fn corrupt_latest_falls_back_to_older_snapshot() {
+        // With `retain_count=3` the snapshotter keeps multiple
+        // envelopes. If the latest is corrupt but an older one is
+        // intact, recover() must walk the list descending and use the
+        // older snapshot rather than redoing a full replay (which would
+        // be wrong if the log is compacted).
+        let store = Arc::new(MemStore::new());
+        let snap_store: Arc<dyn SnapshotStore> = Arc::new(MemSnapshotStore::new());
+        let engine = wire_engine(store.clone());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+        drive_scenario(&engine).await;
+        let truth_after_scenario = public_state_fingerprint(&engine);
+
+        // Snapshot 1: covers the whole scenario. Good.
+        let seq1 = engine.store_last_seq();
+        take_snapshot(
+            &engine,
+            snap_store.as_ref(),
+            &SnapshotConfig::default(),
+            seq1,
+        )
+        .expect("take snapshot 1");
+
+        // Add a couple of events so the next snapshot covers a strictly
+        // greater seq — then plant a corrupt envelope at that seq so
+        // read_latest decode fails and the walk falls back to snap 1.
+        place_plaintext_order(
+            &engine,
+            "BTC-USD",
+            Side::Buy,
+            dec(80),
+            dec(1),
+            "tail-1",
+            Duration::from_secs(60),
+        )
+        .await
+        .unwrap();
+        let seq2 = engine.store_last_seq();
+        snap_store
+            .write(seq2, b"corrupt latest envelope, must be rejected")
+            .unwrap();
+
+        // Restore: latest is garbage, but seq1's envelope is intact and
+        // the event log past seq1 (just one OrderPlaced) is also intact,
+        // so the resulting fingerprint must include that tail order.
+        let restored = wire_engine(store.clone());
+        restored.set_snapshot_store(Some(snap_store.clone()));
+        restored.recover().await.expect("recover with bad latest");
+
+        // Truth includes one extra placed order from the tail.
+        let restored_fp = public_state_fingerprint(&restored);
+        assert_eq!(
+            restored_fp.pairs, truth_after_scenario.pairs,
+            "older snapshot must preserve pair registry",
+        );
+        assert_eq!(
+            restored_fp.active_orders,
+            truth_after_scenario.active_orders + 1,
+            "tail order placed after the corrupt latest must replay on top of the older snapshot",
+        );
+    }
+
+    #[tokio::test]
+    async fn all_corrupt_and_compacted_log_refuses_boot() {
+        // The pathological case the hardening is for: every snapshot
+        // envelope on disk is bad AND the event log has been compacted
+        // past seq 1. Replaying from seq 0 would silently rebuild a
+        // partial book; recover() must refuse to boot instead.
+        let store = Arc::new(MemStore::new());
+        let snap_store: Arc<dyn SnapshotStore> = Arc::new(MemSnapshotStore::new());
+        let engine = wire_engine(store.clone());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+        drive_scenario(&engine).await;
+
+        // Compact the event log so seq 1 is no longer present.
+        let last = engine.store_last_seq();
+        engine.compact_events_before(last).expect("compact");
+
+        // Plant a garbage envelope; this is the only snapshot the
+        // store has, and it cannot decode.
+        snap_store.write(last, b"garbage").unwrap();
+
+        let restored = wire_engine(store.clone());
+        restored.set_snapshot_store(Some(snap_store.clone()));
+        let err = restored
+            .recover()
+            .await
+            .expect_err("must refuse boot on corrupt-snap + compacted-log");
+        assert!(
+            matches!(err, crate::EngineError::SnapshotsCorruptAndLogTruncated),
+            "expected SnapshotsCorruptAndLogTruncated, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn all_corrupt_and_empty_log_refuses_boot() {
+        // Pathological variant of the above: the event log is entirely
+        // empty (e.g. operator wiped the event store but left the
+        // snapshot dir in place). recover() must refuse rather than
+        // silently boot the projection-empty state implied by an empty
+        // event log — that would contradict the (now-unreadable)
+        // snapshot history.
+        let store = Arc::new(MemStore::new());
+        let snap_store: Arc<dyn SnapshotStore> = Arc::new(MemSnapshotStore::new());
+
+        // Plant a garbage envelope at a non-zero seq so list_seqs is
+        // non-empty and read_latest decode fails. No events ever land
+        // in the store.
+        snap_store.write(42, b"garbage").unwrap();
+
+        let engine = wire_engine(store.clone());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+        let err = engine
+            .recover()
+            .await
+            .expect_err("must refuse boot on corrupt-snap + empty-log");
+        assert!(
+            matches!(err, crate::EngineError::SnapshotsCorruptAndLogTruncated),
+            "expected SnapshotsCorruptAndLogTruncated, got {err:?}",
+        );
+    }
+}
+
+/// Property-based crash-recovery tests. Randomises the shape of the
+/// event stream (mix of bid / ask placements, tick cadence, snapshot
+/// timing, optional latest-envelope corruption) and asserts the live
+/// engine, a snapshot-based recovery, and a full-replay recovery all
+/// converge to the same observable state.
+///
+/// Each case runs through a fresh single-thread tokio runtime — proptest
+/// strategies aren't async, so we drive `Engine::recover` and the
+/// scenario via `block_on`. Cases are kept small (low order counts,
+/// short tail) so a full proptest sweep finishes inside the standard
+/// test budget; the fixed-seed deterministic config is documented next
+/// to the strategy.
+#[cfg(test)]
+mod snapshot_recover_prop {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use alloy_primitives::Address;
+    use dp_event::{MemSnapshotStore, MemStore, SnapshotStore};
+    use dp_types::Side;
+    use proptest::prelude::*;
+    use rust_decimal::Decimal;
+
+    use crate::snapshot::{take_snapshot, SnapshotConfig};
+    use crate::test_helpers::{place_plaintext_order, StubAggregator, StubSubmitter};
+    use crate::Engine;
+
+    /// One mutation the property test can apply to the engine.
+    #[derive(Debug, Clone)]
+    enum Step {
+        PlaceBid,
+        PlaceAsk,
+        Tick,
+    }
+
+    /// Wired engine using the plain-text decrypter `place_plaintext_order`
+    /// expects.
+    fn wire_engine(store: Arc<MemStore>) -> Engine {
+        let engine = Engine::new(store, Duration::from_millis(50));
+        engine.set_aggregator(Arc::new(StubAggregator::new(vec![0u8; 32])));
+        engine.set_submitter(Arc::new(StubSubmitter::new()));
+        engine
+    }
+
+    async fn register_pair(engine: &Engine) {
+        engine
+            .register_pair_with_event(
+                "BTC-USD",
+                crate::state::PairConfig::new(Address::repeat_byte(1), Address::repeat_byte(2)),
+            )
+            .expect("register pair");
+    }
+
+    /// Apply a single [`Step`] to `engine`. `seq` disambiguates the
+    /// commitment key so each placement is unique within the scenario.
+    async fn apply_step(engine: &Engine, step: &Step, seq: usize) {
+        match step {
+            Step::PlaceBid => {
+                place_plaintext_order(
+                    engine,
+                    "BTC-USD",
+                    Side::Buy,
+                    Decimal::new(100, 0),
+                    Decimal::new(1, 0),
+                    &format!("bid-{seq}"),
+                    Duration::from_secs(60),
+                )
+                .await
+                .unwrap();
+            }
+            Step::PlaceAsk => {
+                place_plaintext_order(
+                    engine,
+                    "BTC-USD",
+                    Side::Sell,
+                    Decimal::new(100, 0),
+                    Decimal::new(1, 0),
+                    &format!("ask-{seq}"),
+                    Duration::from_secs(60),
+                )
+                .await
+                .unwrap();
+            }
+            Step::Tick => {
+                let _ = engine.run_auction_tick().await;
+            }
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct Fingerprint {
+        active_orders: usize,
+        pending_batches: usize,
+        bid_ids: Vec<uuid::Uuid>,
+        ask_ids: Vec<uuid::Uuid>,
+        auction_log_len: usize,
+    }
+
+    fn fingerprint(engine: &Engine) -> Fingerprint {
+        let (bids, asks) = engine.get_order_book("BTC-USD");
+        let auction_log_len = engine
+            .get_auction_history(Some("BTC-USD"), 100)
+            .map(|v| v.len())
+            .unwrap_or(0);
+        Fingerprint {
+            active_orders: engine.active_order_count(),
+            pending_batches: engine.pending_batch_count(),
+            bid_ids: bids.iter().map(|o| o.id).collect(),
+            ask_ids: asks.iter().map(|o| o.id).collect(),
+            auction_log_len,
+        }
+    }
+
+    fn step_strategy() -> impl Strategy<Value = Step> {
+        prop_oneof![
+            4 => Just(Step::PlaceBid),
+            4 => Just(Step::PlaceAsk),
+            1 => Just(Step::Tick),
+        ]
+    }
+
+    /// Scenario: a stream of steps, a snapshot point (index into the
+    /// stream), and a flag indicating whether to corrupt the latest
+    /// envelope after snapshotting (forces the descending walk back to
+    /// an earlier good envelope or, when none, to a full replay).
+    fn scenario_strategy() -> impl Strategy<Value = (Vec<Step>, usize, bool)> {
+        prop::collection::vec(step_strategy(), 2..16).prop_flat_map(|steps| {
+            let len = steps.len();
+            (
+                Just(steps),
+                // snapshot point must leave at least one step on
+                // each side so both pre- and post-snapshot replay
+                // paths get exercised.
+                1usize..len,
+                any::<bool>(),
+            )
+        })
+    }
+
+    proptest! {
+        // Keep the case count modest so the full proptest sweep finishes
+        // inside the standard cargo test budget. Each case spawns a
+        // tokio runtime, places several orders, runs ticks, and exercises
+        // two recovery paths — significantly more expensive than a
+        // pure-CPU property.
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        #[test]
+        fn recovery_converges_across_random_streams(
+            (steps, snap_at, corrupt_latest) in scenario_strategy(),
+        ) {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            let outcome = rt.block_on(async move {
+                let store = Arc::new(MemStore::new());
+                let snap_store: Arc<dyn SnapshotStore> = Arc::new(MemSnapshotStore::new());
+                let engine = wire_engine(store.clone());
+                engine.set_snapshot_store(Some(snap_store.clone()));
+                register_pair(&engine).await;
+
+                // Phase 1: pre-snapshot steps.
+                for (i, s) in steps.iter().take(snap_at).enumerate() {
+                    apply_step(&engine, s, i).await;
+                }
+
+                // Take a good snapshot covering everything so far.
+                let good_seq = engine.store_last_seq();
+                take_snapshot(
+                    &engine,
+                    snap_store.as_ref(),
+                    &SnapshotConfig::default(),
+                    good_seq,
+                )
+                .expect("take snapshot");
+
+                // Phase 2: post-snapshot steps. The tail replay must
+                // pick these up on top of the snapshot state.
+                for (j, s) in steps.iter().enumerate().skip(snap_at) {
+                    apply_step(&engine, s, j).await;
+                }
+
+                // Optionally plant a corrupt envelope at the latest seq
+                // so read_latest decode fails and recover() must walk
+                // back to the good snapshot. The event tail past `good_seq`
+                // is still on disk so the older-snapshot path must
+                // produce the same fingerprint as the live engine.
+                if corrupt_latest {
+                    let latest = engine.store_last_seq();
+                    if latest != good_seq {
+                        snap_store
+                            .write(latest, b"proptest corrupted envelope")
+                            .unwrap();
+                    }
+                }
+
+                let truth = fingerprint(&engine);
+
+                // Recovery A: snapshot + tail (the path we're stressing).
+                let restore_a = wire_engine(store.clone());
+                restore_a.set_snapshot_store(Some(snap_store.clone()));
+                restore_a.recover().await.expect("recover snapshot path");
+                let fp_a = fingerprint(&restore_a);
+
+                // Recovery B: full replay (no snapshot store wired).
+                let restore_b = wire_engine(store.clone());
+                restore_b.recover().await.expect("recover full");
+                let fp_b = fingerprint(&restore_b);
+
+                (truth, fp_a, fp_b)
+            });
+
+            let (truth, fp_a, fp_b) = outcome;
+            prop_assert_eq!(&fp_a, &truth, "snapshot-based recovery diverged from live engine");
+            prop_assert_eq!(&fp_b, &truth, "full-replay recovery diverged from live engine");
+        }
+    }
+}

--- a/crates/dp-event/migrations/0002_snapshots.sql
+++ b/crates/dp-event/migrations/0002_snapshots.sql
@@ -1,0 +1,5 @@
+CREATE TABLE snapshots (
+    seq        BIGINT       PRIMARY KEY,
+    envelope   BYTEA        NOT NULL,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+);

--- a/crates/dp-event/src/file_snapshot.rs
+++ b/crates/dp-event/src/file_snapshot.rs
@@ -1,0 +1,185 @@
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use crate::{EventError, SnapshotStore};
+
+const SNAP_EXT: &str = "snap";
+const SEQ_DIGITS: usize = 20;
+
+/// On-disk [`SnapshotStore`] that keeps one file per snapshot under a
+/// directory. Filenames are `{seq:020}.snap`, so a lexicographic sort
+/// matches numeric seq order and the latest snapshot is the last entry.
+///
+/// Writes go through a `.tmp` sibling and `fs::rename` so a crash
+/// mid-write does not leave a torn snapshot visible to the next reader.
+pub struct FileSnapshotStore {
+    dir: PathBuf,
+}
+
+impl FileSnapshotStore {
+    pub fn open(dir: impl AsRef<Path>) -> Result<Self, EventError> {
+        let dir = dir.as_ref().to_path_buf();
+        if !dir.exists() {
+            fs::create_dir_all(&dir)?;
+        }
+        Ok(Self { dir })
+    }
+
+    fn path_for(&self, seq: u64) -> PathBuf {
+        self.dir
+            .join(format!("{seq:0width$}.{SNAP_EXT}", width = SEQ_DIGITS))
+    }
+}
+
+fn parse_seq_from_filename(name: &str) -> Option<u64> {
+    let stem = name.strip_suffix(&format!(".{SNAP_EXT}"))?;
+    if stem.len() != SEQ_DIGITS {
+        return None;
+    }
+    stem.parse::<u64>().ok()
+}
+
+impl SnapshotStore for FileSnapshotStore {
+    fn write(&self, seq: u64, envelope: &[u8]) -> Result<(), EventError> {
+        let target = self.path_for(seq);
+        let tmp = target.with_extension("tmp");
+        {
+            let file = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp)?;
+            let mut writer = std::io::BufWriter::new(file);
+            writer.write_all(envelope)?;
+            writer.flush()?;
+            let file = writer
+                .into_inner()
+                .map_err(|e| EventError::Io(e.into_error()))?;
+            file.sync_all()?;
+        }
+        fs::rename(&tmp, &target)?;
+        // Best-effort fsync of the directory so the rename survives a
+        // power loss before the parent dirent has been flushed. Errors
+        // here are not fatal — the snapshot itself is durable.
+        if let Ok(dir) = File::open(&self.dir) {
+            let _ = dir.sync_all();
+        }
+        Ok(())
+    }
+
+    fn read_latest(&self) -> Result<Option<(u64, Vec<u8>)>, EventError> {
+        let seqs = self.list_seqs()?;
+        let Some(&seq) = seqs.last() else {
+            return Ok(None);
+        };
+        let bytes = fs::read(self.path_for(seq))?;
+        Ok(Some((seq, bytes)))
+    }
+
+    fn read_at(&self, seq: u64) -> Result<Option<Vec<u8>>, EventError> {
+        match fs::read(self.path_for(seq)) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    fn list_seqs(&self) -> Result<Vec<u64>, EventError> {
+        let mut out = Vec::new();
+        let read_dir = match fs::read_dir(&self.dir) {
+            Ok(rd) => rd,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(e) => return Err(e.into()),
+        };
+        for entry in read_dir {
+            let entry = entry?;
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            if let Some(seq) = parse_seq_from_filename(name) {
+                out.push(seq);
+            }
+        }
+        out.sort();
+        Ok(out)
+    }
+
+    fn delete_before(&self, before_seq: u64) -> Result<(), EventError> {
+        for seq in self.list_seqs()? {
+            if seq < before_seq {
+                let path = self.path_for(seq);
+                if let Err(e) = fs::remove_file(&path) {
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        return Err(e.into());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_read_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileSnapshotStore::open(dir.path()).unwrap();
+        store.write(42, b"payload").unwrap();
+        let (seq, bytes) = store.read_latest().unwrap().unwrap();
+        assert_eq!(seq, 42);
+        assert_eq!(bytes, b"payload");
+    }
+
+    #[test]
+    fn read_latest_picks_highest_seq() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileSnapshotStore::open(dir.path()).unwrap();
+        store.write(1, b"a").unwrap();
+        store.write(100, b"big").unwrap();
+        store.write(50, b"mid").unwrap();
+        let (seq, bytes) = store.read_latest().unwrap().unwrap();
+        assert_eq!(seq, 100);
+        assert_eq!(bytes, b"big");
+    }
+
+    #[test]
+    fn list_seqs_returns_sorted() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileSnapshotStore::open(dir.path()).unwrap();
+        store.write(30, b"x").unwrap();
+        store.write(10, b"x").unwrap();
+        store.write(20, b"x").unwrap();
+        assert_eq!(store.list_seqs().unwrap(), vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn delete_before_drops_old_snaps_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileSnapshotStore::open(dir.path()).unwrap();
+        for s in [1u64, 5, 10] {
+            store.write(s, b"x").unwrap();
+        }
+        store.delete_before(10).unwrap();
+        assert_eq!(store.list_seqs().unwrap(), vec![10]);
+    }
+
+    #[test]
+    fn read_latest_empty_dir_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileSnapshotStore::open(dir.path()).unwrap();
+        assert!(store.read_latest().unwrap().is_none());
+    }
+
+    #[test]
+    fn ignores_unrelated_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileSnapshotStore::open(dir.path()).unwrap();
+        store.write(7, b"x").unwrap();
+        std::fs::write(dir.path().join("README.txt"), "hi").unwrap();
+        std::fs::write(dir.path().join("00000000000000000099.tmp"), "stale").unwrap();
+        assert_eq!(store.list_seqs().unwrap(), vec![7]);
+    }
+}

--- a/crates/dp-event/src/file_snapshot.rs
+++ b/crates/dp-event/src/file_snapshot.rs
@@ -182,4 +182,38 @@ mod tests {
         std::fs::write(dir.path().join("00000000000000000099.tmp"), "stale").unwrap();
         assert_eq!(store.list_seqs().unwrap(), vec![7]);
     }
+
+    #[test]
+    fn read_at_missing_seq_is_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileSnapshotStore::open(dir.path()).unwrap();
+        assert!(store.read_at(999).unwrap().is_none());
+    }
+
+    #[test]
+    fn read_at_existing_seq_returns_bytes() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileSnapshotStore::open(dir.path()).unwrap();
+        store.write(42, b"hello").unwrap();
+        let bytes = store.read_at(42).unwrap().expect("should be Some");
+        assert_eq!(bytes, b"hello");
+    }
+
+    #[test]
+    fn delete_before_is_idempotent() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileSnapshotStore::open(dir.path()).unwrap();
+        store.write(5, b"x").unwrap();
+        store.delete_before(3).unwrap();
+        store.delete_before(3).unwrap();
+        assert_eq!(store.list_seqs().unwrap(), vec![5]);
+    }
+
+    #[test]
+    fn list_seqs_on_nonexistent_subdir_returns_empty() {
+        let base = tempfile::tempdir().unwrap();
+        let missing = base.path().join("does_not_exist");
+        let store = FileSnapshotStore { dir: missing };
+        assert!(store.list_seqs().unwrap().is_empty());
+    }
 }

--- a/crates/dp-event/src/file_store.rs
+++ b/crates/dp-event/src/file_store.rs
@@ -1,6 +1,6 @@
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufReader, BufWriter, Read, Seek, SeekFrom, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use parking_lot::RwLock;
 
@@ -13,6 +13,12 @@ struct FileInner {
     writer: BufWriter<File>,
     events: Vec<Event>,
     seq: u64,
+    /// Captured at open time so [`Store::compact_before`] can rewrite
+    /// the log atomically without needing the caller to re-supply the
+    /// path. Holding the path on the struct keeps the file handle, the
+    /// in-memory cache, and the on-disk file in lockstep across the
+    /// rewrite.
+    path: PathBuf,
 }
 
 pub struct FileStore {
@@ -21,12 +27,13 @@ pub struct FileStore {
 
 impl FileStore {
     pub fn open(path: impl AsRef<Path>) -> Result<Self, EventError> {
+        let path = path.as_ref().to_path_buf();
         let mut file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
             .truncate(false)
-            .open(path.as_ref())?;
+            .open(&path)?;
 
         let (events, seq, good_end) = load_and_truncate(&mut file)?;
 
@@ -41,6 +48,7 @@ impl FileStore {
                 writer,
                 events,
                 seq,
+                path,
             }),
         })
     }
@@ -140,6 +148,70 @@ impl Store for FileStore {
     fn size_bytes(&self) -> Result<u64, EventError> {
         let inner = self.inner.read();
         Ok(inner.file.metadata()?.len())
+    }
+
+    fn compact_before(&self, before_seq: u64) -> Result<(), EventError> {
+        // Holds the inner write lock for the duration of the rewrite +
+        // fs::rename. At MVP scale (a few thousand retained events,
+        // ~MB of bincode) this is sub-second and the auction tick's
+        // append simply blocks behind it; if event-log growth ever
+        // pushes compaction into multi-second territory, chunk the
+        // rewrite (e.g. drop the lock between batches and re-acquire
+        // for the final atomic publish) instead of widening this
+        // window further.
+        if before_seq == 0 {
+            return Ok(());
+        }
+        let mut inner = self.inner.write();
+
+        // Flush any buffered appends to the live file before we rewrite —
+        // otherwise the post-rename handle would be missing the tail of
+        // events the caller had appended just before compacting.
+        inner.writer.flush()?;
+        inner.file.sync_all()?;
+
+        let tmp_path = inner.path.with_extension("compact.tmp");
+        {
+            let tmp = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&tmp_path)?;
+            let mut tmp_writer = BufWriter::new(tmp);
+            for evt in inner.events.iter().filter(|e| e.seq >= before_seq) {
+                let payload = bincode::serialize(evt)?;
+                let length = payload.len() as u32;
+                tmp_writer.write_all(&length.to_be_bytes())?;
+                tmp_writer.write_all(&payload)?;
+            }
+            tmp_writer.flush()?;
+            let tmp_file = tmp_writer
+                .into_inner()
+                .map_err(|e| EventError::Io(e.into_error()))?;
+            tmp_file.sync_all()?;
+        }
+
+        // Atomic publish. On Linux `rename` is atomic when source and
+        // destination live on the same filesystem — temp file is in the
+        // same directory as the log to guarantee that.
+        std::fs::rename(&tmp_path, &inner.path)?;
+
+        // Re-open the live handle on the rewritten file; the old handle
+        // still points at the now-orphaned inode. seek to EOF and rebuild
+        // the writer so subsequent appends land in the right place.
+        let mut new_file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(&inner.path)?;
+        let end = new_file.seek(SeekFrom::End(0))?;
+        new_file.seek(SeekFrom::Start(end))?;
+        let new_writer = BufWriter::new(new_file.try_clone()?);
+
+        inner.file = new_file;
+        inner.writer = new_writer;
+        inner.events.retain(|e| e.seq >= before_seq);
+        Ok(())
     }
 }
 
@@ -277,5 +349,49 @@ mod tests {
         let after = store.size_bytes().unwrap();
 
         assert!(after > empty, "size {after} should exceed empty {empty}");
+    }
+
+    #[test]
+    fn compact_rewrites_file_and_preserves_tail() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.bin");
+        let store = FileStore::open(&path).unwrap();
+        let mut events = vec![placed_event(), placed_event(), placed_event()];
+        store.append(&mut events).unwrap();
+        let before = store.size_bytes().unwrap();
+
+        store.compact_before(3).unwrap();
+
+        let after = store.size_bytes().unwrap();
+        assert!(
+            after < before,
+            "compacted file {after} not smaller than original {before}"
+        );
+        let read = store.read_from(0, 10).unwrap();
+        assert_eq!(read.len(), 1);
+        assert_eq!(read[0].seq, 3);
+        store.close().unwrap();
+    }
+
+    #[test]
+    fn compact_then_append_then_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.bin");
+        {
+            let store = FileStore::open(&path).unwrap();
+            let mut events = vec![placed_event(), placed_event(), placed_event()];
+            store.append(&mut events).unwrap();
+            store.compact_before(3).unwrap();
+            let mut more = vec![placed_event()];
+            store.append(&mut more).unwrap();
+            assert_eq!(more[0].seq, 4);
+            store.close().unwrap();
+        }
+        let store = FileStore::open(&path).unwrap();
+        let read = store.read_from(0, 10).unwrap();
+        assert_eq!(read.len(), 2);
+        assert_eq!(read[0].seq, 3);
+        assert_eq!(read[1].seq, 4);
+        store.close().unwrap();
     }
 }

--- a/crates/dp-event/src/lib.rs
+++ b/crates/dp-event/src/lib.rs
@@ -3,6 +3,8 @@ mod file_snapshot;
 mod file_store;
 mod mem_store;
 #[cfg(feature = "postgres")]
+mod pg_snapshot;
+#[cfg(feature = "postgres")]
 mod pg_store;
 mod snapshot;
 mod store;
@@ -11,6 +13,8 @@ pub use event::{Event, EventData};
 pub use file_snapshot::FileSnapshotStore;
 pub use file_store::FileStore;
 pub use mem_store::MemStore;
+#[cfg(feature = "postgres")]
+pub use pg_snapshot::PgSnapshotStore;
 #[cfg(feature = "postgres")]
 pub use pg_store::PgStore;
 pub use snapshot::{MemSnapshotStore, SnapshotStore};

--- a/crates/dp-event/src/lib.rs
+++ b/crates/dp-event/src/lib.rs
@@ -1,4 +1,5 @@
 mod event;
+mod file_snapshot;
 mod file_store;
 mod mem_store;
 #[cfg(feature = "postgres")]
@@ -7,6 +8,7 @@ mod snapshot;
 mod store;
 
 pub use event::{Event, EventData};
+pub use file_snapshot::FileSnapshotStore;
 pub use file_store::FileStore;
 pub use mem_store::MemStore;
 #[cfg(feature = "postgres")]

--- a/crates/dp-event/src/lib.rs
+++ b/crates/dp-event/src/lib.rs
@@ -3,6 +3,7 @@ mod file_store;
 mod mem_store;
 #[cfg(feature = "postgres")]
 mod pg_store;
+mod snapshot;
 mod store;
 
 pub use event::{Event, EventData};
@@ -10,6 +11,7 @@ pub use file_store::FileStore;
 pub use mem_store::MemStore;
 #[cfg(feature = "postgres")]
 pub use pg_store::PgStore;
+pub use snapshot::{MemSnapshotStore, SnapshotStore};
 pub use store::{assign_seq_and_timestamp, index_after, Store};
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/dp-event/src/mem_store.rs
+++ b/crates/dp-event/src/mem_store.rs
@@ -54,6 +54,15 @@ impl Store for MemStore {
     fn last_seq(&self) -> u64 {
         self.inner.read().seq
     }
+
+    fn compact_before(&self, before_seq: u64) -> Result<(), EventError> {
+        if before_seq == 0 {
+            return Ok(());
+        }
+        let mut inner = self.inner.write();
+        inner.events.retain(|e| e.seq >= before_seq);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -142,5 +151,26 @@ mod tests {
     fn default_size_bytes_is_zero() {
         let store: Box<dyn Store> = Box::new(MemStore::new());
         assert_eq!(store.size_bytes().unwrap(), 0);
+    }
+
+    #[test]
+    fn compact_drops_events_before_seq() {
+        let store = MemStore::new();
+        let mut events = vec![placed_event(), placed_event(), placed_event()];
+        store.append(&mut events).unwrap();
+        store.compact_before(3).unwrap();
+        let read = store.read_from(0, 10).unwrap();
+        assert_eq!(read.len(), 1);
+        assert_eq!(read[0].seq, 3);
+        assert_eq!(store.last_seq(), 3);
+    }
+
+    #[test]
+    fn compact_zero_is_noop() {
+        let store = MemStore::new();
+        let mut events = vec![placed_event(), placed_event()];
+        store.append(&mut events).unwrap();
+        store.compact_before(0).unwrap();
+        assert_eq!(store.read_from(0, 10).unwrap().len(), 2);
     }
 }

--- a/crates/dp-event/src/pg_snapshot.rs
+++ b/crates/dp-event/src/pg_snapshot.rs
@@ -1,0 +1,101 @@
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use tokio::runtime::Handle;
+
+use crate::{EventError, SnapshotStore};
+
+/// PostgreSQL-backed [`SnapshotStore`]. Same runtime requirement as
+/// [`crate::PgStore`] — methods are synchronous and bridge to async via
+/// `tokio::task::block_in_place` on the captured runtime handle, so
+/// every caller must be inside a multi-threaded tokio runtime.
+pub struct PgSnapshotStore {
+    pool: PgPool,
+    handle: Handle,
+}
+
+impl PgSnapshotStore {
+    pub async fn connect(url: &str) -> Result<Self, EventError> {
+        let pool = PgPoolOptions::new().max_connections(4).connect(url).await?;
+        Self::from_pool(pool).await
+    }
+
+    pub async fn from_pool(pool: PgPool) -> Result<Self, EventError> {
+        sqlx::migrate!("./migrations").run(&pool).await?;
+        Ok(Self {
+            pool,
+            handle: Handle::current(),
+        })
+    }
+}
+
+impl SnapshotStore for PgSnapshotStore {
+    fn write(&self, seq: u64, envelope: &[u8]) -> Result<(), EventError> {
+        let pool = self.pool.clone();
+        let seq = seq as i64;
+        let bytes = envelope.to_vec();
+        tokio::task::block_in_place(|| {
+            self.handle.block_on(async {
+                sqlx::query(
+                    "INSERT INTO snapshots (seq, envelope) VALUES ($1, $2) \
+                     ON CONFLICT (seq) DO UPDATE SET envelope = EXCLUDED.envelope",
+                )
+                .bind(seq)
+                .bind(bytes)
+                .execute(&pool)
+                .await?;
+                Ok::<_, EventError>(())
+            })
+        })
+    }
+
+    fn read_latest(&self) -> Result<Option<(u64, Vec<u8>)>, EventError> {
+        let pool = self.pool.clone();
+        let row: Option<(i64, Vec<u8>)> = tokio::task::block_in_place(|| {
+            self.handle.block_on(async {
+                sqlx::query_as("SELECT seq, envelope FROM snapshots ORDER BY seq DESC LIMIT 1")
+                    .fetch_optional(&pool)
+                    .await
+            })
+        })?;
+        Ok(row.map(|(s, e)| (s as u64, e)))
+    }
+
+    fn read_at(&self, seq: u64) -> Result<Option<Vec<u8>>, EventError> {
+        let pool = self.pool.clone();
+        let key = seq as i64;
+        let row: Option<(Vec<u8>,)> = tokio::task::block_in_place(|| {
+            self.handle.block_on(async {
+                sqlx::query_as("SELECT envelope FROM snapshots WHERE seq = $1")
+                    .bind(key)
+                    .fetch_optional(&pool)
+                    .await
+            })
+        })?;
+        Ok(row.map(|(e,)| e))
+    }
+
+    fn list_seqs(&self) -> Result<Vec<u64>, EventError> {
+        let pool = self.pool.clone();
+        let rows: Vec<(i64,)> = tokio::task::block_in_place(|| {
+            self.handle.block_on(async {
+                sqlx::query_as("SELECT seq FROM snapshots ORDER BY seq ASC")
+                    .fetch_all(&pool)
+                    .await
+            })
+        })?;
+        Ok(rows.into_iter().map(|(s,)| s as u64).collect())
+    }
+
+    fn delete_before(&self, before_seq: u64) -> Result<(), EventError> {
+        let pool = self.pool.clone();
+        let cutoff = before_seq as i64;
+        tokio::task::block_in_place(|| {
+            self.handle.block_on(async {
+                sqlx::query("DELETE FROM snapshots WHERE seq < $1")
+                    .bind(cutoff)
+                    .execute(&pool)
+                    .await?;
+                Ok::<_, EventError>(())
+            })
+        })
+    }
+}

--- a/crates/dp-event/src/pg_store.rs
+++ b/crates/dp-event/src/pg_store.rs
@@ -139,6 +139,23 @@ impl Store for PgStore {
         })
     }
 
+    fn compact_before(&self, before_seq: u64) -> Result<(), EventError> {
+        if before_seq == 0 {
+            return Ok(());
+        }
+        let pool = self.pool.clone();
+        let cutoff = before_seq as i64;
+        tokio::task::block_in_place(|| {
+            self.handle.block_on(async {
+                sqlx::query("DELETE FROM events WHERE seq < $1")
+                    .bind(cutoff)
+                    .execute(&pool)
+                    .await?;
+                Ok::<_, EventError>(())
+            })
+        })
+    }
+
     fn size_bytes(&self) -> Result<u64, EventError> {
         // Bind the table name through a parameter + ::regclass cast so the
         // value is never spliced into the SQL text. Today `EVENTS_TABLE` is

--- a/crates/dp-event/src/snapshot.rs
+++ b/crates/dp-event/src/snapshot.rs
@@ -1,0 +1,133 @@
+use std::collections::BTreeMap;
+
+use parking_lot::RwLock;
+
+use crate::EventError;
+
+/// Persistent home for engine-state snapshots. Snapshots are written
+/// periodically by the engine; on boot, the most recent snapshot is
+/// loaded and only events with `seq > snapshot_seq` are replayed.
+///
+/// Backends MUST surface corruption (checksum mismatch, partial write)
+/// to the caller — engine recovery is expected to drop the bad
+/// envelope and fall back to a full replay, which only works if the
+/// store does not silently mask the failure.
+pub trait SnapshotStore: Send + Sync {
+    /// Write `envelope` keyed by `seq`. Implementations should make the
+    /// publish atomic so a crash mid-write does not leave a torn
+    /// snapshot visible to the next [`SnapshotStore::read_latest`] call.
+    fn write(&self, seq: u64, envelope: &[u8]) -> Result<(), EventError>;
+
+    /// Return the snapshot with the highest `seq`, or `None` if the
+    /// store is empty.
+    fn read_latest(&self) -> Result<Option<(u64, Vec<u8>)>, EventError>;
+
+    /// Read the envelope stored at exactly `seq`, or `None` if that
+    /// seq isn't present. Recovery walks `list_seqs` descending when
+    /// the latest envelope fails to decode (corruption / partial
+    /// write), trying each older snapshot before giving up — without
+    /// this, a single bad latest would force a full event replay even
+    /// when an older, good snapshot is still on disk.
+    fn read_at(&self, seq: u64) -> Result<Option<Vec<u8>>, EventError>;
+
+    /// Sequence numbers of every snapshot the store currently holds, in
+    /// ascending order. Used by the retention sweep.
+    fn list_seqs(&self) -> Result<Vec<u64>, EventError>;
+
+    /// Discard every snapshot with `seq < before_seq`. Used by the
+    /// retention sweep after a fresh envelope has been written.
+    fn delete_before(&self, before_seq: u64) -> Result<(), EventError>;
+}
+
+/// In-memory snapshot store. Used by tests; not durable.
+#[derive(Default)]
+pub struct MemSnapshotStore {
+    snaps: RwLock<BTreeMap<u64, Vec<u8>>>,
+}
+
+impl MemSnapshotStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl SnapshotStore for MemSnapshotStore {
+    fn write(&self, seq: u64, envelope: &[u8]) -> Result<(), EventError> {
+        self.snaps.write().insert(seq, envelope.to_vec());
+        Ok(())
+    }
+
+    fn read_latest(&self) -> Result<Option<(u64, Vec<u8>)>, EventError> {
+        Ok(self
+            .snaps
+            .read()
+            .iter()
+            .next_back()
+            .map(|(s, v)| (*s, v.clone())))
+    }
+
+    fn read_at(&self, seq: u64) -> Result<Option<Vec<u8>>, EventError> {
+        Ok(self.snaps.read().get(&seq).cloned())
+    }
+
+    fn list_seqs(&self) -> Result<Vec<u64>, EventError> {
+        Ok(self.snaps.read().keys().copied().collect())
+    }
+
+    fn delete_before(&self, before_seq: u64) -> Result<(), EventError> {
+        let mut snaps = self.snaps.write();
+        let keep = snaps.split_off(&before_seq);
+        *snaps = keep;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn write_then_read_latest_returns_highest_seq() {
+        let store = MemSnapshotStore::new();
+        store.write(10, b"ten").unwrap();
+        store.write(20, b"twenty").unwrap();
+        store.write(15, b"fifteen").unwrap();
+
+        let (seq, env) = store.read_latest().unwrap().unwrap();
+        assert_eq!(seq, 20);
+        assert_eq!(env, b"twenty");
+    }
+
+    #[test]
+    fn empty_read_latest_is_none() {
+        let store = MemSnapshotStore::new();
+        assert!(store.read_latest().unwrap().is_none());
+    }
+
+    #[test]
+    fn list_seqs_ascending() {
+        let store = MemSnapshotStore::new();
+        store.write(30, b"x").unwrap();
+        store.write(10, b"x").unwrap();
+        store.write(20, b"x").unwrap();
+        assert_eq!(store.list_seqs().unwrap(), vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn delete_before_drops_older_snapshots() {
+        let store = MemSnapshotStore::new();
+        store.write(1, b"a").unwrap();
+        store.write(2, b"b").unwrap();
+        store.write(3, b"c").unwrap();
+        store.delete_before(3).unwrap();
+        assert_eq!(store.list_seqs().unwrap(), vec![3]);
+    }
+
+    #[test]
+    fn delete_before_zero_is_noop() {
+        let store = MemSnapshotStore::new();
+        store.write(5, b"x").unwrap();
+        store.delete_before(0).unwrap();
+        assert_eq!(store.list_seqs().unwrap(), vec![5]);
+    }
+}

--- a/crates/dp-event/src/store.rs
+++ b/crates/dp-event/src/store.rs
@@ -54,5 +54,5 @@ pub fn index_after(events: &[Event], after_seq: u64) -> usize {
     if after_seq == 0 {
         return 0;
     }
-    (after_seq as usize).min(events.len())
+    events.partition_point(|e| e.seq <= after_seq)
 }

--- a/crates/dp-event/src/store.rs
+++ b/crates/dp-event/src/store.rs
@@ -29,6 +29,17 @@ pub trait Store: Send + Sync {
     fn size_bytes(&self) -> Result<u64, EventError> {
         Ok(0)
     }
+
+    /// Discard every event with `seq < before_seq`. Callers MUST only
+    /// invoke this after a snapshot covering at least `before_seq` has
+    /// been durably written; the truncated events are unrecoverable. The
+    /// default is a no-op so backends that do not (yet) support
+    /// compaction keep compiling.
+    ///
+    /// Same runtime requirement as [`Store::ping`].
+    fn compact_before(&self, _before_seq: u64) -> Result<(), EventError> {
+        Ok(())
+    }
 }
 
 pub fn assign_seq_and_timestamp(event: &mut Event, seq: &mut u64) {

--- a/crates/dp-event/src/store.rs
+++ b/crates/dp-event/src/store.rs
@@ -56,3 +56,59 @@ pub fn index_after(events: &[Event], after_seq: u64) -> usize {
     }
     events.partition_point(|e| e.seq <= after_seq)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::EventData;
+    use chrono::DateTime;
+    use dp_types::EventType;
+    use uuid::Uuid;
+
+    fn evt(seq: u64) -> Event {
+        Event {
+            seq,
+            event_type: EventType::OrderPlaced,
+            timestamp: DateTime::default(),
+            data: EventData::OrderPlaced {
+                order_id: Uuid::nil(),
+                commitment: vec![],
+                proof: vec![],
+                ciphertext: vec![],
+                salt_nonce: vec![0u8; 32],
+            },
+        }
+    }
+
+    #[test]
+    fn index_after_zero_always_returns_zero() {
+        let events = vec![evt(5), evt(10)];
+        assert_eq!(index_after(&events, 0), 0);
+        assert_eq!(index_after(&[], 0), 0);
+    }
+
+    #[test]
+    fn index_after_empty_slice_returns_zero() {
+        assert_eq!(index_after(&[], 99), 0);
+    }
+
+    #[test]
+    fn index_after_contiguous_from_one() {
+        let events: Vec<_> = (1..=5).map(evt).collect();
+        assert_eq!(index_after(&events, 2), 2);
+        assert_eq!(index_after(&events, 5), 5);
+        assert_eq!(index_after(&events, 0), 0);
+    }
+
+    #[test]
+    fn index_after_compacted_slice_finds_by_seq_not_index() {
+        // Simulate a compacted store: events start at seq 101, not seq 1.
+        let events: Vec<_> = (101..=105).map(evt).collect();
+        // after_seq=100 → return 0 (start of slice, all events qualify)
+        assert_eq!(index_after(&events, 100), 0);
+        // after_seq=102 → skip 101,102 → return index 2
+        assert_eq!(index_after(&events, 102), 2);
+        // after_seq=105 → all consumed → return 5 (len)
+        assert_eq!(index_after(&events, 105), 5);
+    }
+}

--- a/crates/dp-settlement/src/lib.rs
+++ b/crates/dp-settlement/src/lib.rs
@@ -14,10 +14,11 @@ pub use watcher::{BatchSink, Watcher};
 
 use alloy_primitives::{Address, U256};
 use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
 use std::io;
 use uuid::Uuid;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct SettlementMatch {
     pub bid_order_id: Uuid,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -24,11 +24,16 @@ sonar.coverageReportPaths=coverage/sonar-coverage.xml
 # - crates/dp-event/src/pg_store.rs — requires a live Postgres instance.
 #   Exercised by tests/pg_store.rs which is gated on a runtime DATABASE_URL
 #   and runs in CI separately, not via the standard `cargo test` LCOV pass.
+# - crates/dp-event/src/pg_snapshot.rs — same as pg_store.rs: all methods
+#   require a live Postgres connection via sqlx. Exercised by the same
+#   DATABASE_URL-gated CI job, not the standard `cargo test` LCOV pass.
+# - crates/dp-engine/benches/recover.rs — criterion benchmark. Not compiled
+#   or executed by `cargo test`; coverage tooling never instruments it.
 # - crates/dp-api/src/observability.rs — installs process-global metrics +
 #   tracing subscribers. The env-resolution helpers are extracted and unit
 #   tested; the remaining lines wire up the actual OTLP exporter / batch
 #   provider, which need a live OTel collector to drive coverage.
-sonar.coverage.exclusions=crates/dp-zk-cli/src/bin/**,crates/dp-zk-cli/src/cli.rs,crates/dp-api/src/main.rs,crates/dp-event/src/pg_store.rs,crates/dp-api/src/observability.rs
+sonar.coverage.exclusions=crates/dp-zk-cli/src/bin/**,crates/dp-zk-cli/src/cli.rs,crates/dp-api/src/main.rs,crates/dp-event/src/pg_store.rs,crates/dp-api/src/observability.rs,crates/dp-event/src/pg_snapshot.rs,crates/dp-engine/benches/recover.rs
 
 sonar.cpd.minimumTokens=50
 sonar.cpd.minimumLines=10


### PR DESCRIPTION
Closes #25

## Summary
- Adds a `SnapshotStore` trait (mem/file/postgres backends) alongside the existing `Store`, plus `Store::compact_before` so historical events can be safely deleted once a snapshot covers them.
- Introduces a snapshot envelope codec (magic + version + seq + length + SHA-256 + bincode payload) and a periodic `Snapshotter` task that captures projection state under the engine mutex, then writes / compacts / prunes off-lock.
- Wires snapshot loading into `Engine::recover`: walks retained snapshots descending so a corrupt latest does not strand boot, and replays only events past the chosen snapshot. Guards a hard-error edge case (every snapshot bad **and** event log compacted past seq 1) instead of silently rebuilding contradictory state.
- Exposes six clap flags (`--snapshot-enabled`, `--snapshot-dir`, `--snapshot-every-events`, `--snapshot-interval`, `--snapshot-retain-events`, `--snapshot-retain-count`) and spawns the Snapshotter alongside the auction tick under the shared `CancellationToken`.

## Atomic commit structure
1. `compact_before` trait method + MemStore
2. `SnapshotStore` trait + `MemSnapshotStore`
3. FileStore compaction (atomic tmp+rename)
4. FileSnapshotStore
5. Postgres compaction + `PgSnapshotStore` + migration `0002_snapshots.sql`
6. `Serialize/Deserialize` on `Match` and `SettlementMatch`
7. `BookSnapshot` + `OrderBook::{to_snapshot,restore_from,applied_seq}`
8. `SerializableState` + serde on engine state (skips `Instant` runtime fields)
9. Envelope codec + `Snapshotter` task + Engine wiring
10. Snapshot loading inside `recover()` with multi-snapshot retry
11. dp-api config flags + main wiring
12. Snapshot recovery tests + criterion benchmark
13. Cargo.lock for criterion deps

## Test plan
- [x] `cargo test --workspace --lib` — 327 passed
- [x] `cargo build --workspace --all-targets`
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --no-deps` — no issues
- [x] `cargo bench --bench recover -p dp-engine -- --sample-size 10 --warm-up-time 1 --measurement-time 5` — both `full_replay` and `from_snapshot` paths run end-to-end (1 000 events default; bump `EVENTS` const for the 100k repro)
- [ ] Postgres backend exercised via `DARKPOOL_TEST_PG_URL=... cargo test -p dp-event --features postgres` (no local PG available in this session)
- [ ] Manual smoke: `DARKPOOL_EVENT_BACKEND=file DARKPOOL_EVENT_LOG=/tmp/dp.log DARKPOOL_SNAPSHOT_DIR=/tmp/dp.snap DARKPOOL_SNAPSHOT_EVERY_EVENTS=100 cargo run -p dp-api`, submit ≥100 orders, restart, observe `recovered from snapshot seq=…` log line

## Known limitations
- A snapshot taken between an `OrderMatched` persist and the matching `finalize_pending_batch` (during async proof aggregation) can leave a post-restart `PendingBatch` with empty `matches`. The existing zero-public-inputs poison check in `submit_batch` blocks the bad submission; the operator gets a loud error and resolves manually. Documented inline near the `pending_batches.contains_key` guard in `recover.rs`.
- Bench default at 1 000 events does not visibly separate `full_replay` from `from_snapshot` because per-iteration tokio/setup overhead dominates; scale `EVENTS` (and `--measurement-time`) to surface the gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Periodic configurable state snapshots with retention and trigger controls
  * Faster recovery via snapshot + tail replay; snapshot persistence for order-book state
  * Event-log compaction to keep a tail and reduce disk usage
  * Multiple snapshot backends supported (file, PostgreSQL, in-memory)

* **Tests**
  * Extensive snapshot recovery regression suite and property tests
  * Recovery performance benchmark added

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->