### PR TITLE
[C2] Enable CORS on REST router

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ prost = "0.13"
 prost-types = "0.13"
 axum = "0.7"
 tower = { version = "0.5", features = ["util"] }
-tower-http = { version = "0.5", features = ["limit", "trace", "request-id"] }
+tower-http = { version = "0.5", features = ["cors", "limit", "trace", "request-id"] }
 base64 = "0.22"
 tokio-stream = { version = "0.1", features = ["sync", "net"] }
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -48,6 +48,12 @@ pub struct Config {
     #[arg(long, env = "DARKPOOL_OPERATOR_API_KEYS", default_value = "")]
     operator_api_keys_raw: String,
 
+    /// Comma-separated list of allowed CORS origins. When empty, no CORS
+    /// headers are emitted (browser cross-origin requests will fail).
+    /// Example: `http://localhost:3000,https://app.darkpool.exchange`.
+    #[arg(long, env = "DARKPOOL_CORS_ORIGINS", default_value = "")]
+    cors_origins_raw: String,
+
     /// JSON document seeding the pair registry on first boot. Only
     /// applied when the event log is empty (otherwise pairs are replayed
     /// from `PairRegistered` events). Format:
@@ -163,6 +169,14 @@ pub struct Config {
 impl Config {
     pub fn api_keys(&self) -> Vec<String> {
         self.api_keys_raw
+            .split(',')
+            .map(|p| p.trim().to_string())
+            .filter(|p| !p.is_empty())
+            .collect()
+    }
+
+    pub fn cors_origins(&self) -> Vec<String> {
+        self.cors_origins_raw
             .split(',')
             .map(|p| p.trim().to_string())
             .filter(|p| !p.is_empty())

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -379,6 +379,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         }
     });
 
+    let cors_origins = cfg.cors_origins();
     let rest_app = rest::router_with_ops(
         shared,
         shared_admin,
@@ -387,6 +388,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         admin_auth_core,
         rl_core,
         ops,
+        &cors_origins,
     );
     let http_addr = cfg.http_addr;
     let http_cancel = cancel.clone();

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -136,6 +136,7 @@ pub fn ops_router(state: OpsState) -> Router {
 /// Compose the full server router: public + admin (auth-gated) + ops
 /// (unauthenticated) and apply tracing + x-request-id propagation
 /// across every route so logs and spans share a correlation ID.
+#[allow(clippy::too_many_arguments)]
 pub fn router_with_ops(
     handler: SharedHandler,
     admin_handler: SharedAdminHandler,
@@ -190,10 +191,7 @@ pub fn router_with_ops(
             Method::DELETE,
             Method::OPTIONS,
         ])
-        .allow_headers([
-            header::CONTENT_TYPE,
-            HeaderName::from_static("x-api-key"),
-        ])
+        .allow_headers([header::CONTENT_TYPE, HeaderName::from_static("x-api-key")])
         .expose_headers([HeaderName::from_static("x-request-id")])
         .max_age(Duration::from_secs(3600));
 

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -172,12 +172,24 @@ pub fn router_with_ops(
 
     let origins: Vec<HeaderValue> = cors_origins
         .iter()
-        .filter_map(|o| o.parse().ok())
+        .filter_map(|o| match o.parse::<HeaderValue>() {
+            Ok(v) => Some(v),
+            Err(_) => {
+                tracing::warn!(origin = %o, "ignoring unparseable CORS origin");
+                None
+            }
+        })
         .collect();
 
     let cors = CorsLayer::new()
         .allow_origin(AllowOrigin::list(origins))
-        .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
+        ])
         .allow_headers([
             header::CONTENT_TYPE,
             HeaderName::from_static("x-api-key"),

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::body::Body;
 use axum::extract::{MatchedPath, Path, Query, State};
-use axum::http::{header, HeaderValue, Request as AxumRequest, StatusCode};
+use axum::http::{header, HeaderName, HeaderValue, Method, Request as AxumRequest, StatusCode};
 use axum::middleware::from_fn_with_state;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, patch, post};
@@ -10,6 +11,7 @@ use axum::{Json, Router};
 use metrics_exporter_prometheus::PrometheusHandle;
 use serde::{Deserialize, Serialize};
 use tonic::{Code, Request};
+use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
 use tower_http::request_id::{MakeRequestUuid, PropagateRequestIdLayer, SetRequestIdLayer};
 use tower_http::trace::TraceLayer;
@@ -142,6 +144,7 @@ pub fn router_with_ops(
     admin_auth: AuthCore,
     ratelimit: RateLimitCore,
     ops: OpsState,
+    cors_origins: &[String],
 ) -> Router {
     let base = router_with_admin(
         handler,
@@ -158,9 +161,31 @@ pub fn router_with_ops(
     // so we call them here in the reverse order — propagate (innermost),
     // trace, then SetRequestId (outermost, generates the id before
     // TraceLayer reads it).
-    base.layer(PropagateRequestIdLayer::x_request_id())
+    let traced = base
+        .layer(PropagateRequestIdLayer::x_request_id())
         .layer(TraceLayer::new_for_http().make_span_with(make_http_span))
-        .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid))
+        .layer(SetRequestIdLayer::x_request_id(MakeRequestUuid));
+
+    if cors_origins.is_empty() {
+        return traced;
+    }
+
+    let origins: Vec<HeaderValue> = cors_origins
+        .iter()
+        .filter_map(|o| o.parse().ok())
+        .collect();
+
+    let cors = CorsLayer::new()
+        .allow_origin(AllowOrigin::list(origins))
+        .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
+        .allow_headers([
+            header::CONTENT_TYPE,
+            HeaderName::from_static("x-api-key"),
+        ])
+        .expose_headers([HeaderName::from_static("x-request-id")])
+        .max_age(Duration::from_secs(3600));
+
+    traced.layer(cors)
 }
 
 /// Build the per-request tracing span. Pulls the request_id off the

--- a/crates/dp-api/tests/cors.rs
+++ b/crates/dp-api/tests/cors.rs
@@ -1,0 +1,179 @@
+use axum::body::Body;
+use axum::http::{header, HeaderName, HeaderValue, Method, Request, StatusCode};
+use axum::routing::get;
+use axum::Router;
+use std::time::Duration;
+use tower::ServiceExt;
+use tower_http::cors::{AllowOrigin, CorsLayer};
+
+const ALLOWED_ORIGIN: &str = "http://localhost:3000";
+const UNKNOWN_ORIGIN: &str = "http://evil.example.com";
+
+fn build_cors_layer(origins: &[&str]) -> CorsLayer {
+    let values: Vec<HeaderValue> = origins
+        .iter()
+        .filter_map(|o| o.parse().ok())
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(AllowOrigin::list(values))
+        .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
+        .allow_headers([
+            header::CONTENT_TYPE,
+            HeaderName::from_static("x-api-key"),
+        ])
+        .expose_headers([HeaderName::from_static("x-request-id")])
+        .max_age(Duration::from_secs(3600))
+}
+
+fn app_with_cors(origins: &[&str]) -> Router {
+    Router::new()
+        .route("/v1/orders", get(|| async { "ok" }).post(|| async { "ok" }))
+        .route("/v1/pairs", get(|| async { "ok" }))
+        .layer(build_cors_layer(origins))
+}
+
+fn app_without_cors() -> Router {
+    Router::new()
+        .route("/v1/orders", get(|| async { "ok" }).post(|| async { "ok" }))
+        .route("/v1/pairs", get(|| async { "ok" }))
+}
+
+#[tokio::test]
+async fn preflight_returns_cors_headers() {
+    let app = app_with_cors(&[ALLOWED_ORIGIN]);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/v1/orders")
+                .header("origin", ALLOWED_ORIGIN)
+                .header("access-control-request-method", "POST")
+                .header("access-control-request-headers", "x-api-key,content-type")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("access-control-allow-origin").unwrap(),
+        ALLOWED_ORIGIN,
+    );
+    let methods = resp
+        .headers()
+        .get("access-control-allow-methods")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(methods.contains("POST"), "expected POST in {methods}");
+    assert!(
+        resp.headers().get("access-control-max-age").is_some(),
+        "expected max-age header",
+    );
+}
+
+#[tokio::test]
+async fn actual_cross_origin_get_includes_allow_origin() {
+    let app = app_with_cors(&[ALLOWED_ORIGIN]);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/pairs")
+                .header("origin", ALLOWED_ORIGIN)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(
+        resp.headers().get("access-control-allow-origin").unwrap(),
+        ALLOWED_ORIGIN,
+    );
+    let exposed = resp
+        .headers()
+        .get("access-control-expose-headers")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(
+        exposed.contains("x-request-id"),
+        "expected x-request-id in expose-headers, got {exposed}",
+    );
+}
+
+#[tokio::test]
+async fn unknown_origin_gets_no_allow_header() {
+    let app = app_with_cors(&[ALLOWED_ORIGIN]);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/v1/orders")
+                .header("origin", UNKNOWN_ORIGIN)
+                .header("access-control-request-method", "POST")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        resp.headers().get("access-control-allow-origin").is_none(),
+        "unknown origin must not receive allow-origin",
+    );
+}
+
+#[tokio::test]
+async fn disabled_when_no_origins_configured() {
+    let app = app_without_cors();
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/pairs")
+                .header("origin", ALLOWED_ORIGIN)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(
+        resp.headers().get("access-control-allow-origin").is_none(),
+        "no CORS headers when origins not configured",
+    );
+}
+
+#[tokio::test]
+async fn multiple_origins_allowed() {
+    let second = "https://app.darkpool.exchange";
+    let app = app_with_cors(&[ALLOWED_ORIGIN, second]);
+
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/pairs")
+                .header("origin", second)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.headers().get("access-control-allow-origin").unwrap(),
+        second,
+    );
+}

