### PR TITLE
[F1.12] Onboarding + empty/error/skeleton states everywhere

### DIFF
--- a/front/app/app/_components/onboarding/OnboardingDialog.stories.tsx
+++ b/front/app/app/_components/onboarding/OnboardingDialog.stories.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react'
+
+import { OnboardingDialog, OnboardingPanel } from './OnboardingDialog'
+
+// Ladle: the panel renders inline (no portal). Use this view to inspect
+// the layout, step-indicator accent, and footer button states at each
+// step without involving Radix's Portal.
+export const PanelStep01 = () => (
+  <div className="max-w-xl border border-brand-border bg-brand-surface p-8">
+    <OnboardingPanel
+      step={0}
+      onBack={() => undefined}
+      onNext={() => undefined}
+      onDismiss={() => undefined}
+    />
+  </div>
+)
+
+export const PanelStep02 = () => (
+  <div className="max-w-xl border border-brand-border bg-brand-surface p-8">
+    <OnboardingPanel
+      step={1}
+      onBack={() => undefined}
+      onNext={() => undefined}
+      onDismiss={() => undefined}
+    />
+  </div>
+)
+
+export const PanelStep03 = () => (
+  <div className="max-w-xl border border-brand-border bg-brand-surface p-8">
+    <OnboardingPanel
+      step={2}
+      onBack={() => undefined}
+      onNext={() => undefined}
+      onDismiss={() => undefined}
+    />
+  </div>
+)
+
+// Full Radix dialog story — drives the open state from a button so the
+// portal + overlay + close affordance all render in their final form.
+export const DialogInteractive = () => {
+  const [open, setOpen] = React.useState(true)
+  return (
+    <div className="flex h-screen items-center justify-center bg-brand-bg">
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="border border-brand-border2 px-4 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-fg hover:border-brand-fg"
+      >
+        [ OPEN ONBOARDING ]
+      </button>
+      <OnboardingDialog open={open} onDismiss={() => setOpen(false)} />
+    </div>
+  )
+}

--- a/front/app/app/_components/onboarding/OnboardingDialog.test.tsx
+++ b/front/app/app/_components/onboarding/OnboardingDialog.test.tsx
@@ -1,0 +1,121 @@
+// Render-shape tests for the onboarding panel. Radix `<Dialog>` portals
+// into the DOM and emits no markup under `renderToStaticMarkup`, so we
+// test the pure `<OnboardingPanel>` (which is also what `<Dialog>` ends
+// up rendering inside the portal). Interactive behaviour (open/close,
+// back/next chain) is exercised in the Ladle stories.
+
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { OnboardingPanel } from './OnboardingDialog'
+import {
+  ONBOARDING_BACK_LABEL,
+  ONBOARDING_DONE_LABEL,
+  ONBOARDING_NEXT_LABEL,
+  ONBOARDING_STEPS,
+} from './copy'
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+function panel(step: number) {
+  return <OnboardingPanel step={step} onBack={vi.fn()} onNext={vi.fn()} onDismiss={vi.fn()} />
+}
+
+describe('OnboardingPanel', () => {
+  it('renders all three step indicators at every step', () => {
+    for (const step of [0, 1, 2]) {
+      const html = render(panel(step))
+      expect(html).toContain('01')
+      expect(html).toContain('02')
+      expect(html).toContain('03')
+    }
+  })
+
+  it('uses the lime accent only on the current step indicator', () => {
+    const html = render(panel(1))
+    // Each step renders inside a separate <li>. The current one carries
+    // both `border-brand-accent` and `text-brand-accent`; the others
+    // carry `border-brand-border` / `border-brand-border2` and muted
+    // or fg text. Count accent hits — there should be exactly two
+    // (border + text on the one current node).
+    const accentHits = html.match(/brand-accent/g) ?? []
+    expect(accentHits.length).toBe(2)
+  })
+
+  it('marks the current step with aria-current="step"', () => {
+    const html = render(panel(1))
+    const currentMatches = html.match(/aria-current="step"/g) ?? []
+    expect(currentMatches.length).toBe(1)
+  })
+
+  it('renders the step kicker, title, and body for step 0', () => {
+    const html = render(panel(0))
+    expect(html).toContain(ONBOARDING_STEPS[0].kicker)
+    expect(html).toContain(ONBOARDING_STEPS[0].title)
+    expect(html).toContain(ONBOARDING_STEPS[0].body[0])
+  })
+
+  it('renders the step body for the middle step', () => {
+    const html = render(panel(1))
+    expect(html).toContain(ONBOARDING_STEPS[1].title)
+  })
+
+  it('shows the optional meta line when the step defines one', () => {
+    const html = render(panel(0))
+    expect(html).toContain('Batch cadence: 5 s.')
+  })
+
+  it('disables the back button on the first step', () => {
+    const html = render(panel(0))
+    // Locate the BACK button: its opening tag through the label text.
+    const backStart = html.indexOf(ONBOARDING_BACK_LABEL)
+    expect(backStart).toBeGreaterThan(-1)
+    const before = html.slice(0, backStart)
+    const lastButton = before.lastIndexOf('<button')
+    expect(lastButton).toBeGreaterThan(-1)
+    const buttonTag = before.slice(lastButton)
+    expect(buttonTag).toMatch(/disabled=""/)
+  })
+
+  it('enables the back button on a later step', () => {
+    const html = render(panel(1))
+    const backStart = html.indexOf(ONBOARDING_BACK_LABEL)
+    expect(backStart).toBeGreaterThan(-1)
+    const before = html.slice(0, backStart)
+    const lastButton = before.lastIndexOf('<button')
+    expect(lastButton).toBeGreaterThan(-1)
+    const buttonTag = before.slice(lastButton)
+    expect(buttonTag).not.toMatch(/disabled=""/)
+  })
+
+  it('shows the NEXT label on intermediate steps', () => {
+    const html = render(panel(0))
+    expect(html).toContain(ONBOARDING_NEXT_LABEL)
+    expect(html).not.toContain(ONBOARDING_DONE_LABEL)
+  })
+
+  it('promotes the primary CTA to START TRADING on the last step', () => {
+    const html = render(panel(2))
+    expect(html).toContain(ONBOARDING_DONE_LABEL)
+    expect(html).not.toContain(ONBOARDING_NEXT_LABEL)
+    // The lime CTA carries `bg-brand-accent`. This is the dialog's accent
+    // budget when on the final step; the step-node accent has already
+    // walked to step 03 at this point.
+    expect(html).toContain('bg-brand-accent')
+  })
+
+  it('clamps step out-of-range to the nearest valid index', () => {
+    const negative = render(
+      <OnboardingPanel step={-3} onBack={vi.fn()} onNext={vi.fn()} onDismiss={vi.fn()} />
+    )
+    expect(negative).toContain(ONBOARDING_STEPS[0].title)
+
+    const tooFar = render(
+      <OnboardingPanel step={99} onBack={vi.fn()} onNext={vi.fn()} onDismiss={vi.fn()} />
+    )
+    expect(tooFar).toContain(ONBOARDING_STEPS[2].title)
+  })
+})

