### PR TITLE
Add commit and prove-single-order subcommands to dp-zk-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1862,6 +1862,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "const-hex"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2516,6 +2527,7 @@ dependencies = [
  "ark-crypto-primitives",
  "ark-ec",
  "ark-ff 0.5.0",
+ "ark-groth16",
  "ark-grumpkin",
  "ark-r1cs-std",
  "ark-relations",
@@ -2548,6 +2560,7 @@ dependencies = [
  "clap",
  "dp-zk",
  "hex",
+ "insta",
  "k256",
  "rand 0.8.6",
  "rust_decimal",
@@ -2642,6 +2655,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "enum-ordinalize"
@@ -3615,6 +3634,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+ "tempfile",
 ]
 
 [[package]]
@@ -5937,6 +5968,12 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"

--- a/crates/dp-zk-cli/Cargo.toml
+++ b/crates/dp-zk-cli/Cargo.toml
@@ -30,3 +30,4 @@ ark-snark = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"
+insta = "1"

--- a/crates/dp-zk-cli/src/bin/dp-zk-cli.rs
+++ b/crates/dp-zk-cli/src/bin/dp-zk-cli.rs
@@ -1,11 +1,41 @@
-//! Stdin JSON → stdout proof bytes.
+//! DarkPool ZK CLI — subcommand-based interface.
 //!
-//! Exit codes:
-//! - 0: proof written to stdout.
-//! - 2: stdin read failure, missing private_witness, or invalid input.
-//! - 3: keys missing / version mismatch.
-//! - 4: circuit build, prover, or stdout write failure.
+//! Subcommands:
+//! - `commit`: compute Poseidon commitment for a single order.
+//! - `prove-single-order`: Groth16 proof of commitment preimage.
+//! - `prove-batch`: legacy stdin→stdout batch prover (same as dp-aggregator).
 
-fn main() -> std::process::ExitCode {
-    dp_zk_cli::run_prover_cli("dp-zk-cli", "DarkPool ZK batch prover")
+use std::process::ExitCode;
+
+use clap::{Parser, Subcommand};
+use dp_zk_cli::commit::{run_commit, CommitArgs};
+use dp_zk_cli::prove_single::{run_prove_single, ProveSingleArgs};
+use dp_zk_cli::ProverArgs;
+
+#[derive(Parser)]
+#[command(name = "dp-zk-cli", about = "DarkPool ZK toolkit")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Compute Poseidon commitment for a single order (JSON → hex).
+    Commit(CommitArgs),
+    /// Generate Groth16 proof of commitment preimage knowledge.
+    ProveSingleOrder(ProveSingleArgs),
+    /// Legacy batch prover (stdin JSON → stdout proof bytes).
+    ProveBatch(ProverArgs),
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    match cli.command {
+        Commands::Commit(args) => run_commit(args),
+        Commands::ProveSingleOrder(args) => run_prove_single(args),
+        Commands::ProveBatch(args) => {
+            dp_zk_cli::run_prover(args.batch_size, args.proving_key)
+        }
+    }
 }

--- a/crates/dp-zk-cli/src/bin/dp-zk-cli.rs
+++ b/crates/dp-zk-cli/src/bin/dp-zk-cli.rs
@@ -34,8 +34,6 @@ fn main() -> ExitCode {
     match cli.command {
         Commands::Commit(args) => run_commit(args),
         Commands::ProveSingleOrder(args) => run_prove_single(args),
-        Commands::ProveBatch(args) => {
-            dp_zk_cli::run_prover(args.batch_size, args.proving_key)
-        }
+        Commands::ProveBatch(args) => dp_zk_cli::run_prover(args.batch_size, args.proving_key),
     }
 }

--- a/crates/dp-zk-cli/src/commit.rs
+++ b/crates/dp-zk-cli/src/commit.rs
@@ -67,6 +67,9 @@ pub fn compute_commitment(input: &CommitInput) -> Result<String, String> {
 
     let salt_bytes = hex::decode(input.salt.trim_start_matches("0x"))
         .map_err(|e| format!("salt hex: {e}"))?;
+    if salt_bytes.len() != 32 {
+        return Err(format!("salt must be exactly 32 bytes, got {}", salt_bytes.len()));
+    }
     let salt = bytes_to_scalar(&salt_bytes);
 
     let limit_price = decimal_to_scalar(input.limit_price)
@@ -74,13 +77,15 @@ pub fn compute_commitment(input: &CommitInput) -> Result<String, String> {
     let size = decimal_to_scalar(input.size)
         .map_err(|e| format!("size: {e}"))?;
 
+    let side = match input.side {
+        0 => ark_ff::Zero::zero(),
+        1 => ark_ff::One::one(),
+        other => return Err(format!("side must be 0 or 1, got {other}")),
+    };
+
     let ci = OrderCommitmentInput {
         trader_id,
-        side: if input.side == 0 {
-            ark_ff::Zero::zero()
-        } else {
-            ark_ff::One::one()
-        },
+        side,
         limit_price,
         size,
         salt,
@@ -94,6 +99,9 @@ fn resolve_trader_id(input: &CommitInput) -> Result<ark_bn254::Fr, String> {
     if let Some(ref tid) = input.trader_id {
         let bytes = hex::decode(tid.trim_start_matches("0x"))
             .map_err(|e| format!("trader_id hex: {e}"))?;
+        if bytes.len() != 32 {
+            return Err(format!("trader_id must be exactly 32 bytes, got {}", bytes.len()));
+        }
         Ok(bytes_to_scalar(&bytes))
     } else if let Some(ref ck) = input.commitment_key {
         dp_zk::pedersen::derive_trader_id(ck.as_bytes())

--- a/crates/dp-zk-cli/src/commit.rs
+++ b/crates/dp-zk-cli/src/commit.rs
@@ -1,0 +1,238 @@
+//! `commit` subcommand: compute Poseidon commitment for a single order.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use dp_zk::pedersen::{bytes_to_scalar, commit_native, OrderCommitmentInput};
+use dp_zk::encoding::decimal_to_scalar;
+use rust_decimal::Decimal;
+use serde::Deserialize;
+
+#[derive(Parser, Debug)]
+pub struct CommitArgs {
+    /// Path to JSON input file. Reads from stdin if omitted.
+    #[arg(long)]
+    pub input: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CommitInput {
+    /// Hex-encoded 32-byte trader id (or derived from commitment_key if omitted).
+    pub trader_id: Option<String>,
+    /// Hex-encoded salt bytes.
+    pub salt: String,
+    /// 0 = bid, 1 = ask.
+    pub side: u8,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub limit_price: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub size: Decimal,
+    /// If provided and trader_id is absent, trader_id = poseidon(commitment_key).
+    pub commitment_key: Option<String>,
+}
+
+pub fn run_commit(args: CommitArgs) -> ExitCode {
+    let bytes = match read_input(args.input) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("read input: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let input: CommitInput = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("parse input: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    match compute_commitment(&input) {
+        Ok(hex) => {
+            println!("{hex}");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("commitment: {e}");
+            ExitCode::from(2)
+        }
+    }
+}
+
+pub fn compute_commitment(input: &CommitInput) -> Result<String, String> {
+    let trader_id = resolve_trader_id(input)?;
+
+    let salt_bytes = hex::decode(input.salt.trim_start_matches("0x"))
+        .map_err(|e| format!("salt hex: {e}"))?;
+    let salt = bytes_to_scalar(&salt_bytes);
+
+    let limit_price = decimal_to_scalar(input.limit_price)
+        .map_err(|e| format!("limit_price: {e}"))?;
+    let size = decimal_to_scalar(input.size)
+        .map_err(|e| format!("size: {e}"))?;
+
+    let ci = OrderCommitmentInput {
+        trader_id,
+        side: if input.side == 0 {
+            ark_ff::Zero::zero()
+        } else {
+            ark_ff::One::one()
+        },
+        limit_price,
+        size,
+        salt,
+    };
+
+    let commitment = commit_native(&ci);
+    Ok(hex::encode(dp_zk::fr_to_bytes32(commitment)))
+}
+
+fn resolve_trader_id(input: &CommitInput) -> Result<ark_bn254::Fr, String> {
+    if let Some(ref tid) = input.trader_id {
+        let bytes = hex::decode(tid.trim_start_matches("0x"))
+            .map_err(|e| format!("trader_id hex: {e}"))?;
+        Ok(bytes_to_scalar(&bytes))
+    } else if let Some(ref ck) = input.commitment_key {
+        dp_zk::pedersen::derive_trader_id(ck.as_bytes())
+            .map_err(|e| format!("derive trader_id: {e}"))
+    } else {
+        Err("must provide either trader_id or commitment_key".into())
+    }
+}
+
+fn read_input(path: Option<PathBuf>) -> Result<Vec<u8>, std::io::Error> {
+    match path {
+        Some(p) => std::fs::read(p),
+        None => {
+            let mut buf = Vec::new();
+            std::io::stdin().lock().read_to_end(&mut buf)?;
+            Ok(buf)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_output() {
+        let input = CommitInput {
+            trader_id: None,
+            salt: "22".repeat(32),
+            side: 0,
+            limit_price: Decimal::from(100),
+            size: Decimal::from(10),
+            commitment_key: Some("bid_key".into()),
+        };
+        let a = compute_commitment(&input).unwrap();
+        let b = compute_commitment(&input).unwrap();
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64); // 32 bytes hex
+    }
+
+    #[test]
+    fn explicit_trader_id_matches_derived() {
+        let ck = "bid_key";
+        let tid_bytes = dp_zk::pedersen::derive_trader_id_bytes(ck.as_bytes());
+        let tid_hex = hex::encode(tid_bytes);
+
+        let with_ck = CommitInput {
+            trader_id: None,
+            salt: "11".repeat(32),
+            side: 0,
+            limit_price: Decimal::from(50),
+            size: Decimal::from(5),
+            commitment_key: Some(ck.into()),
+        };
+        let with_tid = CommitInput {
+            trader_id: Some(tid_hex),
+            salt: "11".repeat(32),
+            side: 0,
+            limit_price: Decimal::from(50),
+            size: Decimal::from(5),
+            commitment_key: None,
+        };
+        assert_eq!(
+            compute_commitment(&with_ck).unwrap(),
+            compute_commitment(&with_tid).unwrap(),
+        );
+    }
+
+    #[test]
+    fn different_salt_different_commitment() {
+        let base = CommitInput {
+            trader_id: None,
+            salt: "aa".repeat(32),
+            side: 0,
+            limit_price: Decimal::from(100),
+            size: Decimal::from(10),
+            commitment_key: Some("key".into()),
+        };
+        let other = CommitInput {
+            salt: "bb".repeat(32),
+            ..CommitInput {
+                trader_id: None,
+                salt: String::new(),
+                side: 0,
+                limit_price: Decimal::from(100),
+                size: Decimal::from(10),
+                commitment_key: Some("key".into()),
+            }
+        };
+        assert_ne!(
+            compute_commitment(&base).unwrap(),
+            compute_commitment(&other).unwrap(),
+        );
+    }
+
+    #[test]
+    fn rejects_missing_trader_id_and_key() {
+        let input = CommitInput {
+            trader_id: None,
+            salt: "00".repeat(32),
+            side: 0,
+            limit_price: Decimal::from(100),
+            size: Decimal::from(10),
+            commitment_key: None,
+        };
+        assert!(compute_commitment(&input).is_err());
+    }
+
+    #[test]
+    fn rejects_bad_salt_hex() {
+        let input = CommitInput {
+            trader_id: None,
+            salt: "not-hex".into(),
+            side: 0,
+            limit_price: Decimal::from(100),
+            size: Decimal::from(10),
+            commitment_key: Some("k".into()),
+        };
+        assert!(compute_commitment(&input).is_err());
+    }
+
+    #[test]
+    fn snapshot_known_vector() {
+        let input = CommitInput {
+            trader_id: None,
+            salt: "00".repeat(32),
+            side: 0,
+            limit_price: Decimal::from(100),
+            size: Decimal::from(10),
+            commitment_key: Some("alice".into()),
+        };
+        let hex = compute_commitment(&input).unwrap();
+        // Pin this value — any change to Poseidon params breaks byte-parity.
+        assert_eq!(
+            hex,
+            compute_commitment(&input).unwrap(),
+            "commitment must be deterministic"
+        );
+        // Store the actual value once the test passes to snapshot it.
+        insta::assert_snapshot!("commitment_alice_bid_100_10", hex);
+    }
+}

--- a/crates/dp-zk-cli/src/commit.rs
+++ b/crates/dp-zk-cli/src/commit.rs
@@ -5,8 +5,8 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use clap::Parser;
-use dp_zk::pedersen::{bytes_to_scalar, commit_native, OrderCommitmentInput};
 use dp_zk::encoding::decimal_to_scalar;
+use dp_zk::pedersen::{bytes_to_scalar, commit_native, OrderCommitmentInput};
 use rust_decimal::Decimal;
 use serde::Deserialize;
 
@@ -65,17 +65,19 @@ pub fn run_commit(args: CommitArgs) -> ExitCode {
 pub fn compute_commitment(input: &CommitInput) -> Result<String, String> {
     let trader_id = resolve_trader_id(input)?;
 
-    let salt_bytes = hex::decode(input.salt.trim_start_matches("0x"))
-        .map_err(|e| format!("salt hex: {e}"))?;
+    let salt_bytes =
+        hex::decode(input.salt.trim_start_matches("0x")).map_err(|e| format!("salt hex: {e}"))?;
     if salt_bytes.len() != 32 {
-        return Err(format!("salt must be exactly 32 bytes, got {}", salt_bytes.len()));
+        return Err(format!(
+            "salt must be exactly 32 bytes, got {}",
+            salt_bytes.len()
+        ));
     }
     let salt = bytes_to_scalar(&salt_bytes);
 
-    let limit_price = decimal_to_scalar(input.limit_price)
-        .map_err(|e| format!("limit_price: {e}"))?;
-    let size = decimal_to_scalar(input.size)
-        .map_err(|e| format!("size: {e}"))?;
+    let limit_price =
+        decimal_to_scalar(input.limit_price).map_err(|e| format!("limit_price: {e}"))?;
+    let size = decimal_to_scalar(input.size).map_err(|e| format!("size: {e}"))?;
 
     let side = match input.side {
         0 => ark_ff::Zero::zero(),
@@ -97,10 +99,13 @@ pub fn compute_commitment(input: &CommitInput) -> Result<String, String> {
 
 fn resolve_trader_id(input: &CommitInput) -> Result<ark_bn254::Fr, String> {
     if let Some(ref tid) = input.trader_id {
-        let bytes = hex::decode(tid.trim_start_matches("0x"))
-            .map_err(|e| format!("trader_id hex: {e}"))?;
+        let bytes =
+            hex::decode(tid.trim_start_matches("0x")).map_err(|e| format!("trader_id hex: {e}"))?;
         if bytes.len() != 32 {
-            return Err(format!("trader_id must be exactly 32 bytes, got {}", bytes.len()));
+            return Err(format!(
+                "trader_id must be exactly 32 bytes, got {}",
+                bytes.len()
+            ));
         }
         Ok(bytes_to_scalar(&bytes))
     } else if let Some(ref ck) = input.commitment_key {

--- a/crates/dp-zk-cli/src/lib.rs
+++ b/crates/dp-zk-cli/src/lib.rs
@@ -186,6 +186,7 @@ pub fn run_prover_io<R: Read, W: Write>(
 }
 
 pub mod cli;
+pub mod commit;
 pub use cli::{run_prover, run_prover_cli};
 
 #[cfg(test)]

--- a/crates/dp-zk-cli/src/lib.rs
+++ b/crates/dp-zk-cli/src/lib.rs
@@ -187,6 +187,7 @@ pub fn run_prover_io<R: Read, W: Write>(
 
 pub mod cli;
 pub mod commit;
+pub mod prove_single;
 pub use cli::{run_prover, run_prover_cli};
 
 #[cfg(test)]

--- a/crates/dp-zk-cli/src/prove_single.rs
+++ b/crates/dp-zk-cli/src/prove_single.rs
@@ -1,0 +1,265 @@
+//! `prove-single-order` subcommand: Groth16 proof of commitment preimage.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use ark_ff::{One, Zero};
+use clap::Parser;
+use dp_zk::commitment_circuit::{setup_and_prove, CommitmentPreimageCircuit};
+use dp_zk::encoding::decimal_to_scalar;
+use dp_zk::pedersen::bytes_to_scalar;
+use dp_zk::{fr_to_bytes32, OrderCommitmentInput, commit_native};
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+#[derive(Parser, Debug)]
+pub struct ProveSingleArgs {
+    /// Path to JSON input file. Reads from stdin if omitted.
+    #[arg(long)]
+    pub input: Option<PathBuf>,
+    /// RNG seed for deterministic proof generation. Required for reproducible fixtures.
+    #[arg(long)]
+    pub seed: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ProveSingleInput {
+    pub trader_id: Option<String>,
+    pub salt: String,
+    pub side: u8,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub limit_price: Decimal,
+    #[serde(with = "rust_decimal::serde::str")]
+    pub size: Decimal,
+    pub commitment_key: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProveSingleOutput {
+    pub scalars: ScalarOutput,
+    pub commitment: String,
+    pub proof: String,
+    pub verification_key: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ScalarOutput {
+    pub trader_id: String,
+    pub side: String,
+    pub limit_price: String,
+    pub size: String,
+    pub salt: String,
+}
+
+pub fn run_prove_single(args: ProveSingleArgs) -> ExitCode {
+    let bytes = match read_input(args.input) {
+        Ok(b) => b,
+        Err(e) => {
+            eprintln!("read input: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    let input: ProveSingleInput = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("parse input: {e}");
+            return ExitCode::from(2);
+        }
+    };
+
+    match generate_proof(&input, args.seed) {
+        Ok(output) => {
+            println!("{}", serde_json::to_string_pretty(&output).unwrap());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("prove: {e}");
+            ExitCode::from(4)
+        }
+    }
+}
+
+pub fn generate_proof(
+    input: &ProveSingleInput,
+    seed: Option<u64>,
+) -> Result<ProveSingleOutput, String> {
+    let trader_id = resolve_trader_id(input)?;
+
+    let salt_bytes = hex::decode(input.salt.trim_start_matches("0x"))
+        .map_err(|e| format!("salt hex: {e}"))?;
+    let salt = bytes_to_scalar(&salt_bytes);
+
+    let limit_price = decimal_to_scalar(input.limit_price)
+        .map_err(|e| format!("limit_price: {e}"))?;
+    let size = decimal_to_scalar(input.size)
+        .map_err(|e| format!("size: {e}"))?;
+
+    let side_fr = if input.side == 0 {
+        ark_bn254::Fr::zero()
+    } else {
+        ark_bn254::Fr::one()
+    };
+
+    let circuit = CommitmentPreimageCircuit {
+        trader_id,
+        side: side_fr,
+        limit_price,
+        size,
+        salt,
+    };
+
+    let commitment = commit_native(&OrderCommitmentInput {
+        trader_id: circuit.trader_id,
+        side: circuit.side,
+        limit_price: circuit.limit_price,
+        size: circuit.size,
+        salt: circuit.salt,
+    });
+
+    let mut rng = make_rng(seed);
+    let result = setup_and_prove(&circuit, &mut rng)
+        .map_err(|e| format!("proof generation: {e}"))?;
+
+    Ok(ProveSingleOutput {
+        scalars: ScalarOutput {
+            trader_id: hex::encode(fr_to_bytes32(trader_id)),
+            side: hex::encode(fr_to_bytes32(side_fr)),
+            limit_price: hex::encode(fr_to_bytes32(limit_price)),
+            size: hex::encode(fr_to_bytes32(size)),
+            salt: hex::encode(fr_to_bytes32(salt)),
+        },
+        commitment: hex::encode(fr_to_bytes32(commitment)),
+        proof: hex::encode(&result.proof_bytes),
+        verification_key: hex::encode(&result.vk_bytes),
+    })
+}
+
+fn resolve_trader_id(input: &ProveSingleInput) -> Result<ark_bn254::Fr, String> {
+    if let Some(ref tid) = input.trader_id {
+        let bytes = hex::decode(tid.trim_start_matches("0x"))
+            .map_err(|e| format!("trader_id hex: {e}"))?;
+        Ok(bytes_to_scalar(&bytes))
+    } else if let Some(ref ck) = input.commitment_key {
+        dp_zk::pedersen::derive_trader_id(ck.as_bytes())
+            .map_err(|e| format!("derive trader_id: {e}"))
+    } else {
+        Err("must provide either trader_id or commitment_key".into())
+    }
+}
+
+fn make_rng(seed: Option<u64>) -> ark_std::rand::rngs::StdRng {
+    use ark_std::rand::SeedableRng;
+    let mut full_seed = [0u8; 32];
+    match seed {
+        Some(s) => full_seed[..8].copy_from_slice(&s.to_le_bytes()),
+        None => full_seed[..8].copy_from_slice(&1234567890u64.to_le_bytes()),
+    }
+    ark_std::rand::rngs::StdRng::from_seed(full_seed)
+}
+
+fn read_input(path: Option<PathBuf>) -> Result<Vec<u8>, std::io::Error> {
+    match path {
+        Some(p) => std::fs::read(p),
+        None => {
+            let mut buf = Vec::new();
+            std::io::stdin().lock().read_to_end(&mut buf)?;
+            Ok(buf)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_input() -> ProveSingleInput {
+        ProveSingleInput {
+            trader_id: None,
+            salt: "00".repeat(32),
+            side: 0,
+            limit_price: Decimal::from(100),
+            size: Decimal::from(10),
+            commitment_key: Some("alice".into()),
+        }
+    }
+
+    #[test]
+    fn generates_valid_proof() {
+        let input = sample_input();
+        let output = generate_proof(&input, Some(42)).unwrap();
+        assert_eq!(output.commitment.len(), 64);
+        assert!(!output.proof.is_empty());
+        assert!(!output.verification_key.is_empty());
+    }
+
+    #[test]
+    fn deterministic_with_same_seed() {
+        let input = sample_input();
+        let a = generate_proof(&input, Some(42)).unwrap();
+        let b = generate_proof(&input, Some(42)).unwrap();
+        assert_eq!(a.commitment, b.commitment);
+        assert_eq!(a.proof, b.proof);
+        assert_eq!(a.verification_key, b.verification_key);
+        assert_eq!(a.scalars.trader_id, b.scalars.trader_id);
+    }
+
+    #[test]
+    fn different_seed_different_proof_same_commitment() {
+        let input = sample_input();
+        let a = generate_proof(&input, Some(1)).unwrap();
+        let b = generate_proof(&input, Some(2)).unwrap();
+        assert_eq!(a.commitment, b.commitment);
+        assert_eq!(a.scalars.trader_id, b.scalars.trader_id);
+        // Proof bytes differ because different randomness, but both verify
+        // (vk also differs because setup randomness changes).
+    }
+
+    #[test]
+    fn commitment_matches_commit_subcommand() {
+        let input = sample_input();
+        let proof_output = generate_proof(&input, Some(42)).unwrap();
+
+        let commit_input = crate::commit::CommitInput {
+            trader_id: None,
+            salt: "00".repeat(32),
+            side: 0,
+            limit_price: Decimal::from(100),
+            size: Decimal::from(10),
+            commitment_key: Some("alice".into()),
+        };
+        let commit_hex = crate::commit::compute_commitment(&commit_input).unwrap();
+
+        assert_eq!(proof_output.commitment, commit_hex);
+    }
+
+    #[test]
+    fn proof_independently_verifiable() {
+        let input = sample_input();
+        let output = generate_proof(&input, Some(42)).unwrap();
+
+        let commitment_bytes = hex::decode(&output.commitment).unwrap();
+        let commitment = dp_zk::pedersen::bytes_to_scalar(&commitment_bytes);
+
+        let proof_bytes = hex::decode(&output.proof).unwrap();
+        let vk_bytes = hex::decode(&output.verification_key).unwrap();
+
+        let valid = dp_zk::commitment_circuit::verify_proof(&vk_bytes, &proof_bytes, commitment)
+            .unwrap();
+        assert!(valid);
+    }
+
+    #[test]
+    fn rejects_missing_identity() {
+        let input = ProveSingleInput {
+            trader_id: None,
+            salt: "00".repeat(32),
+            side: 0,
+            limit_price: Decimal::from(100),
+            size: Decimal::from(10),
+            commitment_key: None,
+        };
+        assert!(generate_proof(&input, Some(42)).is_err());
+    }
+}

--- a/crates/dp-zk-cli/src/prove_single.rs
+++ b/crates/dp-zk-cli/src/prove_single.rs
@@ -89,6 +89,9 @@ pub fn generate_proof(
 
     let salt_bytes = hex::decode(input.salt.trim_start_matches("0x"))
         .map_err(|e| format!("salt hex: {e}"))?;
+    if salt_bytes.len() != 32 {
+        return Err(format!("salt must be exactly 32 bytes, got {}", salt_bytes.len()));
+    }
     let salt = bytes_to_scalar(&salt_bytes);
 
     let limit_price = decimal_to_scalar(input.limit_price)
@@ -96,10 +99,10 @@ pub fn generate_proof(
     let size = decimal_to_scalar(input.size)
         .map_err(|e| format!("size: {e}"))?;
 
-    let side_fr = if input.side == 0 {
-        ark_bn254::Fr::zero()
-    } else {
-        ark_bn254::Fr::one()
+    let side_fr = match input.side {
+        0 => ark_bn254::Fr::zero(),
+        1 => ark_bn254::Fr::one(),
+        other => return Err(format!("side must be 0 or 1, got {other}")),
     };
 
     let circuit = CommitmentPreimageCircuit {
@@ -140,6 +143,9 @@ fn resolve_trader_id(input: &ProveSingleInput) -> Result<ark_bn254::Fr, String> 
     if let Some(ref tid) = input.trader_id {
         let bytes = hex::decode(tid.trim_start_matches("0x"))
             .map_err(|e| format!("trader_id hex: {e}"))?;
+        if bytes.len() != 32 {
+            return Err(format!("trader_id must be exactly 32 bytes, got {}", bytes.len()));
+        }
         Ok(bytes_to_scalar(&bytes))
     } else if let Some(ref ck) = input.commitment_key {
         dp_zk::pedersen::derive_trader_id(ck.as_bytes())

--- a/crates/dp-zk-cli/src/prove_single.rs
+++ b/crates/dp-zk-cli/src/prove_single.rs
@@ -9,7 +9,7 @@ use clap::Parser;
 use dp_zk::commitment_circuit::{setup_and_prove, CommitmentPreimageCircuit};
 use dp_zk::encoding::decimal_to_scalar;
 use dp_zk::pedersen::bytes_to_scalar;
-use dp_zk::{fr_to_bytes32, OrderCommitmentInput, commit_native};
+use dp_zk::{commit_native, fr_to_bytes32, OrderCommitmentInput};
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
@@ -87,17 +87,19 @@ pub fn generate_proof(
 ) -> Result<ProveSingleOutput, String> {
     let trader_id = resolve_trader_id(input)?;
 
-    let salt_bytes = hex::decode(input.salt.trim_start_matches("0x"))
-        .map_err(|e| format!("salt hex: {e}"))?;
+    let salt_bytes =
+        hex::decode(input.salt.trim_start_matches("0x")).map_err(|e| format!("salt hex: {e}"))?;
     if salt_bytes.len() != 32 {
-        return Err(format!("salt must be exactly 32 bytes, got {}", salt_bytes.len()));
+        return Err(format!(
+            "salt must be exactly 32 bytes, got {}",
+            salt_bytes.len()
+        ));
     }
     let salt = bytes_to_scalar(&salt_bytes);
 
-    let limit_price = decimal_to_scalar(input.limit_price)
-        .map_err(|e| format!("limit_price: {e}"))?;
-    let size = decimal_to_scalar(input.size)
-        .map_err(|e| format!("size: {e}"))?;
+    let limit_price =
+        decimal_to_scalar(input.limit_price).map_err(|e| format!("limit_price: {e}"))?;
+    let size = decimal_to_scalar(input.size).map_err(|e| format!("size: {e}"))?;
 
     let side_fr = match input.side {
         0 => ark_bn254::Fr::zero(),
@@ -122,8 +124,8 @@ pub fn generate_proof(
     });
 
     let mut rng = make_rng(seed);
-    let result = setup_and_prove(&circuit, &mut rng)
-        .map_err(|e| format!("proof generation: {e}"))?;
+    let result =
+        setup_and_prove(&circuit, &mut rng).map_err(|e| format!("proof generation: {e}"))?;
 
     Ok(ProveSingleOutput {
         scalars: ScalarOutput {
@@ -141,10 +143,13 @@ pub fn generate_proof(
 
 fn resolve_trader_id(input: &ProveSingleInput) -> Result<ark_bn254::Fr, String> {
     if let Some(ref tid) = input.trader_id {
-        let bytes = hex::decode(tid.trim_start_matches("0x"))
-            .map_err(|e| format!("trader_id hex: {e}"))?;
+        let bytes =
+            hex::decode(tid.trim_start_matches("0x")).map_err(|e| format!("trader_id hex: {e}"))?;
         if bytes.len() != 32 {
-            return Err(format!("trader_id must be exactly 32 bytes, got {}", bytes.len()));
+            return Err(format!(
+                "trader_id must be exactly 32 bytes, got {}",
+                bytes.len()
+            ));
         }
         Ok(bytes_to_scalar(&bytes))
     } else if let Some(ref ck) = input.commitment_key {
@@ -251,8 +256,8 @@ mod tests {
         let proof_bytes = hex::decode(&output.proof).unwrap();
         let vk_bytes = hex::decode(&output.verification_key).unwrap();
 
-        let valid = dp_zk::commitment_circuit::verify_proof(&vk_bytes, &proof_bytes, commitment)
-            .unwrap();
+        let valid =
+            dp_zk::commitment_circuit::verify_proof(&vk_bytes, &proof_bytes, commitment).unwrap();
         assert!(valid);
     }
 

--- a/crates/dp-zk-cli/src/snapshots/dp_zk_cli__commit__tests__commitment_alice_bid_100_10.snap
+++ b/crates/dp-zk-cli/src/snapshots/dp_zk_cli__commit__tests__commitment_alice_bid_100_10.snap
@@ -1,0 +1,6 @@
+---
+source: crates/dp-zk-cli/src/commit.rs
+assertion_line: 236
+expression: hex
+---
+221ab7304a89b8c85504d2711eca0fad71d02dece5d47543ce4b54e4cfb0bd73

--- a/crates/dp-zk/Cargo.toml
+++ b/crates/dp-zk/Cargo.toml
@@ -14,6 +14,7 @@ ark-snark = { workspace = true }
 ark-bn254 = { workspace = true, features = ["std"] }
 ark-grumpkin = { workspace = true }
 ark-crypto-primitives = { workspace = true, features = ["std", "sponge", "constraints"] }
+ark-groth16 = { workspace = true, features = ["std"] }
 folding-schemes = { workspace = true }
 
 uuid = { workspace = true }

--- a/crates/dp-zk/src/commitment_circuit.rs
+++ b/crates/dp-zk/src/commitment_circuit.rs
@@ -1,0 +1,193 @@
+//! Groth16 circuit proving knowledge of a Poseidon commitment preimage.
+//!
+//! Public input:  commitment (1 Fr element)
+//! Private witness: (trader_id, side, limit_price, size, salt)
+//! Constraint:    poseidon(trader_id, side, limit_price, size, salt) == commitment
+
+use ark_bn254::{Bn254, Fr};
+use ark_crypto_primitives::snark::SNARK;
+use ark_crypto_primitives::sponge::constraints::CryptographicSpongeVar;
+use ark_crypto_primitives::sponge::poseidon::constraints::PoseidonSpongeVar;
+use ark_groth16::Groth16;
+use ark_r1cs_std::alloc::AllocVar;
+use ark_r1cs_std::eq::EqGadget;
+use ark_r1cs_std::fields::fp::FpVar;
+use ark_relations::gr1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize, Compress, Validate};
+use ark_std::rand::{CryptoRng, RngCore};
+
+use crate::pedersen::{commit_native, poseidon_config, OrderCommitmentInput};
+
+#[derive(Clone, Debug)]
+pub struct CommitmentPreimageCircuit {
+    pub trader_id: Fr,
+    pub side: Fr,
+    pub limit_price: Fr,
+    pub size: Fr,
+    pub salt: Fr,
+}
+
+impl ConstraintSynthesizer<Fr> for CommitmentPreimageCircuit {
+    fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> Result<(), SynthesisError> {
+        let cfg = poseidon_config();
+
+        let trader_id = FpVar::new_witness(cs.clone(), || Ok(self.trader_id))?;
+        let side = FpVar::new_witness(cs.clone(), || Ok(self.side))?;
+        let limit_price = FpVar::new_witness(cs.clone(), || Ok(self.limit_price))?;
+        let size = FpVar::new_witness(cs.clone(), || Ok(self.size))?;
+        let salt = FpVar::new_witness(cs.clone(), || Ok(self.salt))?;
+
+        let expected = compute_commitment_native(&self);
+        let expected_var = FpVar::new_input(cs.clone(), || Ok(expected))?;
+
+        let mut sponge = PoseidonSpongeVar::<Fr>::new(cs, &cfg);
+        sponge.absorb(
+            &[
+                trader_id,
+                side,
+                limit_price,
+                size,
+                salt,
+            ]
+            .as_ref(),
+        )?;
+        let computed = sponge.squeeze_field_elements(1)?[0].clone();
+
+        computed.enforce_equal(&expected_var)?;
+
+        Ok(())
+    }
+}
+
+fn compute_commitment_native(circuit: &CommitmentPreimageCircuit) -> Fr {
+    let input = OrderCommitmentInput {
+        trader_id: circuit.trader_id,
+        side: circuit.side,
+        limit_price: circuit.limit_price,
+        size: circuit.size,
+        salt: circuit.salt,
+    };
+    commit_native(&input)
+}
+
+pub struct SingleOrderProof {
+    pub commitment: Fr,
+    pub proof_bytes: Vec<u8>,
+    pub vk_bytes: Vec<u8>,
+}
+
+pub fn setup_and_prove<R: RngCore + CryptoRng>(
+    circuit: &CommitmentPreimageCircuit,
+    rng: &mut R,
+) -> Result<SingleOrderProof, crate::ZkError> {
+    let commitment = compute_commitment_native(circuit);
+
+    let (pk, vk) = Groth16::<Bn254>::circuit_specific_setup(circuit.clone(), rng)
+        .map_err(|e| crate::ZkError::Setup(e.to_string()))?;
+
+    let proof = Groth16::<Bn254>::prove(&pk, circuit.clone(), rng)
+        .map_err(|e| crate::ZkError::Prove(e.to_string()))?;
+
+    let pvk = Groth16::<Bn254>::process_vk(&vk)
+        .map_err(|e| crate::ZkError::Setup(e.to_string()))?;
+
+    let valid = Groth16::<Bn254>::verify_with_processed_vk(&pvk, &[commitment], &proof)
+        .map_err(|e| crate::ZkError::Prove(e.to_string()))?;
+
+    if !valid {
+        return Err(crate::ZkError::Verify);
+    }
+
+    let mut proof_bytes = Vec::new();
+    proof
+        .serialize_with_mode(&mut proof_bytes, Compress::Yes)
+        .map_err(|e| crate::ZkError::Serialize(e.to_string()))?;
+
+    let mut vk_bytes = Vec::new();
+    vk.serialize_with_mode(&mut vk_bytes, Compress::Yes)
+        .map_err(|e| crate::ZkError::Serialize(e.to_string()))?;
+
+    Ok(SingleOrderProof {
+        commitment,
+        proof_bytes,
+        vk_bytes,
+    })
+}
+
+pub fn verify_proof(vk_bytes: &[u8], proof_bytes: &[u8], commitment: Fr) -> Result<bool, crate::ZkError> {
+    let vk = ark_groth16::VerifyingKey::<Bn254>::deserialize_with_mode(
+        vk_bytes,
+        Compress::Yes,
+        Validate::Yes,
+    )
+    .map_err(|e| crate::ZkError::Serialize(format!("deserialize vk: {e}")))?;
+
+    let proof = ark_groth16::Proof::<Bn254>::deserialize_with_mode(
+        proof_bytes,
+        Compress::Yes,
+        Validate::Yes,
+    )
+    .map_err(|e| crate::ZkError::Serialize(format!("deserialize proof: {e}")))?;
+
+    let pvk = ark_groth16::prepare_verifying_key(&vk);
+    let valid = Groth16::<Bn254>::verify_with_processed_vk(&pvk, &[commitment], &proof)
+        .map_err(|e| crate::ZkError::Prove(e.to_string()))?;
+
+    Ok(valid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ark_ff::{One, Zero};
+    use ark_std::rand::SeedableRng;
+    use ark_std::rand::rngs::StdRng;
+    use crate::encoding::decimal_to_scalar;
+    use crate::pedersen::bytes_to_scalar;
+    use rust_decimal::Decimal;
+
+    fn fixed_rng() -> StdRng {
+        StdRng::from_seed([42u8; 32])
+    }
+
+    fn sample_circuit() -> CommitmentPreimageCircuit {
+        let trader_id = crate::pedersen::derive_trader_id(b"alice").unwrap();
+        let salt = bytes_to_scalar(&[0x22u8; 32]);
+        CommitmentPreimageCircuit {
+            trader_id,
+            side: Fr::zero(),
+            limit_price: decimal_to_scalar(Decimal::from(100)).unwrap(),
+            size: decimal_to_scalar(Decimal::from(10)).unwrap(),
+            salt,
+        }
+    }
+
+    #[test]
+    fn proof_verifies() {
+        let circuit = sample_circuit();
+        let mut rng = fixed_rng();
+        let result = setup_and_prove(&circuit, &mut rng).unwrap();
+        assert!(verify_proof(&result.vk_bytes, &result.proof_bytes, result.commitment).unwrap());
+    }
+
+    #[test]
+    fn proof_rejects_wrong_commitment() {
+        let circuit = sample_circuit();
+        let mut rng = fixed_rng();
+        let result = setup_and_prove(&circuit, &mut rng).unwrap();
+        let wrong_commitment = result.commitment + Fr::one();
+        assert!(!verify_proof(&result.vk_bytes, &result.proof_bytes, wrong_commitment).unwrap());
+    }
+
+    #[test]
+    fn deterministic_with_same_rng_seed() {
+        let circuit = sample_circuit();
+        let mut rng1 = fixed_rng();
+        let mut rng2 = fixed_rng();
+        let r1 = setup_and_prove(&circuit, &mut rng1).unwrap();
+        let r2 = setup_and_prove(&circuit, &mut rng2).unwrap();
+        assert_eq!(r1.commitment, r2.commitment);
+        assert_eq!(r1.proof_bytes, r2.proof_bytes);
+        assert_eq!(r1.vk_bytes, r2.vk_bytes);
+    }
+}

--- a/crates/dp-zk/src/commitment_circuit.rs
+++ b/crates/dp-zk/src/commitment_circuit.rs
@@ -41,16 +41,7 @@ impl ConstraintSynthesizer<Fr> for CommitmentPreimageCircuit {
         let expected_var = FpVar::new_input(cs.clone(), || Ok(expected))?;
 
         let mut sponge = PoseidonSpongeVar::<Fr>::new(cs, &cfg);
-        sponge.absorb(
-            &[
-                trader_id,
-                side,
-                limit_price,
-                size,
-                salt,
-            ]
-            .as_ref(),
-        )?;
+        sponge.absorb(&[trader_id, side, limit_price, size, salt].as_ref())?;
         let computed = sponge.squeeze_field_elements(1)?[0].clone();
 
         computed.enforce_equal(&expected_var)?;
@@ -88,8 +79,8 @@ pub fn setup_and_prove<R: RngCore + CryptoRng>(
     let proof = Groth16::<Bn254>::prove(&pk, circuit.clone(), rng)
         .map_err(|e| crate::ZkError::Prove(e.to_string()))?;
 
-    let pvk = Groth16::<Bn254>::process_vk(&vk)
-        .map_err(|e| crate::ZkError::Setup(e.to_string()))?;
+    let pvk =
+        Groth16::<Bn254>::process_vk(&vk).map_err(|e| crate::ZkError::Setup(e.to_string()))?;
 
     let valid = Groth16::<Bn254>::verify_with_processed_vk(&pvk, &[commitment], &proof)
         .map_err(|e| crate::ZkError::Prove(e.to_string()))?;
@@ -114,7 +105,11 @@ pub fn setup_and_prove<R: RngCore + CryptoRng>(
     })
 }
 
-pub fn verify_proof(vk_bytes: &[u8], proof_bytes: &[u8], commitment: Fr) -> Result<bool, crate::ZkError> {
+pub fn verify_proof(
+    vk_bytes: &[u8],
+    proof_bytes: &[u8],
+    commitment: Fr,
+) -> Result<bool, crate::ZkError> {
     let vk = ark_groth16::VerifyingKey::<Bn254>::deserialize_with_mode(
         vk_bytes,
         Compress::Yes,
@@ -139,11 +134,11 @@ pub fn verify_proof(vk_bytes: &[u8], proof_bytes: &[u8], commitment: Fr) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ark_ff::{One, Zero};
-    use ark_std::rand::SeedableRng;
-    use ark_std::rand::rngs::StdRng;
     use crate::encoding::decimal_to_scalar;
     use crate::pedersen::bytes_to_scalar;
+    use ark_ff::{One, Zero};
+    use ark_std::rand::rngs::StdRng;
+    use ark_std::rand::SeedableRng;
     use rust_decimal::Decimal;
 
     fn fixed_rng() -> StdRng {

--- a/crates/dp-zk/src/lib.rs
+++ b/crates/dp-zk/src/lib.rs
@@ -15,6 +15,7 @@
 //! is what binds the order inside the ZK circuit. There is no separate
 //! SHA256 commitment.
 
+pub mod commitment_circuit;
 pub mod encoding;
 pub mod folding;
 pub mod params;


### PR DESCRIPTION
Closes #86

## Summary
- Adds `commit` subcommand: JSON order input → deterministic Poseidon commitment hex
- Adds `prove-single-order` subcommand: Groth16 proof of commitment preimage knowledge (outputs scalars, commitment, proof, verification key as JSON)
- Adds `CommitmentPreimageCircuit` to dp-zk: minimal Groth16 circuit proving `poseidon(trader_id, side, limit_price, size, salt) == commitment`
- Restructures `dp-zk-cli` binary to use clap subcommands; `dp-aggregator` unchanged

## Key decisions
- **Real ZK proof**: `prove-single-order` generates an actual Groth16 SNARK, not just a constraint satisfaction check
- **Deterministic fixtures**: `--seed` flag pins RNG for reproducible golden-value outputs in CI
- **Commitment consistency**: both subcommands produce identical commitment values for the same input

## Test plan
- [x] 45 tests pass across dp-zk and dp-zk-cli (3 circuit tests + 25 CLI tests + existing)
- [x] Snapshot test pins commitment byte value for regression detection
- [x] Proof independently verifiable via `verify_proof` API
- [x] Determinism verified: same seed → identical output
- [x] End-to-end: pipe JSON through binary, get expected hex/JSON output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI reworked into subcommands: compute order commitment, generate a single-order proof, and keep legacy batch prove mode.
  * JSON input via file or stdin; outputs include hex commitment, proof bytes, and verification key.
  * Optional seed for deterministic proof generation.

* **Tests**
  * Added unit tests for commitment correctness, proof generation/verification, determinism, and error conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/141?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->