### PR TITLE
Publish deployments/{chainId}.json from Deploy script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,7 +26,10 @@ RUST_LOG=info,dp_event=debug,dp_engine=info
 
 # --- Anvil + deployer ---
 ANVIL_PORT=8545
+# Alchemy (or other) RPC URL for remote deploys (`just deploy-remote`).
+# Example: https://eth-sepolia.g.alchemy.com/v2/<YOUR_API_KEY>
+RPC_URL=
 # Anvil dev key #0 is used as the compose default; override here only when
 # pointing at a non-anvil chain. Never set a real-chain key in this file.
-DEPLOYER_PRIVATE_KEY=
+PRIVATE_KEY=
 FEE_RECIPIENT=0xf39Fd6e51aad88F6F4ce6aB8827279cfFFb92266

--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -1,2 +1,4 @@
 /out/
 /cache/
+/deployments/*
+!/deployments/31337.json

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,66 +1,80 @@
-## Foundry
+# DarkPool Contracts
 
-**Foundry is a blazing fast, portable and modular toolkit for Ethereum application development written in Rust.**
+Solidity contracts for the ZK Dark Pool DEX, built with [Foundry](https://book.getfoundry.sh/).
 
-Foundry consists of:
+## Contracts
 
-- **Forge**: Ethereum testing framework (like Truffle, Hardhat and DappTools).
-- **Cast**: Swiss army knife for interacting with EVM smart contracts, sending transactions and getting chain data.
-- **Anvil**: Local Ethereum node, akin to Ganache, Hardhat Network.
-- **Chisel**: Fast, utilitarian, and verbose solidity REPL.
+| Contract | Purpose |
+|---|---|
+| `DarkPool.sol` | Escrow + batch settlement. Traders deposit ERC20s, operator submits batches with Groth16 proof. 5 bps protocol fee. |
+| `VerifierProxy.sol` | Governance router — allows rotating the verifier without redeploying DarkPool. |
+| `Groth16Verifier.sol` | BN254 proof verifier. VK is immutable at deploy. |
+| `HyperNovaDeciderVerifier.sol` | Stub IVC verifier (not for mainnet). |
 
-## Documentation
-
-https://book.getfoundry.sh/
-
-## Usage
-
-### Build
+## Build & Test
 
 ```shell
-$ forge build
+forge build
+forge test -vv
 ```
 
-### Test
+## Deploy
+
+### Local (anvil)
 
 ```shell
-$ forge test
+just anvil          # start local chain
+just deploy         # deploy to localhost:8545
 ```
+
+### Remote (testnet / mainnet)
+
+Set the following in your `.env` at the repo root:
+
+```shell
+RPC_URL=https://eth-sepolia.g.alchemy.com/v2/<YOUR_API_KEY>
+PRIVATE_KEY=0x<deployer private key>
+FEE_RECIPIENT=<address to receive protocol fees>
+VK_JSON_PATH=./test/fixtures/vk.json
+OPERATOR_PUBKEY_HEX=0x<33-byte compressed or 65-byte uncompressed SEC1 pubkey>
+# Optional (defaults to deployer; required on mainnet):
+# VERIFIER_GOVERNOR=<timelock or multisig address>
+```
+
+Then run:
+
+```shell
+just deploy-remote
+```
+
+## Deployment JSON
+
+Each deploy writes `contracts/deployments/{chainId}.json` with the deployed addresses and metadata. The frontend imports this statically to resolve contract addresses per network.
 
 ### Format
 
-```shell
-$ forge fmt
+```json
+{
+  "darkPool": "0x...",
+  "verifierProxy": "0x...",
+  "groth16Verifier": "0x...",
+  "hypernovaDeciderVerifier": "0x...",
+  "deployedAt": 1748189000,
+  "blockNumber": 10920379,
+  "gitSha": "40a8187"
+}
 ```
 
-### Gas Snapshots
+| Field | Type | Description |
+|---|---|---|
+| `darkPool` | `address` | Main escrow + settlement contract |
+| `verifierProxy` | `address` | Proxy routing verification calls |
+| `groth16Verifier` | `address` | Groth16 proof verifier |
+| `hypernovaDeciderVerifier` | `address` | IVC decider verifier (stub on testnet) |
+| `deployedAt` | `uint256` | Unix timestamp of the deploy block |
+| `blockNumber` | `uint256` | Block number of the deploy |
+| `gitSha` | `string` | Short git SHA at deploy time |
 
-```shell
-$ forge snapshot
-```
+### Committed deployments
 
-### Anvil
-
-```shell
-$ anvil
-```
-
-### Deploy
-
-```shell
-$ forge script script/Counter.s.sol:CounterScript --rpc-url <your_rpc_url> --private-key <your_private_key>
-```
-
-### Cast
-
-```shell
-$ cast <subcommand>
-```
-
-### Help
-
-```shell
-$ forge --help
-$ anvil --help
-$ cast --help
-```
+- `deployments/31337.json` — localhost (anvil) deployment for local dev and E2E tests.

--- a/contracts/deployments/31337.json
+++ b/contracts/deployments/31337.json
@@ -1,0 +1,9 @@
+{
+  "blockNumber": 2,
+  "darkPool": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
+  "deployedAt": 1779730616,
+  "gitSha": "40a8187",
+  "groth16Verifier": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+  "hypernovaDeciderVerifier": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
+  "verifierProxy": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
+}

--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -12,7 +12,10 @@ remappings = [
     "forge-std/=lib/forge-std/src/",
 ]
 
-fs_permissions = [{ access = "read", path = "./test/fixtures" }]
+fs_permissions = [
+    { access = "read", path = "./test/fixtures" },
+    { access = "read-write", path = "./deployments" },
+]
 
 [fuzz]
 runs = 256

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -84,7 +84,37 @@ contract DeployScript is Script {
             console.log("VerifierProxy ownership transferred to governor:", governor);
         }
 
+        _writeDeployment(
+            address(pool),
+            address(proxy),
+            address(verifier),
+            address(hypernova)
+        );
+
         vm.stopBroadcast();
+    }
+
+    function _writeDeployment(
+        address darkPool,
+        address verifierProxy,
+        address groth16Verifier,
+        address hypernovaVerifier
+    ) internal {
+        string memory out = "deployment";
+        out.serialize("darkPool", darkPool);
+        out.serialize("verifierProxy", verifierProxy);
+        out.serialize("groth16Verifier", groth16Verifier);
+        out.serialize("hypernovaDeciderVerifier", hypernovaVerifier);
+        out.serialize("deployedAt", block.timestamp);
+        out.serialize("blockNumber", block.number);
+        string memory gitSha = vm.envOr("GIT_SHA", string("unknown"));
+        string memory json = out.serialize("gitSha", gitSha);
+
+        string memory path = string.concat(
+            "./deployments/", vm.toString(block.chainid), ".json"
+        );
+        vm.writeJson(json, path);
+        console.log("Deployment written to:", path);
     }
 
     function _loadVk(string memory path)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - ./contracts:/contracts
       - shared:/shared
     environment:
-      PRIVATE_KEY: ${DEPLOYER_PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}
+      PRIVATE_KEY: ${PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}
       FEE_RECIPIENT: ${FEE_RECIPIENT:-0xf39Fd6e51aad88F6F4ce6aB8827279cfFFb92266}
       VK_JSON_PATH: /contracts/test/fixtures/vk.json
     entrypoint:

--- a/justfile
+++ b/justfile
@@ -163,7 +163,18 @@ anvil:
 
 # Deploy contracts to a local anvil
 deploy RPC="http://127.0.0.1:8545":
-    cd contracts && forge script script/Deploy.s.sol:DeployScript --rpc-url {{RPC}} --broadcast
+    mkdir -p contracts/deployments
+    cd contracts && GIT_SHA=$(git rev-parse --short HEAD) forge script script/Deploy.s.sol:DeployScript --rpc-url {{RPC}} --broadcast
+
+# Deploy contracts to a remote chain (Alchemy RPC from .env)
+deploy-remote:
+    @test -n "${RPC_URL:-}" || { echo "ERROR: RPC_URL not set in .env"; exit 1; }
+    @test -n "${PRIVATE_KEY:-}" || { echo "ERROR: PRIVATE_KEY not set in .env"; exit 1; }
+    mkdir -p contracts/deployments
+    cd contracts && GIT_SHA=$(git rev-parse --short HEAD) forge script script/Deploy.s.sol:DeployScript \
+        --rpc-url "$RPC_URL" \
+        --broadcast \
+        --verify
 
 # ---------------------------------------------------------------------------
 # Database


### PR DESCRIPTION
Closes #84

## Summary
- `Deploy.s.sol` now writes `contracts/deployments/{chainId}.json` after each deploy with contract addresses, `deployedAt`, `blockNumber`, and `gitSha`
- New `just deploy-remote` recipe reads `RPC_URL` from `.env` for Alchemy/remote deploys with `--verify`
- Committed deterministic anvil deployment (`31337.json`) so contributors can run E2E without redeploying
- Documented contracts, deploy workflow, and deployment JSON format in `contracts/README.md`
- Renamed `DEPLOYER_PRIVATE_KEY` → `PRIVATE_KEY` across `.env.example` and `docker-compose.yml` for consistency with `Deploy.s.sol`

## Test plan
- [x] `forge build` compiles successfully
- [x] `forge test -vv` — 96/96 tests pass
- [x] `just deploy` against local anvil produces `deployments/31337.json`
- [x] `just deploy-remote` against Sepolia produces `deployments/11155111.json` with verified contracts on Sourcify

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensive contracts documentation with build, test, and deployment instructions added.

* **Chores**
  * Standardized environment variable naming: `DEPLOYER_PRIVATE_KEY` → `PRIVATE_KEY` across configuration files.
  * Added `RPC_URL` configuration for remote deployments.
  * Enhanced deployment workflow to capture and persist deployment metadata (addresses, block number, timestamp, git commit).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/140?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->