--- a/front/app/app/_components/onboarding/OnboardingDialog.tsx
+++ b/front/app/app/_components/onboarding/OnboardingDialog.tsx
@@ -1,0 +1,209 @@
+'use client'
+
+import * as React from 'react'
+import * as DialogPrimitive from '@radix-ui/react-dialog'
+
+import { Dialog, DialogContent } from '@/components/ui/dialog'
+import { cn } from '@/components/ui/cn'
+
+import {
+  ONBOARDING_BACK_LABEL,
+  ONBOARDING_DIALOG_DESCRIPTION,
+  ONBOARDING_DIALOG_TITLE,
+  ONBOARDING_DONE_LABEL,
+  ONBOARDING_NEXT_LABEL,
+  ONBOARDING_STEPS,
+  type OnboardingStep,
+} from './copy'
+
+/**
+ * Pure step indicator (`01 02 03`). The current step renders in the
+ * lime accent — this is the dialog's single accent budget. Past steps
+ * read as completed (`primary`); future steps read as inert (`muted`).
+ */
+function StepIndicator({ step }: { step: number }) {
+  return (
+    <ol aria-label="Onboarding progress" className="flex items-center gap-2">
+      {ONBOARDING_STEPS.map((s, i) => {
+        const status = i === step ? 'current' : i < step ? 'past' : 'future'
+        return (
+          <li
+            key={s.id}
+            aria-current={status === 'current' ? 'step' : undefined}
+            className={cn(
+              'flex h-[30px] min-w-[30px] items-center justify-center border px-2 font-mono text-label-md uppercase tracking-labelWide',
+              status === 'current' && 'border-brand-accent text-brand-accent',
+              status === 'past' && 'border-brand-border2 text-brand-fg',
+              status === 'future' && 'border-brand-border text-brand-muted'
+            )}
+          >
+            {s.id}
+          </li>
+        )
+      })}
+    </ol>
+  )
+}
+
+function StepBody({ step }: { step: OnboardingStep }) {
+  return (
+    <div className="flex flex-col gap-4">
+      <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+        {step.kicker}
+      </span>
+      <h2 className="font-display text-display-sm uppercase leading-none text-brand-fg">
+        {step.title}
+      </h2>
+      <div className="flex flex-col gap-3">
+        {step.body.map((p, i) => (
+          <p key={i} className="font-mono text-body-md text-brand-fg">
+            {p}
+          </p>
+        ))}
+      </div>
+      {step.meta ? (
+        <p className="font-mono text-body-sm uppercase tracking-label text-brand-muted">
+          {step.meta}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+export interface OnboardingPanelProps {
+  /** 0-indexed current step. */
+  step: number
+  onBack: () => void
+  onNext: () => void
+  onDismiss: () => void
+  /** Total steps. Defaults to ONBOARDING_STEPS.length. */
+  totalSteps?: number
+}
+
+/**
+ * The dialog body, without the Radix `<Dialog>` chrome. Exported so
+ * tests can render it via `renderToStaticMarkup` — Radix's Portal-based
+ * `<DialogContent>` emits no markup in SSR, so the dialog wrapper would
+ * leave the test with an empty string. The portal-free panel is also
+ * usable in Ladle stories that just want to inspect the layout.
+ */
+export function OnboardingPanel({
+  step,
+  onBack,
+  onNext,
+  onDismiss,
+  totalSteps = ONBOARDING_STEPS.length,
+}: OnboardingPanelProps) {
+  const safeStep = Math.max(0, Math.min(step, totalSteps - 1))
+  const current = ONBOARDING_STEPS[safeStep]
+  const isFirst = safeStep === 0
+  const isLast = safeStep === totalSteps - 1
+  return (
+    <div className="flex flex-col gap-6">
+      <header className="flex flex-col gap-3">
+        <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+          {ONBOARDING_DIALOG_TITLE}
+        </span>
+        <StepIndicator step={safeStep} />
+      </header>
+      <StepBody step={current} />
+      <footer className="flex items-center justify-between gap-3 border-t border-brand-border pt-5">
+        <button
+          type="button"
+          onClick={onBack}
+          disabled={isFirst}
+          className={cn(
+            'border border-brand-border2 px-4 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-fg transition-colors',
+            'hover:border-brand-fg focus-visible:border-brand-fg focus-visible:outline-none',
+            'disabled:cursor-not-allowed disabled:border-brand-border disabled:text-brand-muted'
+          )}
+        >
+          {ONBOARDING_BACK_LABEL}
+        </button>
+        {isLast ? (
+          <button
+            type="button"
+            onClick={onDismiss}
+            className={cn(
+              'bg-brand-accent px-6 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-on-accent',
+              'transition-shadow hover:shadow-accent-glow focus-visible:shadow-accent-glow focus-visible:outline-none'
+            )}
+          >
+            {ONBOARDING_DONE_LABEL}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={onNext}
+            className={cn(
+              'border border-brand-border2 px-4 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-fg transition-colors',
+              'hover:border-brand-fg focus-visible:border-brand-fg focus-visible:outline-none'
+            )}
+          >
+            {ONBOARDING_NEXT_LABEL}
+          </button>
+        )}
+      </footer>
+    </div>
+  )
+}
+
+export interface OnboardingDialogProps {
+  /** Controlled open flag. */
+  open: boolean
+  /** Called when the user dismisses (close icon, `[ START TRADING ]`, or Esc). */
+  onDismiss: () => void
+}
+
+/**
+ * Radix-wrapped onboarding modal. Renders only when `open` is true; the
+ * Portal mounts under the document body, so this component is
+ * pre-hydration safe (the `OnboardingMount` host gates it on
+ * `isReady`).
+ */
+export function OnboardingDialog({ open, onDismiss }: OnboardingDialogProps) {
+  const [step, setStep] = React.useState(0)
+  const totalSteps = ONBOARDING_STEPS.length
+
+  // Reset to step 0 each time the dialog opens so a re-trigger starts
+  // from the beginning. We intentionally do NOT reset on close so the
+  // final-screen exit animation can play with the right step.
+  React.useEffect(() => {
+    if (open) setStep(0)
+  }, [open])
+
+  const handleOpenChange = React.useCallback(
+    (next: boolean) => {
+      if (!next) onDismiss()
+    },
+    [onDismiss]
+  )
+
+  const handleBack = React.useCallback(() => {
+    setStep((s) => Math.max(0, s - 1))
+  }, [])
+  const handleNext = React.useCallback(() => {
+    setStep((s) => Math.min(totalSteps - 1, s + 1))
+  }, [totalSteps])
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        aria-label={ONBOARDING_DIALOG_TITLE}
+        className="max-w-xl border border-brand-border"
+      >
+        <DialogPrimitive.Title className="sr-only">{ONBOARDING_DIALOG_TITLE}</DialogPrimitive.Title>
+        <DialogPrimitive.Description className="sr-only">
+          {ONBOARDING_DIALOG_DESCRIPTION}
+        </DialogPrimitive.Description>
+        <OnboardingPanel
+          step={step}
+          onBack={handleBack}
+          onNext={handleNext}
+          onDismiss={onDismiss}
+          totalSteps={totalSteps}
+        />
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/front/app/app/_components/onboarding/OnboardingMount.tsx
+++ b/front/app/app/_components/onboarding/OnboardingMount.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import * as React from 'react'
+import { useAccount } from 'wagmi'
+
+import { OnboardingDialog } from './OnboardingDialog'
+import { useOnboardingDismiss } from './useOnboardingDismiss'
+
+/**
+ * Layout-level host that decides whether the onboarding modal renders.
+ *
+ * Rules:
+ *  - The dialog opens once we have read storage (`isReady`) AND the
+ *    user has not dismissed it for the current bucket (per-wallet
+ *    when connected; anon otherwise).
+ *  - We do not unmount on dismiss — the close animation plays on
+ *    `open=false`. The dismissed flag is persisted before `open`
+ *    flips so a hard reload does not see the modal again.
+ *  - When the wallet later connects, the anon dismissal is promoted
+ *    forward inside `useOnboardingDismiss`, so connecting does not
+ *    re-trigger the modal.
+ */
+export function OnboardingMount() {
+  const { address } = useAccount()
+  const { isReady, dismissed, dismiss } = useOnboardingDismiss({
+    address: address ?? null,
+  })
+  const [open, setOpen] = React.useState(false)
+
+  React.useEffect(() => {
+    if (!isReady) return
+    if (dismissed) {
+      setOpen(false)
+      return
+    }
+    setOpen(true)
+  }, [isReady, dismissed])
+
+  const handleDismiss = React.useCallback(() => {
+    dismiss()
+    setOpen(false)
+  }, [dismiss])
+
+  return <OnboardingDialog open={open} onDismiss={handleDismiss} />
+}

--- a/front/app/app/_components/onboarding/copy.ts
+++ b/front/app/app/_components/onboarding/copy.ts
@@ -1,0 +1,63 @@
+/**
+ * Copy for the three onboarding steps. Tone follows DESIGN-INSPIRATIONS:
+ *  - Sentence case, no marketing voice, no exclamation marks.
+ *  - Borrows the batch-auction explainer from CoW Swap (sec. "Direct
+ *    genre peers"). Same protocol property, same vocabulary.
+ *  - Steps lead with the property, then the consequence the trader feels.
+ *
+ * Step IDs are 1-indexed so the rendered `step-node` reads as `01`, `02`,
+ * `03` per the design token.
+ */
+
+export interface OnboardingStep {
+  /** Two-digit zero-padded id rendered inside the step-node. */
+  id: '01' | '02' | '03'
+  /** Bracketed-tag kicker above the title, e.g. `[ STEP 01 · PROTOCOL ]`. */
+  kicker: string
+  /** Display headline (Bebas Neue uppercase). */
+  title: string
+  /** Body paragraphs (sentence case, IBM Plex Mono). */
+  body: readonly string[]
+  /** Optional metadata line in `body-sm` (e.g. cadence or duration). */
+  meta?: string
+}
+
+export const ONBOARDING_STEPS: readonly OnboardingStep[] = [
+  {
+    id: '01',
+    kicker: '[ STEP 01 · PROTOCOL ]',
+    title: 'BATCH AUCTIONS',
+    body: [
+      'Orders sit encrypted in a sealed batch. Every five seconds the engine clears the batch at a single price.',
+      'Everyone in the same batch trades at the same price, so there is no race to be first and no value to extract by sequencing the queue.',
+    ],
+    meta: 'Batch cadence: 5 s.',
+  },
+  {
+    id: '02',
+    kicker: '[ STEP 02 · CUSTODY ]',
+    title: 'OPERATOR CUSTODY',
+    body: [
+      'Deposit ERC-20 tokens to the DarkPool contract before trading. Balances are tracked inside the contract; the operator never holds funds on a centralized server.',
+      'Withdraw at any time. Settlement of every batch is proven on-chain with a zero-knowledge proof — the operator cannot move funds outside the matched trades.',
+    ],
+    meta: 'On-chain settlement, off-chain matching.',
+  },
+  {
+    id: '03',
+    kicker: '[ STEP 03 · PROVING ]',
+    title: 'PROOF IN THE BROWSER',
+    body: [
+      'Submitting an order builds a zero-knowledge proof of validity in this tab before it leaves your machine. That keeps your price and size hidden from the operator and from any external observer until the batch settles.',
+      'Proof generation runs locally and takes roughly fifteen to thirty seconds. The submit button reports each stage so you can watch it progress.',
+    ],
+    meta: 'Local proving time: ~15–30 s.',
+  },
+]
+
+export const ONBOARDING_BACK_LABEL = '[ BACK ]'
+export const ONBOARDING_NEXT_LABEL = '[ NEXT ]'
+export const ONBOARDING_DONE_LABEL = '[ START TRADING ]'
+export const ONBOARDING_DIALOG_TITLE = 'Welcome to DarkPool.'
+export const ONBOARDING_DIALOG_DESCRIPTION =
+  'Three things to know before you place an order. Skip with the close icon at any time.'

--- a/front/app/app/_components/onboarding/index.ts
+++ b/front/app/app/_components/onboarding/index.ts
@@ -1,0 +1,11 @@
+export { OnboardingDialog, OnboardingPanel } from './OnboardingDialog'
+export { OnboardingMount } from './OnboardingMount'
+export { ONBOARDING_STEPS } from './copy'
+export { useOnboardingDismiss } from './useOnboardingDismiss'
+export {
+  isDismissed,
+  setDismissed,
+  clearDismissed,
+  promoteAnonToAddress,
+  type StorageLike,
+} from './storage'

--- a/front/app/app/_components/onboarding/storage.test.ts
+++ b/front/app/app/_components/onboarding/storage.test.ts
@@ -63,6 +63,20 @@ describe('onboarding storage', () => {
     expect(isDismissed(storage, '0xabc')).toBe(false)
   })
 
+  it('mirrors a connected-address dismissal forward to the anon bucket', () => {
+    // The user's "I've seen this" intent is wallet-agnostic; the keys
+    // are not. Mirror at write time so a later disconnect does not
+    // re-pop the modal.
+    setDismissed(storage, '0xabc')
+    expect(isDismissed(storage, '0xabc')).toBe(true)
+    expect(isDismissed(storage, null)).toBe(true)
+  })
+
+  it('does not touch other address buckets when mirroring', () => {
+    setDismissed(storage, '0xabc')
+    expect(isDismissed(storage, '0xdef')).toBe(false)
+  })
+
   describe('promoteAnonToAddress', () => {
     it('copies an anon-bucket dismissal to the connecting address', () => {
       setDismissed(storage, null)

--- a/front/app/app/_components/onboarding/storage.test.ts
+++ b/front/app/app/_components/onboarding/storage.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  clearDismissed,
+  isDismissed,
+  promoteAnonToAddress,
+  setDismissed,
+  type StorageLike,
+} from './storage'
+
+function inMemoryStorage(): StorageLike {
+  const map = new Map<string, string>()
+  return {
+    getItem: (k) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k, v) => {
+      map.set(k, v)
+    },
+    removeItem: (k) => {
+      map.delete(k)
+    },
+  }
+}
+
+describe('onboarding storage', () => {
+  let storage: StorageLike
+
+  beforeEach(() => {
+    storage = inMemoryStorage()
+  })
+
+  it('is not dismissed by default for any bucket', () => {
+    expect(isDismissed(storage, null)).toBe(false)
+    expect(isDismissed(storage, '0xabc')).toBe(false)
+    expect(isDismissed(storage, '')).toBe(false)
+  })
+
+  it('persists dismissal for the connected address', () => {
+    setDismissed(storage, '0xAbC123')
+    expect(isDismissed(storage, '0xAbC123')).toBe(true)
+  })
+
+  it('treats addresses case-insensitively', () => {
+    setDismissed(storage, '0xAbC123')
+    expect(isDismissed(storage, '0xabc123')).toBe(true)
+    expect(isDismissed(storage, '0xABC123')).toBe(true)
+  })
+
+  it('isolates buckets per address', () => {
+    setDismissed(storage, '0xaaa')
+    expect(isDismissed(storage, '0xaaa')).toBe(true)
+    expect(isDismissed(storage, '0xbbb')).toBe(false)
+  })
+
+  it('uses an anon bucket when no wallet is connected', () => {
+    setDismissed(storage, null)
+    expect(isDismissed(storage, null)).toBe(true)
+    expect(isDismissed(storage, '0xabc')).toBe(false)
+  })
+
+  it('clears the per-address flag', () => {
+    setDismissed(storage, '0xabc')
+    clearDismissed(storage, '0xabc')
+    expect(isDismissed(storage, '0xabc')).toBe(false)
+  })
+
+  describe('promoteAnonToAddress', () => {
+    it('copies an anon-bucket dismissal to the connecting address', () => {
+      setDismissed(storage, null)
+      promoteAnonToAddress(storage, '0xAbC')
+      expect(isDismissed(storage, '0xAbC')).toBe(true)
+    })
+
+    it('does nothing when there is no anon dismissal', () => {
+      promoteAnonToAddress(storage, '0xAbC')
+      expect(isDismissed(storage, '0xAbC')).toBe(false)
+    })
+
+    it('does nothing for an empty address', () => {
+      setDismissed(storage, null)
+      promoteAnonToAddress(storage, '')
+      // anon bucket survives, but no address bucket was touched.
+      expect(isDismissed(storage, null)).toBe(true)
+    })
+  })
+})

--- a/front/app/app/_components/onboarding/storage.ts
+++ b/front/app/app/_components/onboarding/storage.ts
@@ -40,6 +40,14 @@ export function isDismissed(storage: StorageLike, address: string | null | undef
 
 export function setDismissed(storage: StorageLike, address: string | null | undefined): void {
   storage.setItem(keyFor(address), FLAG)
+  // Mirror to the anon bucket so a subsequent disconnect doesn't pop the
+  // modal again. This is the symmetric counterpart to
+  // `promoteAnonToAddress`: the user's intent ("I've seen this") is
+  // wallet-agnostic, but the storage keys are wallet-specific, so we
+  // keep both buckets in sync at write time.
+  if (normalize(address) !== ANON_KEY) {
+    storage.setItem(PREFIX + ANON_KEY, FLAG)
+  }
 }
 
 export function clearDismissed(storage: StorageLike, address: string | null | undefined): void {

--- a/front/app/app/_components/onboarding/storage.ts
+++ b/front/app/app/_components/onboarding/storage.ts
@@ -1,0 +1,58 @@
+/**
+ * Persistence for the first-run onboarding modal.
+ *
+ * Acceptance criterion: "Dismiss persists per wallet." We key the
+ * dismissal flag by lowercased wallet address; when no wallet is yet
+ * connected we still need a usable bucket so the modal does not
+ * re-pop on every reload of the disconnected app, so we fall back to
+ * an `anon` bucket. The on-connect transition can promote the anon
+ * dismissal to the address-keyed entry — see `promoteAnonToAddress`.
+ *
+ * The module is intentionally storage-adapter shaped (it takes a
+ * `Storage`-like object, not `window.localStorage` directly) so the
+ * pure helpers stay unit-testable in node without a JSDOM environment.
+ * The runtime call sites pass `window.localStorage`; tests pass an
+ * in-memory `Map`-backed adapter (see storage.test.ts).
+ */
+
+const PREFIX = 'dp:onboarding-dismissed:'
+const ANON_KEY = 'anon'
+const FLAG = '1'
+
+export interface StorageLike {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+  removeItem(key: string): void
+}
+
+function normalize(address: string | null | undefined): string {
+  if (!address) return ANON_KEY
+  return address.toLowerCase()
+}
+
+function keyFor(address: string | null | undefined): string {
+  return PREFIX + normalize(address)
+}
+
+export function isDismissed(storage: StorageLike, address: string | null | undefined): boolean {
+  return storage.getItem(keyFor(address)) === FLAG
+}
+
+export function setDismissed(storage: StorageLike, address: string | null | undefined): void {
+  storage.setItem(keyFor(address), FLAG)
+}
+
+export function clearDismissed(storage: StorageLike, address: string | null | undefined): void {
+  storage.removeItem(keyFor(address))
+}
+
+/**
+ * When the wallet connects, copy any prior anon-bucket dismissal forward
+ * so the user doesn't see the modal again as soon as they connect.
+ * No-op when there is no prior anon dismissal or the address is empty.
+ */
+export function promoteAnonToAddress(storage: StorageLike, address: string): void {
+  if (!address) return
+  if (storage.getItem(PREFIX + ANON_KEY) !== FLAG) return
+  storage.setItem(keyFor(address), FLAG)
+}

--- a/front/app/app/_components/onboarding/useOnboardingDismiss.ts
+++ b/front/app/app/_components/onboarding/useOnboardingDismiss.ts
@@ -1,0 +1,79 @@
+'use client'
+
+import * as React from 'react'
+
+import {
+  type StorageLike,
+  isDismissed as readDismissed,
+  promoteAnonToAddress,
+  setDismissed,
+} from './storage'
+
+export interface UseOnboardingDismissOptions {
+  /** Address of the connected wallet, or null if disconnected. */
+  address: string | null
+  /** Injectable storage adapter — defaults to `window.localStorage`. */
+  storage?: StorageLike | null
+}
+
+export interface UseOnboardingDismissReturn {
+  /** True once we have read the browser storage (post-hydration). */
+  isReady: boolean
+  /** True iff the user has dismissed onboarding for the current bucket. */
+  dismissed: boolean
+  /** Persist the dismissal for the current bucket. */
+  dismiss: () => void
+}
+
+function getDefaultStorage(): StorageLike | null {
+  if (typeof window === 'undefined') return null
+  try {
+    return window.localStorage
+  } catch {
+    // Safari private mode + sandboxed iframes throw on access.
+    return null
+  }
+}
+
+/**
+ * Reads (and writes) the dismissal flag for the connected wallet. When
+ * the wallet is disconnected the hook reads/writes an `anon` bucket;
+ * when a wallet connects after an anon dismissal the flag is promoted
+ * forward so the modal does not re-pop.
+ *
+ * Returns `isReady=false` during SSR and the first client commit so
+ * callers can gate the modal mount on a stable client-side state and
+ * avoid hydration mismatch.
+ */
+export function useOnboardingDismiss({
+  address,
+  storage,
+}: UseOnboardingDismissOptions): UseOnboardingDismissReturn {
+  const resolvedStorage = storage === undefined ? getDefaultStorage() : storage
+  const [isReady, setIsReady] = React.useState(false)
+  const [dismissed, setDismissedState] = React.useState(false)
+
+  // Initial read after hydration so we never disagree with SSR markup.
+  React.useEffect(() => {
+    if (!resolvedStorage) {
+      setIsReady(true)
+      return
+    }
+    if (address) {
+      promoteAnonToAddress(resolvedStorage, address)
+    }
+    setDismissedState(readDismissed(resolvedStorage, address))
+    setIsReady(true)
+  }, [resolvedStorage, address])
+
+  const dismiss = React.useCallback(() => {
+    if (!resolvedStorage) {
+      setDismissedState(true)
+      return
+    }
+    setDismissed(resolvedStorage, address)
+    setDismissedState(true)
+  }, [resolvedStorage, address])
+
+  return { isReady, dismissed, dismiss }
+}

--- a/front/app/app/layout.tsx
+++ b/front/app/app/layout.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { WalletProviders } from '@/lib/wallet'
 import { ConnectButton } from './_components/ConnectButton'
+import { OnboardingMount } from './_components/onboarding'
 import { AuctionStrip } from './_shell/AuctionStrip'
 import { ArbitrumHex } from './_shell/icons'
 import { PairSelector } from './_shell/PairSelector'
@@ -27,6 +28,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <Banner />
         <Rail />
         <main className="pt-16 lg:pl-56">{children}</main>
+        <OnboardingMount />
       </div>
     </WalletProviders>
   )

--- a/front/app/app/layout.tsx
+++ b/front/app/app/layout.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { Toaster } from '@/components/ui/toaster'
 import { WalletProviders } from '@/lib/wallet'
 import { ConnectButton } from './_components/ConnectButton'
 import { OnboardingMount } from './_components/onboarding'
@@ -29,6 +30,7 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
         <Rail />
         <main className="pt-16 lg:pl-56">{children}</main>
         <OnboardingMount />
+        <Toaster />
       </div>
     </WalletProviders>
   )

--- a/front/app/app/portfolio/_components/FillHistoryTable.tsx
+++ b/front/app/app/portfolio/_components/FillHistoryTable.tsx
@@ -6,6 +6,7 @@ import type { Fill } from '@/lib/mock-store'
 
 import { ExportCsvButton } from './ExportCsvButton'
 import { FillHistoryRow } from './FillHistoryRow'
+import { FillHistoryEmpty } from './states'
 
 export interface FillHistoryTableProps {
   fills: readonly Fill[]
@@ -20,7 +21,7 @@ export function FillHistoryTable({ fills }: FillHistoryTableProps): JSX.Element 
       <TableTitleBar count={fills.length} fills={fills} />
       <TableHeader />
       {fills.length === 0 ? (
-        <EmptyState />
+        <FillHistoryEmpty />
       ) : (
         <ol className="flex-1 overflow-y-auto">
           {fills.map((f) => (
@@ -54,19 +55,6 @@ function TableHeader() {
       <span className="text-right">PRICE</span>
       <span className="text-right">SIZE</span>
       <span className="text-right">BATCH</span>
-    </div>
-  )
-}
-
-function EmptyState() {
-  return (
-    <div className="flex flex-1 items-center justify-center px-4 py-12">
-      <p
-        role="status"
-        className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
-      >
-        [ NO FILLS YET — PLACE AN ORDER ON /APP/TRADE ]
-      </p>
     </div>
   )
 }

--- a/front/app/app/portfolio/_components/PortfolioPanel.tsx
+++ b/front/app/app/portfolio/_components/PortfolioPanel.tsx
@@ -34,7 +34,7 @@ export function PortfolioPanel(): JSX.Element {
       ) : (
         <section
           aria-label="Wallet disconnected"
-          className="border border-brand-border bg-brand-surface px-5 py-6"
+          className="border border-brand-border bg-brand-surface"
         >
           <PortfolioDisconnected />
         </section>

--- a/front/app/app/portfolio/_components/PortfolioPanel.tsx
+++ b/front/app/app/portfolio/_components/PortfolioPanel.tsx
@@ -7,6 +7,7 @@ import { useInternalBalances, useWallet } from '@/lib/wallet/hooks'
 import { DivergenceBanner } from './DivergenceBanner'
 import { FillHistoryTable } from './FillHistoryTable'
 import { PnLCard } from './PnLCard'
+import { PortfolioDisconnected } from './states'
 import { usePortfolio } from '../_hooks/usePortfolio'
 
 /**
@@ -31,7 +32,12 @@ export function PortfolioPanel(): JSX.Element {
           <DivergenceBanner result={divergence} />
         </>
       ) : (
-        <Disconnected />
+        <section
+          aria-label="Wallet disconnected"
+          className="border border-brand-border bg-brand-surface px-5 py-6"
+        >
+          <PortfolioDisconnected />
+        </section>
       )}
       <FillHistoryTable fills={fills} />
     </div>
@@ -46,21 +52,5 @@ function PageHeader() {
       </span>
       <h1 className="font-display text-display-md tracking-brand text-brand-fg">POSITIONS</h1>
     </header>
-  )
-}
-
-function Disconnected() {
-  return (
-    <section
-      aria-label="Wallet disconnected"
-      className="border border-brand-border bg-brand-surface px-5 py-6"
-    >
-      <p
-        role="status"
-        className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
-      >
-        [ CONNECT WALLET TO SEE POSITION + P&L ]
-      </p>
-    </section>
   )
 }

--- a/front/app/app/portfolio/_components/states.test.tsx
+++ b/front/app/app/portfolio/_components/states.test.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import {
+  FillHistoryEmpty,
+  FillHistoryError,
+  FillHistoryLoading,
+  PortfolioDisconnected,
+  PortfolioError,
+  PortfolioStatsLoading,
+} from './states'
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+describe('portfolio state primitives', () => {
+  it('Disconnected surfaces the wallet prompt', () => {
+    const html = render(<PortfolioDisconnected />)
+    // React encodes `&` to `&amp;` in SSR markup.
+    expect(html).toContain('[ CONNECT WALLET TO SEE POSITION + P&amp;L ]')
+  })
+
+  it('PortfolioStatsLoading renders one row of three stat skeletons', () => {
+    const html = render(<PortfolioStatsLoading />)
+    const spans = html.match(/<span/g) ?? []
+    // 1 row * 3 cols = 3 + 1 sr-only span = 4
+    expect(spans.length).toBe(4)
+  })
+
+  it('FillHistoryLoading renders rows of five-column skeletons', () => {
+    const html = render(<FillHistoryLoading rows={2} />)
+    const spans = html.match(/<span/g) ?? []
+    // 2 rows * 5 cols = 10 + 1 sr-only span = 11
+    expect(spans.length).toBe(11)
+  })
+
+  it('FillHistoryEmpty surfaces the terse no-fills copy with a hint', () => {
+    const html = render(<FillHistoryEmpty />)
+    expect(html).toContain('[ NO FILLS YET ]')
+    expect(html).toContain('Place an order on /app/trade')
+  })
+
+  it('PortfolioError surfaces the unavailable label with a retry handler', () => {
+    const html = render(<PortfolioError message="sync failed" onRetry={vi.fn()} />)
+    expect(html).toContain('[ PORTFOLIO UNAVAILABLE ]')
+    expect(html).toContain('sync failed')
+    expect(html).toContain('[ RETRY ]')
+  })
+
+  it('FillHistoryError surfaces the fill-history label', () => {
+    expect(render(<FillHistoryError />)).toContain('[ FILL HISTORY UNAVAILABLE ]')
+  })
+})

--- a/front/app/app/portfolio/_components/states.tsx
+++ b/front/app/app/portfolio/_components/states.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import * as React from 'react'
+
+import { BoxSkeletonBlock, PanelEmpty, PanelError } from '@/components/ui/panel-state'
+
+export function PortfolioStatsLoading() {
+  // Single line of 3 stat "values" — matches the WETH / USDC / P&L triplet.
+  return <BoxSkeletonBlock rows={1} cols={3} ariaLabel="Loading portfolio summary" />
+}
+
+export function FillHistoryLoading({ rows = 4 }: { rows?: number }) {
+  return <BoxSkeletonBlock rows={rows} cols={5} ariaLabel="Loading fill history" />
+}
+
+export function PortfolioDisconnected() {
+  return <PanelEmpty label="[ CONNECT WALLET TO SEE POSITION + P&L ]" />
+}
+
+export function FillHistoryEmpty() {
+  return (
+    <PanelEmpty
+      label="[ NO FILLS YET ]"
+      hint="Place an order on /app/trade to start your history."
+    />
+  )
+}
+
+export interface PortfolioErrorProps {
+  label?: string
+  message?: string
+  onRetry?: () => void
+}
+
+export function PortfolioError({
+  label = '[ PORTFOLIO UNAVAILABLE ]',
+  message,
+  onRetry,
+}: PortfolioErrorProps = {}) {
+  return <PanelError label={label} message={message} onRetry={onRetry} />
+}
+
+export function FillHistoryError({
+  label = '[ FILL HISTORY UNAVAILABLE ]',
+  message,
+  onRetry,
+}: PortfolioErrorProps = {}) {
+  return <PanelError label={label} message={message} onRetry={onRetry} />
+}

--- a/front/app/app/trade/_components/balances/BalancesPanel.tsx
+++ b/front/app/app/trade/_components/balances/BalancesPanel.tsx
@@ -6,6 +6,7 @@ import { NumericText } from '@/components/NumericText'
 import { useInternalBalances, useWallet, useWalletBalances } from '@/lib/wallet/hooks'
 import type { Balances, TokenSymbol } from '@/lib/wallet/types'
 import { displayDecimalsFor } from '../../_lib/balances/format-balance'
+import { BalancesDisconnected } from './states'
 
 const TOKEN_ROWS: readonly TokenSymbol[] = ['WETH', 'USDC']
 
@@ -23,7 +24,11 @@ export function BalancesPanel() {
       className="flex h-full flex-col border border-brand-border bg-brand-surface"
     >
       <Header id={headerId} />
-      {isConnected ? <BalancesGrid wallet={wallet} internal={internal} /> : <Disconnected />}
+      {isConnected ? (
+        <BalancesGrid wallet={wallet} internal={internal} />
+      ) : (
+        <BalancesDisconnected />
+      )}
     </section>
   )
 }
@@ -35,16 +40,6 @@ function Header({ id }: { id: string }) {
         [ BALANCES ]
       </span>
     </header>
-  )
-}
-
-function Disconnected() {
-  return (
-    <div className="flex flex-1 items-center justify-center p-6">
-      <p role="status" className="font-mono text-label-md uppercase text-brand-muted">
-        [ CONNECT WALLET ]
-      </p>
-    </div>
   )
 }
 

--- a/front/app/app/trade/_components/balances/states.test.tsx
+++ b/front/app/app/trade/_components/balances/states.test.tsx
@@ -1,0 +1,30 @@
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { BalancesDisconnected, BalancesError, BalancesLoading } from './states'
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+describe('balances state primitives', () => {
+  it('Loading renders one skeleton row per token (default 2 rows)', () => {
+    const html = render(<BalancesLoading />)
+    const spans = html.match(/<span/g) ?? []
+    // 2 rows * 3 cols = 6 + 1 sr-only span = 7
+    expect(spans.length).toBe(7)
+  })
+
+  it('Disconnected surfaces the connect-wallet label', () => {
+    const html = render(<BalancesDisconnected />)
+    expect(html).toContain('[ CONNECT WALLET ]')
+  })
+
+  it('Error surfaces the unavailable label + retry button', () => {
+    const html = render(<BalancesError message="rpc down" onRetry={vi.fn()} />)
+    expect(html).toContain('[ BALANCES UNAVAILABLE ]')
+    expect(html).toContain('rpc down')
+    expect(html).toContain('[ RETRY ]')
+  })
+})

--- a/front/app/app/trade/_components/balances/states.tsx
+++ b/front/app/app/trade/_components/balances/states.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import * as React from 'react'
+
+import { BoxSkeletonBlock, PanelEmpty, PanelError } from '@/components/ui/panel-state'
+
+export function BalancesLoading({ rows = 2 }: { rows?: number }) {
+  return <BoxSkeletonBlock rows={rows} cols={3} ariaLabel="Loading balances" />
+}
+
+/**
+ * Disconnected hint. Balances do not have a "zero is empty" state — a
+ * connected wallet with zero balances is still a real state worth
+ * surfacing as `0.00`. This component covers the disconnected path
+ * exclusively.
+ */
+export function BalancesDisconnected() {
+  return <PanelEmpty label="[ CONNECT WALLET ]" />
+}
+
+export interface BalancesErrorProps {
+  message?: string
+  onRetry?: () => void
+}
+
+export function BalancesError({ message, onRetry }: BalancesErrorProps) {
+  return <PanelError label="[ BALANCES UNAVAILABLE ]" message={message} onRetry={onRetry} />
+}

--- a/front/app/app/trade/_components/charts/DepthChart.tsx
+++ b/front/app/app/trade/_components/charts/DepthChart.tsx
@@ -12,6 +12,8 @@ import { type DepthSeries, buildDepthSeries } from '../../_lib/charts/selectors'
 import { useMockStore } from '@/lib/mock-store'
 import { cn } from '@/components/ui/cn'
 
+import { DepthChartEmpty } from './states'
+
 const COLORS = {
   bidStroke: '#FFFFFF',
   bidFill: '#FFFFFF',
@@ -183,7 +185,11 @@ export function DepthChart({ className }: DepthChartProps = {}) {
             />
           )}
         </ParentSize>
-        {isEmpty && <DepthChartEmptyState />}
+        {isEmpty && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <DepthChartEmpty />
+          </div>
+        )}
       </div>
       <figcaption id="depth-chart-caption" className="sr-only">
         Cumulative bid and ask depth for the active pair.
@@ -203,19 +209,6 @@ function DepthChartHeader({ series }: { series: DepthSeries }) {
         {'  ·  '}
         {series.spread !== null ? `SPR ${series.spread.toFixed(2)}` : 'SPR —'}
       </span>
-    </div>
-  )
-}
-
-function DepthChartEmptyState() {
-  return (
-    <div className="absolute inset-0 flex items-center justify-center">
-      <p
-        role="status"
-        className="font-mono text-label-md uppercase tracking-[0.2em] text-brand-muted"
-      >
-        [ NO BOOK YET ]
-      </p>
     </div>
   )
 }

--- a/front/app/app/trade/_components/charts/states.test.tsx
+++ b/front/app/app/trade/_components/charts/states.test.tsx
@@ -1,0 +1,38 @@
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { ChartError, ChartLoading, DepthChartEmpty, PriceChartEmpty } from './states'
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+describe('charts state primitives', () => {
+  it('ChartLoading renders a polite live region with a shimmer block', () => {
+    const html = render(<ChartLoading />)
+    expect(html).toMatch(/role="status"/)
+    expect(html).toMatch(/aria-live="polite"/)
+    // Reduced-motion respect comes from the shared Skeleton primitive.
+    expect(html).toContain('motion-reduce:animate-none')
+  })
+
+  it('DepthChartEmpty surfaces the no-book label', () => {
+    expect(render(<DepthChartEmpty />)).toContain('[ NO BOOK YET ]')
+  })
+
+  it('PriceChartEmpty surfaces the no-history label', () => {
+    expect(render(<PriceChartEmpty />)).toContain('[ NO PRICE HISTORY ]')
+  })
+
+  it('ChartError surfaces the default label and supports a retry handler', () => {
+    const html = render(<ChartError message="render failed" onRetry={vi.fn()} />)
+    expect(html).toContain('[ CHART UNAVAILABLE ]')
+    expect(html).toContain('render failed')
+    expect(html).toContain('[ RETRY ]')
+  })
+
+  it('ChartError accepts a custom label', () => {
+    expect(render(<ChartError label="[ DEPTH UNAVAILABLE ]" />)).toContain('[ DEPTH UNAVAILABLE ]')
+  })
+})

--- a/front/app/app/trade/_components/charts/states.tsx
+++ b/front/app/app/trade/_components/charts/states.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import * as React from 'react'
+
+import { cn } from '@/components/ui/cn'
+import { PanelEmpty, PanelError } from '@/components/ui/panel-state'
+import { Skeleton } from '@/components/ui/skeleton'
+
+export interface ChartLoadingProps {
+  className?: string
+  ariaLabel?: string
+}
+
+/**
+ * Rectangular shimmer for chart panels. Box-drawing skeletons only suit
+ * tabular surfaces; a chart canvas reads better as a faint pulsing
+ * block. The shimmer freezes under `prefers-reduced-motion`.
+ */
+export function ChartLoading({ className, ariaLabel = 'Loading chart' }: ChartLoadingProps = {}) {
+  return (
+    <div
+      role="status"
+      aria-label={ariaLabel}
+      aria-live="polite"
+      className={cn('flex h-full w-full items-stretch p-4', className)}
+    >
+      <Skeleton className="h-full w-full bg-brand-border" />
+      <span className="sr-only">{ariaLabel}…</span>
+    </div>
+  )
+}
+
+export function DepthChartEmpty() {
+  return <PanelEmpty label="[ NO BOOK YET ]" />
+}
+
+export function PriceChartEmpty() {
+  return <PanelEmpty label="[ NO PRICE HISTORY ]" />
+}
+
+export interface ChartErrorProps {
+  label?: string
+  message?: string
+  onRetry?: () => void
+}
+
+export function ChartError({
+  label = '[ CHART UNAVAILABLE ]',
+  message,
+  onRetry,
+}: ChartErrorProps = {}) {
+  return <PanelError label={label} message={message} onRetry={onRetry} />
+}

--- a/front/app/app/trade/_components/my-orders/MyOrdersPanel.tsx
+++ b/front/app/app/trade/_components/my-orders/MyOrdersPanel.tsx
@@ -22,6 +22,7 @@ import {
   type UseMyOrdersReturn,
 } from '../../_hooks/my-orders/useMyOrders'
 import { OrderRow } from './OrderRow'
+import { MyOrdersEmpty } from './states'
 
 export interface MyOrdersPanelProps {
   /**
@@ -53,9 +54,9 @@ export function MyOrdersPanel({ useOrders = useMyOrders }: MyOrdersPanelProps = 
     >
       <Header id={headerId} />
       {!isConnected ? (
-        <EmptyState label="[ CONNECT WALLET ]" />
+        <MyOrdersEmpty disconnected />
       ) : rows.length === 0 ? (
-        <EmptyState label="[ NO ORDERS YET ]" />
+        <MyOrdersEmpty />
       ) : (
         <div className="flex flex-1 flex-col overflow-y-auto">
           <ColumnHeader />
@@ -97,19 +98,6 @@ function ColumnHeader(): JSX.Element {
       <span className="text-right" aria-hidden="true">
         {/* cancel column header is intentionally blank — action, not data */}
       </span>
-    </div>
-  )
-}
-
-function EmptyState({ label }: { label: string }): JSX.Element {
-  return (
-    <div className="flex flex-1 items-center justify-center p-6">
-      <p
-        role="status"
-        className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
-      >
-        {label}
-      </p>
     </div>
   )
 }

--- a/front/app/app/trade/_components/my-orders/states.test.tsx
+++ b/front/app/app/trade/_components/my-orders/states.test.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { MyOrdersEmpty, MyOrdersError, MyOrdersLoading } from './states'
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+describe('my-orders state primitives', () => {
+  it('Loading renders a 5-column skeleton matching the row layout', () => {
+    const html = render(<MyOrdersLoading rows={3} />)
+    const spans = html.match(/<span/g) ?? []
+    // 3 rows * 5 cols = 15 + 1 sr-only span = 16
+    expect(spans.length).toBe(16)
+  })
+
+  it('Empty surfaces the no-orders label by default', () => {
+    const html = render(<MyOrdersEmpty />)
+    expect(html).toContain('[ NO ORDERS YET ]')
+  })
+
+  it('Empty surfaces the connect-wallet label in disconnected mode', () => {
+    const html = render(<MyOrdersEmpty disconnected />)
+    expect(html).toContain('[ CONNECT WALLET ]')
+  })
+
+  it('Error surfaces the unavailable label + retry button', () => {
+    const html = render(<MyOrdersError message="stream dropped" onRetry={vi.fn()} />)
+    expect(html).toContain('[ ORDERS UNAVAILABLE ]')
+    expect(html).toContain('stream dropped')
+    expect(html).toContain('[ RETRY ]')
+  })
+})

--- a/front/app/app/trade/_components/my-orders/states.tsx
+++ b/front/app/app/trade/_components/my-orders/states.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import * as React from 'react'
+
+import { BoxSkeletonBlock, PanelEmpty, PanelError } from '@/components/ui/panel-state'
+
+export function MyOrdersLoading({ rows = 4 }: { rows?: number }) {
+  return <BoxSkeletonBlock rows={rows} cols={5} ariaLabel="Loading open orders" />
+}
+
+export function MyOrdersEmpty({ disconnected = false }: { disconnected?: boolean } = {}) {
+  return <PanelEmpty label={disconnected ? '[ CONNECT WALLET ]' : '[ NO ORDERS YET ]'} />
+}
+
+export interface MyOrdersErrorProps {
+  message?: string
+  onRetry?: () => void
+}
+
+export function MyOrdersError({ message, onRetry }: MyOrdersErrorProps) {
+  return <PanelError label="[ ORDERS UNAVAILABLE ]" message={message} onRetry={onRetry} />
+}

--- a/front/app/app/trade/_components/orderbook/OrderBook.tsx
+++ b/front/app/app/trade/_components/orderbook/OrderBook.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useMemo, type ReactNode } from 'react'
+import { useEffect, useMemo, useRef, type ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
+import { useToast } from '@/components/ui/use-toast'
 import { DEFAULT_PAIR } from '@/lib/sdk/mocks/factories'
 import { Side } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
 
@@ -67,6 +68,26 @@ export function OrderBookContent({
   const effectivePair = pair ?? DEFAULT_PAIR
   const book = useOrderBook({ pair: effectivePair, refetchIntervalMs })
   const auctions = useRecentAuctions({ pair: effectivePair, limit: 2, refetchIntervalMs })
+  const { toast } = useToast()
+  const lastErrorAtRef = useRef<unknown>(null)
+
+  // Fire one toast on the transition into an error state. We key on the
+  // error object identity so subsequent re-renders of the same failure
+  // don't re-toast; a new failure (different reference) triggers again.
+  // Retry lives on the inline `<OrderBookError>` body — the toast is a
+  // transient ack for users looking at another panel.
+  useEffect(() => {
+    if (!book.isError || !book.error) {
+      lastErrorAtRef.current = null
+      return
+    }
+    if (lastErrorAtRef.current === book.error) return
+    lastErrorAtRef.current = book.error
+    toast({
+      title: 'Orderbook unavailable',
+      description: book.error instanceof Error ? book.error.message : undefined,
+    })
+  }, [book.isError, book.error, toast])
 
   const depth = useMemo(() => {
     if (!book.data) return null

--- a/front/app/app/trade/_components/orderbook/states.test.tsx
+++ b/front/app/app/trade/_components/orderbook/states.test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { OrderBookEmpty, OrderBookError, OrderBookLoading } from './states'
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+describe('orderbook state primitives', () => {
+  it('Loading renders an a11y-tagged box-drawing skeleton', () => {
+    const html = render(<OrderBookLoading rows={5} />)
+    expect(html).toMatch(/role="status"/)
+    expect(html).toMatch(/aria-label="Loading orderbook"/)
+    // 5 rows * 3 cols = 15 + 1 sr-only span = 16
+    const spans = html.match(/<span/g) ?? []
+    expect(spans.length).toBe(16)
+  })
+
+  it('Empty renders the bracketed label inside a status region', () => {
+    const html = render(<OrderBookEmpty />)
+    expect(html).toContain('[ NO ORDERS YET ]')
+    expect(html).toMatch(/role="status"/)
+  })
+
+  it('Error renders the bracketed label and message', () => {
+    const html = render(<OrderBookError message="Network refused" />)
+    expect(html).toContain('[ ORDERBOOK UNAVAILABLE ]')
+    expect(html).toContain('Network refused')
+    expect(html).toMatch(/role="alert"/)
+  })
+
+  it('Error renders the retry button only when onRetry is provided', () => {
+    const noRetry = render(<OrderBookError />)
+    expect(noRetry).not.toContain('[ RETRY ]')
+
+    const withRetry = render(<OrderBookError onRetry={vi.fn()} />)
+    expect(withRetry).toContain('[ RETRY ]')
+  })
+})

--- a/front/app/app/trade/_components/orderbook/states.tsx
+++ b/front/app/app/trade/_components/orderbook/states.tsx
@@ -1,54 +1,21 @@
 'use client'
 
-const SKELETON_BAR = '████░░░░'
+import * as React from 'react'
+
+import { BoxSkeletonBlock, PanelEmpty, PanelError } from '@/components/ui/panel-state'
 
 /**
- * Box-drawing skeleton — per DESIGN-INSPIRATIONS, loading uses skeleton
- * blocks (`█ ░`) rather than spinners. Each row's mask offset is fixed so
- * the skeleton reads as orderbook-shaped rather than uniform noise.
+ * Orderbook skeleton — three-column box-drawing block that matches the
+ * Price / Size / Total layout of the populated rows. Driven by the shared
+ * `BoxSkeletonBlock` primitive so all panels share the same shimmer
+ * cadence and a11y wiring.
  */
 export function OrderBookLoading({ rows = 8 }: { rows?: number }) {
-  return (
-    <div
-      role="status"
-      aria-label="Loading orderbook"
-      aria-live="polite"
-      className="flex flex-col gap-1 px-4 py-3"
-    >
-      {Array.from({ length: rows }).map((_, i) => (
-        <div
-          key={i}
-          className="flex items-center justify-between font-mono text-body-sm text-brand-border2 animate-pulse"
-          aria-hidden="true"
-        >
-          <span>{shift(SKELETON_BAR, i)}</span>
-          <span>{shift(SKELETON_BAR, i + 3)}</span>
-          <span>{shift(SKELETON_BAR, i + 5)}</span>
-        </div>
-      ))}
-      <span className="sr-only">Loading orderbook…</span>
-    </div>
-  )
+  return <BoxSkeletonBlock rows={rows} cols={3} ariaLabel="Loading orderbook" />
 }
 
-function shift(bar: string, by: number): string {
-  const offset = ((by % bar.length) + bar.length) % bar.length
-  return bar.slice(offset) + bar.slice(0, offset)
-}
-
-/**
- * Empty state — visually distinct from loading per the acceptance
- * criteria. Terse copy per DESIGN-INSPIRATIONS tone-of-copy table.
- */
 export function OrderBookEmpty() {
-  return (
-    <div
-      role="status"
-      className="flex flex-1 items-center justify-center px-4 py-8 font-mono text-label-lg uppercase text-brand-muted"
-    >
-      [ NO ORDERS YET ]
-    </div>
-  )
+  return <PanelEmpty label="[ NO ORDERS YET ]" />
 }
 
 export interface OrderBookErrorProps {
@@ -57,26 +24,5 @@ export interface OrderBookErrorProps {
 }
 
 export function OrderBookError({ message, onRetry }: OrderBookErrorProps) {
-  return (
-    <div
-      role="alert"
-      className="flex flex-1 flex-col items-center justify-center gap-3 px-4 py-8 text-center"
-    >
-      <span className="font-mono text-label-lg uppercase text-brand-muted">
-        [ ORDERBOOK UNAVAILABLE ]
-      </span>
-      {message ? (
-        <span className="max-w-xs font-mono text-body-sm text-brand-muted">{message}</span>
-      ) : null}
-      {onRetry ? (
-        <button
-          type="button"
-          onClick={onRetry}
-          className="border border-brand-border2 px-4 py-2 font-mono text-label-md uppercase text-brand-fg transition-colors hover:border-brand-accent hover:text-brand-accent focus-visible:border-brand-accent focus-visible:text-brand-accent focus-visible:outline-none"
-        >
-          [ RETRY ]
-        </button>
-      ) : null}
-    </div>
-  )
+  return <PanelError label="[ ORDERBOOK UNAVAILABLE ]" message={message} onRetry={onRetry} />
 }

--- a/front/app/app/trade/_components/tape/Tape.tsx
+++ b/front/app/app/trade/_components/tape/Tape.tsx
@@ -7,6 +7,7 @@ import type { AuctionSummary } from '@/lib/sdk'
 import { Countdown } from './Countdown'
 import { TapeDrawer } from './TapeDrawer'
 import { TapeRow } from './TapeRow'
+import { TapeEmpty } from './states'
 import { useAuctionHistory } from '../../_hooks/tape/useAuctionHistory'
 import { useNow } from '../../_hooks/tape/useNow'
 
@@ -31,7 +32,7 @@ export function Tape({ limit }: TapeProps = {}): JSX.Element {
       <Countdown latestAuctionUnixSeconds={latestUnix} nowUnixSeconds={nowSeconds} />
       <TableHeader />
       {auctions.length === 0 ? (
-        <EmptyState />
+        <TapeEmpty />
       ) : (
         <ol aria-live="polite" aria-atomic="false" className="flex-1 overflow-y-auto">
           {auctions.map((a) => (
@@ -56,14 +57,6 @@ function TableHeader(): JSX.Element {
       <span className="text-right">PRICE</span>
       <span className="text-right">VOLUME</span>
       <span className="text-right">MATCH</span>
-    </div>
-  )
-}
-
-function EmptyState(): JSX.Element {
-  return (
-    <div className="flex flex-1 items-center justify-center font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
-      [ NO AUCTIONS YET ]
     </div>
   )
 }

--- a/front/app/app/trade/_components/tape/states.test.tsx
+++ b/front/app/app/trade/_components/tape/states.test.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { TapeEmpty, TapeError, TapeLoading } from './states'
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+describe('tape state primitives', () => {
+  it('Loading announces and renders a 4-column skeleton', () => {
+    const html = render(<TapeLoading rows={3} />)
+    expect(html).toMatch(/aria-label="Loading auction tape"/)
+    const spans = html.match(/<span/g) ?? []
+    // 3 rows * 4 cols = 12 + 1 sr-only span = 13
+    expect(spans.length).toBe(13)
+  })
+
+  it('Empty surfaces the no-auctions label', () => {
+    const html = render(<TapeEmpty />)
+    expect(html).toContain('[ NO AUCTIONS YET ]')
+  })
+
+  it('Error surfaces the unavailable label with a retry handler', () => {
+    const html = render(<TapeError message="timeout" onRetry={vi.fn()} />)
+    expect(html).toContain('[ TAPE UNAVAILABLE ]')
+    expect(html).toContain('timeout')
+    expect(html).toContain('[ RETRY ]')
+  })
+})

--- a/front/app/app/trade/_components/tape/states.tsx
+++ b/front/app/app/trade/_components/tape/states.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import * as React from 'react'
+
+import { BoxSkeletonBlock, PanelEmpty, PanelError } from '@/components/ui/panel-state'
+
+export function TapeLoading({ rows = 6 }: { rows?: number }) {
+  return <BoxSkeletonBlock rows={rows} cols={4} ariaLabel="Loading auction tape" />
+}
+
+export function TapeEmpty() {
+  return <PanelEmpty label="[ NO AUCTIONS YET ]" />
+}
+
+export interface TapeErrorProps {
+  message?: string
+  onRetry?: () => void
+}
+
+export function TapeError({ message, onRetry }: TapeErrorProps) {
+  return <PanelError label="[ TAPE UNAVAILABLE ]" message={message} onRetry={onRetry} />
+}

--- a/front/components/ui/panel-state.stories.tsx
+++ b/front/components/ui/panel-state.stories.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react'
+
+import { BoxSkeletonBlock, PanelEmpty, PanelError } from './panel-state'
+
+export const SkeletonRows = () => (
+  <div className="w-80 border border-brand-border bg-brand-surface">
+    <BoxSkeletonBlock rows={6} cols={3} ariaLabel="Loading orderbook" />
+  </div>
+)
+
+export const SkeletonWideRows = () => (
+  <div className="w-[420px] border border-brand-border bg-brand-surface">
+    <BoxSkeletonBlock rows={4} cols={4} ariaLabel="Loading fills" />
+  </div>
+)
+
+export const Empty = () => (
+  <div className="flex h-64 w-80 flex-col border border-brand-border bg-brand-surface">
+    <PanelEmpty label="[ NO ORDERS YET ]" />
+  </div>
+)
+
+export const EmptyWithHint = () => (
+  <div className="flex h-64 w-80 flex-col border border-brand-border bg-brand-surface">
+    <PanelEmpty label="[ NO FILLS YET ]" hint="Place an order to start your fill history." />
+  </div>
+)
+
+export const Errored = () => (
+  <div className="flex h-64 w-80 flex-col border border-brand-border bg-brand-surface">
+    <PanelError label="[ ORDERBOOK UNAVAILABLE ]" message="Could not reach the engine." />
+  </div>
+)
+
+export const ErroredWithRetry = () => (
+  <div className="flex h-64 w-80 flex-col border border-brand-border bg-brand-surface">
+    <PanelError
+      label="[ ORDERBOOK UNAVAILABLE ]"
+      message="Network refused the request."
+      onRetry={() => console.info('retry')}
+    />
+  </div>
+)

--- a/front/components/ui/panel-state.test.tsx
+++ b/front/components/ui/panel-state.test.tsx
@@ -1,0 +1,124 @@
+import * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+import { BoxSkeletonBlock, BoxSkeletonRow, PanelEmpty, PanelError } from './panel-state'
+
+function render(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+describe('BoxSkeletonRow', () => {
+  it('renders one span per column with box-drawing characters', () => {
+    const html = render(<BoxSkeletonRow cols={3} index={0} />)
+    const spans = html.match(/<span/g) ?? []
+    expect(spans.length).toBe(3)
+    // Box-drawing chars survive renderToStaticMarkup as UTF-8 literals.
+    const fills = html.match(/█/g) ?? []
+    expect(fills.length).toBeGreaterThanOrEqual(3)
+    const empties = html.match(/░/g) ?? []
+    expect(empties.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('respects a custom cols count', () => {
+    const html = render(<BoxSkeletonRow cols={5} />)
+    const spans = html.match(/<span/g) ?? []
+    expect(spans.length).toBe(5)
+  })
+
+  it('is decorative for assistive tech', () => {
+    const html = render(<BoxSkeletonRow />)
+    expect(html).toMatch(/aria-hidden="true"/)
+  })
+
+  it('honors prefers-reduced-motion', () => {
+    const html = render(<BoxSkeletonRow />)
+    expect(html).toContain('motion-reduce:animate-none')
+  })
+})
+
+describe('BoxSkeletonBlock', () => {
+  it('renders the configured row count', () => {
+    const html = render(<BoxSkeletonBlock rows={4} cols={3} />)
+    // 4 rows * 3 cols = 12 inner spans + 1 sr-only span for the live region.
+    const spans = html.match(/<span/g) ?? []
+    expect(spans.length).toBe(13)
+  })
+
+  it('exposes the polite status with the supplied label', () => {
+    const html = render(<BoxSkeletonBlock ariaLabel="Loading orderbook" />)
+    expect(html).toMatch(/role="status"/)
+    expect(html).toMatch(/aria-live="polite"/)
+    expect(html).toContain('Loading orderbook')
+  })
+})
+
+describe('PanelEmpty', () => {
+  it('renders the bracketed label inside a status region', () => {
+    const html = render(<PanelEmpty label="[ NO ORDERS YET ]" />)
+    expect(html).toContain('[ NO ORDERS YET ]')
+    expect(html).toMatch(/role="status"/)
+  })
+
+  it('renders the optional hint when provided', () => {
+    const html = render(<PanelEmpty label="[ NO FILLS YET ]" hint="Place an order to start." />)
+    expect(html).toContain('Place an order to start.')
+  })
+
+  it('omits the hint node when not provided', () => {
+    const html = render(<PanelEmpty label="[ NO FILLS YET ]" />)
+    // Only one text span (the label).
+    const spans = html.match(/<span/g) ?? []
+    expect(spans.length).toBe(1)
+  })
+
+  it('renders muted copy — never the lime accent', () => {
+    const html = render(<PanelEmpty label="[ NO FILLS YET ]" hint="hint" />)
+    expect(html).not.toMatch(/brand-accent/)
+  })
+})
+
+describe('PanelError', () => {
+  it('renders the bracketed label inside an alert region', () => {
+    const html = render(<PanelError label="[ ORDERBOOK UNAVAILABLE ]" />)
+    expect(html).toContain('[ ORDERBOOK UNAVAILABLE ]')
+    expect(html).toMatch(/role="alert"/)
+  })
+
+  it('renders message when provided', () => {
+    const html = render(<PanelError label="[ ERR ]" message="Network unreachable." />)
+    expect(html).toContain('Network unreachable.')
+  })
+
+  it('renders the retry button only when onRetry is provided', () => {
+    const noRetry = render(<PanelError label="[ ERR ]" />)
+    expect(noRetry).not.toContain('[ RETRY ]')
+
+    const withRetry = render(<PanelError label="[ ERR ]" onRetry={() => undefined} />)
+    expect(withRetry).toContain('[ RETRY ]')
+  })
+
+  it('allows a custom retry label', () => {
+    const html = render(
+      <PanelError label="[ ERR ]" onRetry={() => undefined} retryLabel="[ RELOAD ]" />
+    )
+    expect(html).toContain('[ RELOAD ]')
+  })
+
+  it('keeps the accent off the rest state — accent appears only on retry focus/hover utilities', () => {
+    const html = render(<PanelError label="[ ERR ]" message="oops" onRetry={() => undefined} />)
+    // Static accent classes ARE allowed on the retry button (hover/focus
+    // states), but no `bg-brand-accent` should fill the button at rest.
+    expect(html).not.toMatch(/bg-brand-accent/)
+  })
+
+  it('invokes onRetry via the button (smoke render — handler binding present)', () => {
+    const spy = vi.fn()
+    // We render to static markup so the click handler isn't bound to a
+    // DOM event. The presence of the button is enough — the binding is
+    // type-safe in TS. The actual click is exercised by Ladle.
+    const html = render(<PanelError label="[ ERR ]" onRetry={spy} />)
+    expect(html).toContain('[ RETRY ]')
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/front/components/ui/panel-state.tsx
+++ b/front/components/ui/panel-state.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import * as React from 'react'
+
+import { cn } from './cn'
+
+const SKELETON_BAR = '████░░░░'
+
+function shift(bar: string, by: number): string {
+  const offset = ((by % bar.length) + bar.length) % bar.length
+  return bar.slice(offset) + bar.slice(0, offset)
+}
+
+export interface BoxSkeletonRowProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Row index — drives the per-column shift so the block reads as data, not noise. */
+  index?: number
+  /** Number of bar segments rendered side-by-side. */
+  cols?: number
+}
+
+/**
+ * Single box-drawing skeleton row. The shifted offsets per column give the
+ * row the silhouette of a populated table line rather than uniform noise —
+ * DESIGN-INSPIRATIONS prescribes box-drawing skeletons over spinners.
+ */
+export function BoxSkeletonRow({ index = 0, cols = 3, className, ...rest }: BoxSkeletonRowProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn(
+        'flex items-center justify-between gap-3 font-mono text-body-sm text-brand-border2 animate-pulse motion-reduce:animate-none',
+        className
+      )}
+      {...rest}
+    >
+      {Array.from({ length: cols }).map((_, c) => (
+        <span key={c} className="whitespace-pre">
+          {shift(SKELETON_BAR, index + c * 3)}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+export interface BoxSkeletonBlockProps {
+  rows?: number
+  cols?: number
+  /** Live label announced to assistive tech; defaults to `Loading`. */
+  ariaLabel?: string
+  className?: string
+  rowClassName?: string
+}
+
+/**
+ * Stack of `rows` box-drawing skeleton lines. Use this for tabular panels
+ * (orderbook, tape, my-orders, portfolio fills). Charts that need a
+ * rectangular shimmer should compose `<Skeleton>` from `./skeleton`
+ * directly — it matches the design rule for non-tabular surfaces.
+ */
+export function BoxSkeletonBlock({
+  rows = 6,
+  cols = 3,
+  ariaLabel = 'Loading',
+  className,
+  rowClassName,
+}: BoxSkeletonBlockProps) {
+  return (
+    <div
+      role="status"
+      aria-label={ariaLabel}
+      aria-live="polite"
+      className={cn('flex flex-col gap-1 px-4 py-3', className)}
+    >
+      {Array.from({ length: rows }).map((_, i) => (
+        <BoxSkeletonRow key={i} index={i} cols={cols} className={rowClassName} />
+      ))}
+      <span className="sr-only">{ariaLabel}…</span>
+    </div>
+  )
+}
+
+export interface PanelEmptyProps {
+  /**
+   * Bracketed-tag label (e.g. `[ NO ORDERS YET ]`). Caller is responsible
+   * for the brackets so the wording reads naturally per-panel.
+   */
+  label: string
+  /** Optional second line in `body-sm` mono. */
+  hint?: string
+  className?: string
+}
+
+export function PanelEmpty({ label, hint, className }: PanelEmptyProps) {
+  return (
+    <div
+      role="status"
+      className={cn(
+        'flex flex-1 flex-col items-center justify-center gap-2 px-4 py-8 text-center',
+        className
+      )}
+    >
+      <span className="font-mono text-label-lg uppercase tracking-label text-brand-muted">
+        {label}
+      </span>
+      {hint ? (
+        <span className="max-w-xs font-mono text-body-sm text-brand-muted">{hint}</span>
+      ) : null}
+    </div>
+  )
+}
+
+export interface PanelErrorProps {
+  /** Bracketed-tag label (e.g. `[ ORDERBOOK UNAVAILABLE ]`). */
+  label: string
+  /** Optional message line in `body-sm`. */
+  message?: string
+  /** When provided, renders a ghost `[ RETRY ]` button that invokes it. */
+  onRetry?: () => void
+  /** Override the retry button label. Defaults to `[ RETRY ]`. */
+  retryLabel?: string
+  className?: string
+}
+
+export function PanelError({
+  label,
+  message,
+  onRetry,
+  retryLabel = '[ RETRY ]',
+  className,
+}: PanelErrorProps) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex flex-1 flex-col items-center justify-center gap-3 px-4 py-8 text-center',
+        className
+      )}
+    >
+      <span className="font-mono text-label-lg uppercase tracking-label text-brand-muted">
+        {label}
+      </span>
+      {message ? (
+        <span className="max-w-xs font-mono text-body-sm text-brand-muted">{message}</span>
+      ) : null}
+      {onRetry ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="border border-brand-border2 px-4 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-fg transition-colors hover:border-brand-accent hover:text-brand-accent focus-visible:border-brand-accent focus-visible:text-brand-accent focus-visible:outline-none"
+        >
+          {retryLabel}
+        </button>
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
Closes #79.

## Summary

- **Shared state primitives** in `front/components/ui/panel-state.tsx`: `<BoxSkeletonRow>`, `<BoxSkeletonBlock>`, `<PanelEmpty>`, `<PanelError>`. Box-drawing skeletons (`████░░░░` shifted per index) match the DESIGN-INSPIRATIONS rule of "no spinners". Skeletons honor `prefers-reduced-motion`; empty/error wrap in `role=status` / `role=alert` with terse bracketed-tag copy and an optional `[ RETRY ]` ghost button.
- **First-run OnboardingDialog** under `front/app/app/_components/onboarding/`: 3 steps (`01 PROTOCOL` · `02 CUSTODY` · `03 PROVING`) using the existing `<Dialog>` chrome and `step-node` design. Copy is sentence-case, no marketing voice; borrows CoW Swap's batch-auction phrasing per the genre-peer section of DESIGN-INSPIRATIONS. Lime accent rides on the current step-node and (final step only) the `[ START TRADING ]` CTA — one accent target per surface. Mounted once from `app/app/layout.tsx`.
- **Per-wallet dismiss persistence**: `localStorage["dp:onboarding-dismissed:<address>"]` keyed by lowercased address; anon bucket covers the disconnected case and `promoteAnonToAddress` lifts it forward when the wallet connects so the modal doesn't re-pop.
- **Per-panel `states.tsx`** for orderbook, tape, my-orders, balances, charts, portfolio, and fill-history. Each composes the shared primitives with the panel's bracketed-tag copy (e.g. `[ NO AUCTIONS YET ]`, `[ ORDERS UNAVAILABLE ]`) and row shape (col counts match each panel's table layout).
- **Inline empty states refactored** in BalancesPanel, MyOrdersPanel, PortfolioPanel, FillHistoryTable, DepthChart, Tape, OrderBook to consume the shared components. No behavior changes — the rendered copy and a11y wiring stay identical to the previous panel-specific implementations.
- **Toast on orderbook error**: `useToast` fires once per error-object identity when `useOrderBook` transitions into `isError` (the only panel today with a real `isError` signal — others are mock-store-backed and surface their error UI from Phase 2 when the hooks gain async semantics). Inline retry stays the primary affordance.

## Scope notes

- The Loading and Error variants of the mock-store-backed panels (tape, my-orders, balances, portfolio, charts) exist as components and are visible via the Ladle stories but won't fire in Phase 1 — those hooks synchronously read in-memory state. The wiring lights up when each panel's hook is swapped for its TanStack-Query-backed Phase 2 counterpart (issues #93, #94, #95, etc.).
- `PriceHistoryChart.tsx`'s inline empty state is intentionally retained — it discriminates between "no auctions" and "need ≥ 2 auctions" with different copy, which is too panel-specific to push down into the shared primitive.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 450 passed (+ 25 new tests, +1 test file per panel + onboarding storage + dialog + primitives)
- [x] `npm run build` — succeeds; bundle sizes unchanged for /app/trade (4.79 kB) and /app/portfolio (3.91 kB)
- [x] `npm run format:check` — clean
- [ ] Manual: open `/app/trade` first time → modal appears, walk back/next, dismiss persists across reload
- [ ] Manual: connect a wallet after dismissing anon → modal does NOT reappear (promoteAnonToAddress)
- [ ] Manual: each panel's state variants reviewed via `npm run ladle:serve` stories

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Onboarding dialog with multi-step guided flow and persistent wallet-specific dismissal tracking
  * Loading skeleton animations across portfolio and trading panels
  * Consistent empty and error state components with retry functionality
  * Toast notifications when order book encounters errors

* **Tests**
  * Added comprehensive test coverage for onboarding flows and UI state components across the app

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->