--- a/crates/dp-api/tests/cors.rs
+++ b/crates/dp-api/tests/cors.rs
@@ -17,7 +17,7 @@ fn build_cors_layer(origins: &[&str]) -> CorsLayer {
 
     CorsLayer::new()
         .allow_origin(AllowOrigin::list(values))
-        .allow_methods([Method::GET, Method::POST, Method::DELETE, Method::OPTIONS])
+        .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE, Method::OPTIONS])
         .allow_headers([
             header::CONTENT_TYPE,
             HeaderName::from_static("x-api-key"),
@@ -176,4 +176,31 @@ async fn multiple_origins_allowed() {
         resp.headers().get("access-control-allow-origin").unwrap(),
         second,
     );
+}
+
+#[tokio::test]
+async fn preflight_allows_patch_for_admin_routes() {
+    let app = app_with_cors(&[ALLOWED_ORIGIN]);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("OPTIONS")
+                .uri("/v1/orders")
+                .header("origin", ALLOWED_ORIGIN)
+                .header("access-control-request-method", "PATCH")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let methods = resp
+        .headers()
+        .get("access-control-allow-methods")
+        .unwrap()
+        .to_str()
+        .unwrap();
+    assert!(methods.contains("PATCH"), "expected PATCH in {methods}");
 }

--- a/crates/dp-api/tests/cors.rs
+++ b/crates/dp-api/tests/cors.rs
@@ -10,18 +10,18 @@ const ALLOWED_ORIGIN: &str = "http://localhost:3000";
 const UNKNOWN_ORIGIN: &str = "http://evil.example.com";
 
 fn build_cors_layer(origins: &[&str]) -> CorsLayer {
-    let values: Vec<HeaderValue> = origins
-        .iter()
-        .filter_map(|o| o.parse().ok())
-        .collect();
+    let values: Vec<HeaderValue> = origins.iter().filter_map(|o| o.parse().ok()).collect();
 
     CorsLayer::new()
         .allow_origin(AllowOrigin::list(values))
-        .allow_methods([Method::GET, Method::POST, Method::PATCH, Method::DELETE, Method::OPTIONS])
-        .allow_headers([
-            header::CONTENT_TYPE,
-            HeaderName::from_static("x-api-key"),
+        .allow_methods([
+            Method::GET,
+            Method::POST,
+            Method::PATCH,
+            Method::DELETE,
+            Method::OPTIONS,
         ])
+        .allow_headers([header::CONTENT_TYPE, HeaderName::from_static("x-api-key")])
         .expose_headers([HeaderName::from_static("x-request-id")])
         .max_age(Duration::from_secs(3600))
 }

--- a/crates/dp-api/tests/observability_http.rs
+++ b/crates/dp-api/tests/observability_http.rs
@@ -54,6 +54,7 @@ fn make_router(probes: ReadinessProbes) -> axum::Router {
             prom: shared_prom(),
             readiness: probes,
         },
+        &[],
     )
 }
 


### PR DESCRIPTION
Closes #82

## Summary

- Add `DARKPOOL_CORS_ORIGINS` env var (comma-separated allowlist) to `Config`
- Conditionally apply `CorsLayer` as the outermost layer in `router_with_ops` — when empty (default), no CORS headers are emitted and behavior is unchanged
- Allow `GET`, `POST`, `DELETE`, `OPTIONS` methods; allow `content-type` + `x-api-key` headers; expose `x-request-id`; cache preflight for 1 hour
- 5 integration tests: preflight, actual cross-origin GET, unknown origin rejection, disabled-when-empty, multiple origins

## Test plan

- [x] `cargo test -p dp-api` — all 225 tests pass (14 suites)
- [x] `cargo test -p dp-api --test cors` — 5/5 CORS-specific tests pass
- [ ] Manual smoke: `DARKPOOL_CORS_ORIGINS=http://localhost:3000 cargo run -p dp-api` then `curl -i -X OPTIONS http://localhost:8080/v1/orders -H "Origin: http://localhost:3000" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: x-api-key,content-type"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CORS (Cross-Origin Resource Sharing) support to enable cross-origin API requests.
  * Configure allowed origins using the new `DARKPOOL_CORS_ORIGINS` environment variable as a comma-separated list.
  * CORS headers are automatically applied with support for specified HTTP methods and request headers.

* **Tests**
  * Added comprehensive CORS integration test suite.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/135?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->