### PR TITLE
Wire EthSubmitter into server boot path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2238,6 +2238,7 @@ name = "dp-api"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "alloy-provider",
  "async-trait",
  "axum",
  "axum-server",

--- a/crates/dp-api/Cargo.toml
+++ b/crates/dp-api/Cargo.toml
@@ -24,6 +24,7 @@ axum-server.workspace = true
 rustls.workspace = true
 rustls-pemfile.workspace = true
 alloy-primitives.workspace = true
+alloy-provider.workspace = true
 axum.workspace = true
 tower.workspace = true
 tower-http.workspace = true

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -205,9 +205,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
             let provider = alloy_provider::ProviderBuilder::new()
                 .wallet(signer.wallet())
-                .connect_http(rpc.parse().map_err(|e| {
-                    format!("bad DARKPOOL_ETH_RPC URL: {e}")
-                })?);
+                .connect_http(
+                    rpc.parse()
+                        .map_err(|e| format!("bad DARKPOOL_ETH_RPC URL: {e}"))?,
+                );
 
             let submitter_cfg = dp_settlement::EthSubmitterConfig {
                 rpc_url: rpc.to_string(),

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -196,27 +196,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     }
 
     if let Some(rpc) = cfg.eth_rpc_url() {
-        // Resolve the signer URI up-front so a typo in operator config
-        // fails at boot rather than on the first batch. Submitter
-        // construction beyond signer building still needs a fully-built
-        // alloy `Provider` (with the wallet attached); that path lands
-        // in a follow-up, but the signer side of issue #28 is wired now
-        // so KMS / age URIs surface their parsing errors at boot.
         if let Some(uri) = cfg.signer_key_uri_str() {
             let signer = dp_settlement::signer::from_uri(uri)?;
-            // Loud on purpose: with the signer resolved but no
-            // submitter installed in `Engine`, batches still settle on
-            // the noop path even though the operator configured both
-            // ETH_RPC and a signer URI. Surfaces at warn so a config
-            // audit catches it instead of discovering it via empty
-            // BatchSettled events on chain.
-            warn!(
+            let contract_addr = cfg.contract_address().ok_or(
+                "DARKPOOL_ETH_RPC and DARKPOOL_SIGNER_KEY_URI are set but \
+                 DARKPOOL_CONTRACT_ADDR is missing — cannot build EthSubmitter",
+            )?;
+
+            let provider = alloy_provider::ProviderBuilder::new()
+                .wallet(signer.wallet())
+                .connect_http(rpc.parse().map_err(|e| {
+                    format!("bad DARKPOOL_ETH_RPC URL: {e}")
+                })?);
+
+            let submitter_cfg = dp_settlement::EthSubmitterConfig {
+                rpc_url: rpc.to_string(),
+                signer,
+                contract_address: contract_addr.to_string(),
+                chain_id: cfg.chain_id,
+                gas_limit: Some(cfg.submit_gas),
+            };
+
+            let submitter = dp_settlement::EthSubmitter::new(provider, &submitter_cfg)?;
+            engine.set_submitter(Arc::new(submitter));
+
+            info!(
                 rpc = %rpc,
-                signer = %sanitize_uri_for_log(uri),
-                address = %signer.address(),
-                "operator signer resolved but submitter wiring is NOT installed yet \
-                 (issue #28 follow-up). Auctions will NOT settle on-chain until the \
-                 alloy Provider+wallet+contract glue lands."
+                contract = %contract_addr,
+                chain_id = cfg.chain_id,
+                "batch submitter: on-chain (EthSubmitter)"
             );
         } else {
             warn!(


### PR DESCRIPTION
## Summary

- **On-chain settlement was non-functional** — both `--eth-rpc` code paths in `darkpool-server` logged a WARN and fell through to `NoopSubmitter`. Zero batches were ever sent to chain.
- Constructs an alloy `Provider` with the operator wallet, builds `EthSubmitter` from existing config fields (`DARKPOOL_CONTRACT_ADDR`, `DARKPOOL_CHAIN_ID`, `DARKPOOL_SUBMIT_GAS`), and installs it via `engine.set_submitter()`.
- Missing `DARKPOOL_CONTRACT_ADDR` now fails at boot rather than silently no-op'ing.

## Test plan

- [ ] Verify `cargo check -p dp-api` passes (confirmed)
- [ ] Verify `cargo clippy -p dp-api -- -D warnings` passes (confirmed)
- [ ] Boot with `--eth-rpc` + `--signer-key-uri` + `--contract-addr` → logs `batch submitter: on-chain (EthSubmitter)` instead of the old WARN
- [ ] Boot with `--eth-rpc` + `--signer-key-uri` but no `--contract-addr` → fails at startup with clear error
- [ ] Boot without `--eth-rpc` → noop path unchanged
- [ ] Run an auction tick against a local anvil node → `BatchConfirmed` event has a real tx hash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On-chain settlement is now enabled for auctions when the required environment variables and contract configuration are properly configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->