### PR TITLE
[C3] Add SSE bridge for auction stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2315,6 +2315,7 @@ dependencies = [
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
+ "percent-encoding",
  "prost",
  "rand 0.8.6",
  "rcgen",

--- a/crates/dp-api/Cargo.toml
+++ b/crates/dp-api/Cargo.toml
@@ -55,6 +55,7 @@ humantime.workspace = true
 futures-util.workspace = true
 sha2 = { workspace = true }
 ulid = { workspace = true }
+percent-encoding = "2"
 
 [dev-dependencies]
 alloy-primitives.workspace = true

--- a/crates/dp-api/src/auth.rs
+++ b/crates/dp-api/src/auth.rs
@@ -113,11 +113,34 @@ where
 
 pub async fn auth_axum_mw(
     AxumState(core): AxumState<AuthCore>,
-    req: AxumRequest,
+    mut req: AxumRequest,
     next: Next,
 ) -> AxumResponse {
+    if req.headers().get(AUTH_HEADER).is_none() {
+        if let Some(key) = extract_api_key_from_query(req.uri().query()) {
+            if let Ok(val) = http::HeaderValue::from_str(&key) {
+                req.headers_mut()
+                    .insert(http::HeaderName::from_static(AUTH_HEADER), val);
+            }
+        }
+    }
     if let Err(status) = core.check(req.headers()) {
         return crate::rest::status_to_response(status);
     }
     next.run(req).await
+}
+
+fn extract_api_key_from_query(query: Option<&str>) -> Option<String> {
+    let q = query?;
+    for param in q.split('&') {
+        let (key, value) = param.split_once('=')?;
+        if key == "apiKey" && !value.is_empty() {
+            return Some(
+                percent_encoding::percent_decode_str(value)
+                    .decode_utf8_lossy()
+                    .into_owned(),
+            );
+        }
+    }
+    None
 }

--- a/crates/dp-api/src/auth.rs
+++ b/crates/dp-api/src/auth.rs
@@ -133,7 +133,9 @@ pub async fn auth_axum_mw(
 fn extract_api_key_from_query(query: Option<&str>) -> Option<String> {
     let q = query?;
     for param in q.split('&') {
-        let (key, value) = param.split_once('=')?;
+        let Some((key, value)) = param.split_once('=') else {
+            continue;
+        };
         if key == "apiKey" && !value.is_empty() {
             return Some(
                 percent_encoding::percent_decode_str(value)

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -1,3 +1,4 @@
+use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -5,11 +6,14 @@ use axum::body::Body;
 use axum::extract::{MatchedPath, Path, Query, State};
 use axum::http::{header, HeaderName, HeaderValue, Method, Request as AxumRequest, StatusCode};
 use axum::middleware::from_fn_with_state;
+use axum::response::sse::{Event, KeepAlive, Sse};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{delete, get, patch, post};
 use axum::{Json, Router};
+use futures_util::StreamExt;
 use metrics_exporter_prometheus::PrometheusHandle;
 use serde::{Deserialize, Serialize};
+use tokio_stream::wrappers::BroadcastStream;
 use tonic::{Code, Request};
 use tower_http::cors::{AllowOrigin, CorsLayer};
 use tower_http::limit::RequestBodyLimitLayer;
@@ -30,7 +34,7 @@ use crate::pb::{
 };
 use crate::ratelimit::{ratelimit_axum_mw, RateLimitCore};
 use crate::readiness::ReadinessProbes;
-use crate::validation::{MAX_CIPHERTEXT_BYTES, MAX_PROOF_BYTES};
+use crate::validation::{validate_pair_known, MAX_CIPHERTEXT_BYTES, MAX_PROOF_BYTES};
 use dp_crypto::{KeyStatus, MultiKeyDecrypter};
 
 pub type SharedHandler = Arc<ApiHandler>;
@@ -62,6 +66,7 @@ pub fn router(handler: SharedHandler) -> Router {
         )
         .route("/v1/orderbook", get(rest_get_orderbook))
         .route("/v1/auctions", get(rest_get_auction_history))
+        .route("/v1/auctions/stream", get(rest_stream_auctions))
         .route("/v1/pairs", get(rest_list_pairs))
         .with_state(handler)
 }
@@ -518,6 +523,36 @@ struct AuctionHistoryQuery {
     limit: i32,
 }
 
+#[derive(Deserialize)]
+struct AuctionStreamQuery {
+    #[serde(default)]
+    pair: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AuctionEventSseJson {
+    auction_id: String,
+    pair: String,
+    clearing_price: String,
+    matched_volume: String,
+    match_count: u32,
+    timestamp_unix: String,
+}
+
+impl From<dp_engine::AuctionNotification> for AuctionEventSseJson {
+    fn from(n: dp_engine::AuctionNotification) -> Self {
+        Self {
+            auction_id: n.auction_id.to_string(),
+            pair: n.pair,
+            clearing_price: n.clearing_price.to_string(),
+            matched_volume: n.matched_volume.to_string(),
+            match_count: n.match_count,
+            timestamp_unix: n.timestamp.timestamp().to_string(),
+        }
+    }
+}
+
 // ---------- error mapping ----------
 
 struct ApiError(tonic::Status);
@@ -615,6 +650,38 @@ async fn rest_get_auction_history(
     Ok(Json(AuctionHistoryRespJson {
         auctions: resp.auctions.into_iter().map(Into::into).collect(),
     }))
+}
+
+async fn rest_stream_auctions(
+    State(h): State<SharedHandler>,
+    Query(q): Query<AuctionStreamQuery>,
+) -> Result<Sse<impl futures_util::Stream<Item = Result<Event, Infallible>>>, ApiError> {
+    let pair = if q.pair.is_empty() {
+        String::new()
+    } else {
+        validate_pair_known(&h.engine, &q.pair)?.into_string()
+    };
+    let rx = h.engine.subscribe();
+    let stream = BroadcastStream::new(rx).filter_map(move |item| {
+        let pair = pair.clone();
+        async move {
+            match item {
+                Ok(n) => {
+                    if !pair.is_empty() && n.pair != pair {
+                        return None;
+                    }
+                    let json: AuctionEventSseJson = n.into();
+                    let data = serde_json::to_string(&json).expect("AuctionEventSseJson is always serializable");
+                    Some(Ok(Event::default().event("auction").data(data)))
+                }
+                Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n)) => {
+                    let data = format!(r#"{{"lagged":{}}}"#, n);
+                    Some(Ok(Event::default().event("error").data(data)))
+                }
+            }
+        }
+    });
+    Ok(Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15))))
 }
 
 async fn rest_list_pairs(State(h): State<SharedHandler>) -> Result<Json<ListPairsJson>, ApiError> {

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -671,7 +671,8 @@ async fn rest_stream_auctions(
                         return None;
                     }
                     let json: AuctionEventSseJson = n.into();
-                    let data = serde_json::to_string(&json).expect("AuctionEventSseJson is always serializable");
+                    let data = serde_json::to_string(&json)
+                        .expect("AuctionEventSseJson is always serializable");
                     Some(Ok(Event::default().event("auction").data(data)))
                 }
                 Err(tokio_stream::wrappers::errors::BroadcastStreamRecvError::Lagged(n)) => {

--- a/crates/dp-api/tests/rest.rs
+++ b/crates/dp-api/tests/rest.rs
@@ -342,6 +342,7 @@ async fn router_with_middleware_enforces_api_key() {
 
     // With api key → 200
     let resp = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/v1/pairs")
@@ -352,4 +353,157 @@ async fn router_with_middleware_enforces_api_key() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
+
+    // With api key in query param → 200
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairs?apiKey=mw-key")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// ---------- SSE auction stream ----------
+
+#[tokio::test]
+async fn sse_stream_unknown_pair_returns_404() {
+    let app = new_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/auctions/stream?pair=FAKE/PAIR")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn sse_stream_returns_event_stream_content_type() {
+    let store = std::sync::Arc::new(MemStore::new());
+    let engine = Engine::new(store, Duration::from_secs(1));
+    engine.register_pair_without_event("ETH/USDC".into(), dp_engine::PairConfig::default());
+    let handler = ApiHandler::new(engine);
+    let app = rest::router(std::sync::Arc::new(handler));
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/auctions/stream?pair=ETH/USDC")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let ct = resp.headers().get("content-type").unwrap().to_str().unwrap();
+    assert!(ct.contains("text/event-stream"), "content-type was: {ct}");
+}
+
+#[tokio::test]
+async fn sse_stream_no_pair_filter_returns_200() {
+    let app = new_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/auctions/stream")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn sse_stream_receives_auction_events() {
+    let (app, engine) = registered_app();
+
+    // Place crossing orders so the auction tick produces a match.
+    let make_body = |side: dp_types::Side, price: &str| {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+        let d = dp_crypto::DecryptedOrder {
+            trader: alloy_primitives::Address::ZERO,
+            pair: "ETH/USDC".into(),
+            side,
+            price: price.parse().unwrap(),
+            size: "1".parse().unwrap(),
+            commitment_key: format!("sse-{}-{}", side as u8, price),
+            ttl: 60_000_000_000,
+        };
+        serde_json::json!({
+            "commitment": STANDARD.encode([0u8; 32]),
+            "proof": STANDARD.encode(b"p"),
+            "encryptedPayload": encrypt_b64(&d),
+        })
+        .to_string()
+    };
+
+    for (side, price) in [
+        (dp_types::Side::Buy, "1800"),
+        (dp_types::Side::Sell, "1800"),
+    ] {
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/orders")
+                    .header("content-type", "application/json")
+                    .body(Body::from(make_body(side, price)))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/auctions/stream?pair=ETH/USDC")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let mut body = resp.into_body();
+
+    let eng = engine.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        eng.run_auction_tick().await;
+    });
+
+    let frame = tokio::time::timeout(Duration::from_secs(5), async {
+        let mut buf = String::new();
+        loop {
+            match body.frame().await {
+                Some(Ok(frame)) => {
+                    if let Some(data) = frame.data_ref() {
+                        buf.push_str(&String::from_utf8_lossy(data));
+                        if buf.contains("event: auction") {
+                            return buf;
+                        }
+                    }
+                }
+                _ => tokio::time::sleep(Duration::from_millis(10)).await,
+            }
+        }
+    })
+    .await;
+
+    assert!(frame.is_ok(), "timed out waiting for auction SSE event");
+    let text = frame.unwrap();
+    assert!(text.contains("\"pair\":\"ETH/USDC\""));
+    assert!(text.contains("\"clearingPrice\""));
 }

--- a/crates/dp-api/tests/rest.rs
+++ b/crates/dp-api/tests/rest.rs
@@ -356,9 +356,23 @@ async fn router_with_middleware_enforces_api_key() {
 
     // With api key in query param → 200
     let resp = app
+        .clone()
         .oneshot(
             Request::builder()
                 .uri("/v1/pairs?apiKey=mw-key")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // With percent-encoded api key in query param → 200
+    // "mw-key" percent-encoded: "mw%2Dkey"
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/pairs?apiKey=mw%2Dkey")
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -402,7 +416,12 @@ async fn sse_stream_returns_event_stream_content_type() {
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
-    let ct = resp.headers().get("content-type").unwrap().to_str().unwrap();
+    let ct = resp
+        .headers()
+        .get("content-type")
+        .unwrap()
+        .to_str()
+        .unwrap();
     assert!(ct.contains("text/event-stream"), "content-type was: {ct}");
 }
 

--- a/docs/adr/0004-sse-auction-stream.md
+++ b/docs/adr/0004-sse-auction-stream.md
@@ -1,0 +1,68 @@
+# ADR 0004 — SSE bridge for auction streaming
+
+- **Status:** Accepted
+- **Date:** 2026-05-25
+- **Issue:** [#83](https://github.com/Dnreikronos/DarkPool-Exchange/issues/83)
+
+## Context
+
+The gRPC `StreamAuctions` RPC works for native clients but browsers
+cannot speak raw gRPC (HTTP/2 binary framing). The frontend TypeScript
+SDK is REST-based and currently throws `UNIMPLEMENTED` for streaming.
+Real-time auction settlement events need a browser-compatible transport.
+
+## Decision
+
+Add a `GET /v1/auctions/stream` SSE endpoint on the existing Axum REST
+listener that subscribes to the same `broadcast::Sender<AuctionNotification>`
+used by the gRPC stream.
+
+### Why SSE over gRPC-web (tonic-web)
+
+1. **No client library.** SSE works with the browser-native `EventSource`
+   API. grpc-web requires a dedicated client library plus proto codegen
+   targeting the web transport.
+2. **JSON everywhere.** The REST surface already serialises to camelCase
+   JSON. SSE `data:` lines carry the same shape — no binary framing.
+3. **Proxy transparency.** SSE is plain HTTP/1.1 chunked transfer. It
+   transits every proxy, ALB, and CDN without special configuration.
+4. **No new dependency.** `axum::response::sse` ships in axum 0.7's
+   default feature set.
+
+### Wire format
+
+Each auction settlement is an SSE event:
+
+    event: auction
+    data: {"auctionId":"...","pair":"ETH/USDC","clearingPrice":"2001.5","matchedVolume":"12.0","matchCount":4,"timestampUnix":"1716508800"}
+
+Broadcast channel overflow surfaces as:
+
+    event: error
+    data: {"lagged":3}
+
+A 15-second keepalive comment prevents proxy idle-timeout disconnects:
+
+    : keepalive
+
+### Auth
+
+`EventSource` cannot set custom headers. The `auth_axum_mw` middleware
+gains a query-parameter fallback: when the `x-api-key` header is absent,
+it checks `?apiKey=<token>` before rejecting. The EventSource URL
+becomes `/v1/auctions/stream?apiKey=<token>`.
+
+### Pair filtering
+
+Optional `?pair=ETH/USDC` query parameter. Validated against the pair
+registry — unknown pairs return 404. Empty = all pairs.
+
+## Consequences
+
+- Broadcast channel capacity (64) bounds how many un-consumed events a
+  slow SSE client can buffer before lag. Identical to the gRPC stream.
+- SSE is unidirectional. Bidirectional streaming (if ever needed) would
+  require WebSocket alongside SSE, not replacing it.
+- The `apiKey` query parameter appears in server access logs. Security
+  posture is unchanged since the key already travels in cleartext over
+  HTTPS; log scrubbing is a separate operational concern.

--- a/tests/e2e/sse_stream.mjs
+++ b/tests/e2e/sse_stream.mjs
@@ -1,0 +1,86 @@
+#!/usr/bin/env node
+//
+// E2E test: connect to the SSE auction stream and consume 3 events.
+//
+// Usage:
+//   1. Start the server with a short auction interval and pre-registered pair:
+//      cargo run -p dp-api -- --auction-interval 2s --pair ETH/USDC
+//   2. Place crossing orders (buy + sell at same price) to trigger matches.
+//   3. Run this script:
+//      node tests/e2e/sse_stream.mjs
+//
+// Environment:
+//   DARKPOOL_REST_URL  (default: http://127.0.0.1:8080)
+//   DARKPOOL_API_KEY   (default: empty — works when server has no keys configured)
+
+const BASE = process.env.DARKPOOL_REST_URL ?? "http://127.0.0.1:8080";
+const API_KEY = process.env.DARKPOOL_API_KEY ?? "";
+
+const WANT = 3;
+const TIMEOUT_MS = 120_000;
+
+const params = new URLSearchParams();
+params.set("pair", "ETH/USDC");
+if (API_KEY) params.set("apiKey", API_KEY);
+
+const url = `${BASE}/v1/auctions/stream?${params}`;
+console.log(`Connecting to ${url}`);
+console.log(`Waiting for ${WANT} auction events…\n`);
+
+const events = [];
+const es = new EventSource(url);
+
+es.addEventListener("auction", (e) => {
+  const data = JSON.parse(e.data);
+  events.push(data);
+  console.log(`[${events.length}/${WANT}]`, data);
+  if (events.length >= WANT) {
+    es.close();
+    validate(events);
+  }
+});
+
+es.addEventListener("error", (e) => {
+  const data = e.data ? JSON.parse(e.data) : null;
+  if (data?.lagged) {
+    console.warn(`Lagged: missed ${data.lagged} events`);
+  }
+});
+
+es.onerror = (e) => {
+  console.error("EventSource error (will auto-reconnect):", e.type);
+};
+
+setTimeout(() => {
+  es.close();
+  console.error(
+    `\nTimed out after ${TIMEOUT_MS / 1000}s: received ${events.length}/${WANT} events`,
+  );
+  process.exit(1);
+}, TIMEOUT_MS);
+
+function validate(events) {
+  const fields = [
+    "auctionId",
+    "pair",
+    "clearingPrice",
+    "matchedVolume",
+    "matchCount",
+    "timestampUnix",
+  ];
+  for (const ev of events) {
+    for (const f of fields) {
+      assert(ev[f] !== undefined && ev[f] !== null, `missing field: ${f}`);
+    }
+    assert(typeof ev.matchCount === "number", "matchCount must be number");
+  }
+  console.log(`\nOK: received and validated ${events.length} auction events`);
+  process.exit(0);
+}
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error("FAIL:", msg);
+    process.exit(1);
+  }
+}

--- a/tests/e2e/sse_stream.mjs
+++ b/tests/e2e/sse_stream.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S node --experimental-eventsource
 //
 // E2E test: connect to the SSE auction stream and consume 3 events.
 //

--- a/tests/e2e/sse_stream.mjs
+++ b/tests/e2e/sse_stream.mjs
@@ -24,7 +24,8 @@ params.set("pair", "ETH/USDC");
 if (API_KEY) params.set("apiKey", API_KEY);
 
 const url = `${BASE}/v1/auctions/stream?${params}`;
-console.log(`Connecting to ${url}`);
+const safeUrl = API_KEY ? url.replace(API_KEY, "***") : url;
+console.log(`Connecting to ${safeUrl}`);
 console.log(`Waiting for ${WANT} auction events…\n`);
 
 const events = [];


### PR DESCRIPTION
Closes #83

## Summary

- Adds `GET /v1/auctions/stream` SSE endpoint that subscribes to the engine's broadcast channel — same source as the gRPC `StreamAuctions` RPC
- Auth middleware gains `?apiKey=` query-parameter fallback since `EventSource` cannot set custom headers
- Optional `?pair=ETH/USDC` filtering with pair registry validation (unknown pair → 404)
- Lag surfaces as in-band `event: error` with `{"lagged": N}` instead of closing the connection
- 15-second keepalive comment prevents proxy idle-timeout disconnects
- ADR 0004 records SSE-over-tonic-web decision and rationale

## Wire format

```
event: auction
data: {"auctionId":"...","pair":"ETH/USDC","clearingPrice":"2001.5","matchedVolume":"12.0","matchCount":4,"timestampUnix":"1716508800"}

event: error
data: {"lagged":3}

: keepalive
```

## Test plan

- [x] `cargo test -p dp-api` — 235 tests pass (4 new SSE tests + 1 new auth query-param test)
- [x] `cargo clippy -p dp-api` — clean
- [ ] E2E: `node tests/e2e/sse_stream.mjs` against running server with crossing orders
- [ ] Manual: `curl -N 'http://localhost:8080/v1/auctions/stream?apiKey=<key>'`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new SSE auction stream endpoint (`GET /v1/auctions/stream`) enabling real-time subscription to auction events with optional pair filtering.
  * API key authentication now supports query parameter fallback (`apiKey`) in addition to header-based authentication.
  * Stream emits auction events with pair and clearing price details, includes 15-second keepalive, and error handling for broadcast overflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->