### PR TITLE
Docker Compose for local stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,13 @@ RPC_URL=
 # pointing at a non-anvil chain. Never set a real-chain key in this file.
 PRIVATE_KEY=
 FEE_RECIPIENT=0xf39Fd6e51aad88F6F4ce6aB8827279cfFFb92266
+
+# --- Contract address (set after `just deploy`) ---
+DARKPOOL_CONTRACT_ADDR=
+
+# --- Frontend (--profile frontend) ---
+FRONTEND_PORT=3000
+NEXT_PUBLIC_USE_MOCKS=false
+NEXT_PUBLIC_API_URL=http://localhost:8080
+NEXT_PUBLIC_GRPC_URL=http://localhost:9090
+NEXT_PUBLIC_RPC_URL=http://localhost:8545

--- a/README.md
+++ b/README.md
@@ -139,7 +139,43 @@ flowchart TB
 
 ---
 
-## Build & run
+## Local development (Docker Compose)
+
+Prerequisites: Docker (with Compose v2.20+), [Foundry](https://getfoundry.sh), [just](https://github.com/casey/just).
+
+```bash
+cp .env.example .env
+
+# 1. Start infra (postgres + anvil + dp-api)
+just up
+
+# 2. Deploy contracts to the local anvil chain
+just deploy
+
+# 3. Fund a test trader with mock WETH + USDC
+just fund-trader
+
+# 4. (Optional) Start the frontend on :3000
+just up-frontend
+```
+
+Other useful recipes:
+
+```bash
+just logs                  # tail darkpool-server logs
+just logs anvil            # tail anvil logs
+just up-obs                # add Prometheus + Grafana + Jaeger
+just up-zk                 # add ZK keygen + aggregator
+just ps                    # show running services
+just down                  # stop everything
+just clean                 # stop + remove volumes (destructive)
+```
+
+See `.env.example` for all configurable variables.
+
+---
+
+## Build & run (without Docker)
 
 ```bash
 cargo build --release --workspace

--- a/contracts/script/FundTrader.s.sol
+++ b/contracts/script/FundTrader.s.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Script, console} from "forge-std/Script.sol";
+import {MockERC20} from "../test/mocks/MockERC20.sol";
+
+/// @notice Deploys mock WETH + USDC tokens and funds a test trader address.
+/// Usage: TRADER=0x... forge script script/FundTrader.s.sol:FundTrader --rpc-url ... --broadcast
+contract FundTrader is Script {
+    function run() public {
+        uint256 deployerKey = vm.envUint("PRIVATE_KEY");
+        address trader = vm.envOr("TRADER", vm.addr(deployerKey));
+
+        vm.startBroadcast(deployerKey);
+
+        MockERC20 weth = new MockERC20("Wrapped Ether", "WETH", 18);
+        MockERC20 usdc = new MockERC20("USD Coin", "USDC", 6);
+
+        weth.mint(trader, 100 ether);
+        usdc.mint(trader, 1_000_000e6);
+
+        console.log("WETH:", address(weth));
+        console.log("USDC:", address(usdc));
+        console.log("Trader:", trader);
+        console.log("WETH balance:", weth.balanceOf(trader));
+        console.log("USDC balance:", usdc.balanceOf(trader));
+
+        vm.stopBroadcast();
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,41 +31,6 @@ services:
       timeout: 3s
       retries: 20
 
-  deployer:
-    image: ghcr.io/foundry-rs/foundry:stable
-    container_name: darkpool-deployer
-    depends_on:
-      anvil:
-        condition: service_healthy
-    working_dir: /contracts
-    user: "0:0"
-    volumes:
-      - ./contracts:/contracts
-      - shared:/shared
-    environment:
-      PRIVATE_KEY: ${PRIVATE_KEY:-0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80}
-      FEE_RECIPIENT: ${FEE_RECIPIENT:-0xf39Fd6e51aad88F6F4ce6aB8827279cfFFb92266}
-      VK_JSON_PATH: /contracts/test/fixtures/vk.json
-    entrypoint:
-      - /bin/sh
-      - -c
-      - |
-        set -eu
-        forge script script/Deploy.s.sol:DeployScript \
-          --rpc-url http://anvil:8545 --broadcast 2>&1 | tee /tmp/deploy.log
-        DARKPOOL_ADDR=$$(grep -oE 'DarkPool: 0x[a-fA-F0-9]{40}' /tmp/deploy.log | tail -n1 | awk '{print $$2}')
-        VERIFIER_ADDR=$$(grep -oE 'VerifierProxy: 0x[a-fA-F0-9]{40}' /tmp/deploy.log | tail -n1 | awk '{print $$2}')
-        if [ -z "$$DARKPOOL_ADDR" ] || [ -z "$$VERIFIER_ADDR" ]; then
-          echo "failed to parse deploy output; full log:" >&2
-          cat /tmp/deploy.log >&2
-          exit 1
-        fi
-        # broadcast/ is written as root (foundry image default); make it host-writable.
-        chmod -R a+rwX broadcast 2>/dev/null || true
-        printf 'DARKPOOL_CONTRACT_ADDR=%s\n' "$$DARKPOOL_ADDR" > /shared/contracts.env
-        echo "deployed -> DarkPool=$$DARKPOOL_ADDR VerifierProxy=$$VERIFIER_ADDR (verifier wired via DarkPool ctor)"
-    restart: "no"
-
   darkpool-server:
     build:
       context: .
@@ -77,15 +42,13 @@ services:
         condition: service_healthy
       anvil:
         condition: service_healthy
-      deployer:
-        condition: service_completed_successfully
       keygen:
         condition: service_completed_successfully
         required: false
     volumes:
-      - shared:/shared:ro
       - zk-keys:/keys:ro
     environment:
+      DARKPOOL_CONTRACT_ADDR: ${DARKPOOL_CONTRACT_ADDR:-}
       DARKPOOL_GRPC_ADDR: 0.0.0.0:9090
       DARKPOOL_HTTP_ADDR: 0.0.0.0:8080
       DARKPOOL_EVENT_DB: postgres://${POSTGRES_USER:-darkpool}:${POSTGRES_PASSWORD:-darkpool}@postgres:5432/${POSTGRES_DB:-darkpool}
@@ -108,15 +71,7 @@ services:
       OTEL_SERVICE_NAME: ${OTEL_SERVICE_NAME:-darkpool-api}
       DP_ENVIRONMENT: ${DP_ENVIRONMENT:-local}
       DP_LOG_FORMAT: ${DP_LOG_FORMAT:-json}
-    entrypoint:
-      - /bin/sh
-      - -c
-      - |
-        set -eu
-        set -a
-        . /shared/contracts.env
-        set +a
-        exec /usr/local/bin/darkpool-server
+    entrypoint: ["/usr/local/bin/darkpool-server"]
     ports:
       - "${DARKPOOL_GRPC_PORT:-9090}:9090"
       - "${DARKPOOL_HTTP_PORT:-8080}:8080"
@@ -186,5 +141,4 @@ services:
 
 volumes:
   postgres-data:
-  shared:
   zk-keys:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,31 @@ services:
     ports:
       - "${GRAFANA_PORT:-3001}:3000"
 
+  frontend:
+    image: node:22-alpine
+    container_name: darkpool-frontend
+    profiles: ["frontend"]
+    working_dir: /app
+    volumes:
+      - ./front:/app
+      - frontend-node-modules:/app/node_modules
+    environment:
+      NEXT_PUBLIC_USE_MOCKS: ${NEXT_PUBLIC_USE_MOCKS:-false}
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8080}
+      NEXT_PUBLIC_GRPC_URL: ${NEXT_PUBLIC_GRPC_URL:-http://localhost:9090}
+      NEXT_PUBLIC_CHAIN_ID: ${DARKPOOL_CHAIN_ID:-31337}
+      NEXT_PUBLIC_RPC_URL: ${NEXT_PUBLIC_RPC_URL:-http://localhost:8545}
+      NEXT_PUBLIC_DARKPOOL_ADDR: ${DARKPOOL_CONTRACT_ADDR:-}
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        corepack enable && corepack prepare pnpm@latest --activate
+        pnpm install --frozen-lockfile
+        exec pnpm dev --hostname 0.0.0.0
+    ports:
+      - "${FRONTEND_PORT:-3000}:3000"
+
   keygen:
     image: darkpool-server:dev
     container_name: darkpool-keygen
@@ -142,3 +167,4 @@ services:
 volumes:
   postgres-data:
   zk-keys:
+  frontend-node-modules:

--- a/justfile
+++ b/justfile
@@ -100,6 +100,10 @@ up-zk:
     DARKPOOL_ZK_PROVING_KEY={{ZK_KEYS}} \
     {{COMPOSE}} --profile zk up -d --build
 
+# Bring up stack with frontend on :3000
+up-frontend:
+    {{COMPOSE}} --profile frontend up -d --build
+
 # Bring up the obs stack (default services + prometheus/grafana/jaeger; server pushes OTLP to jaeger)
 up-obs:
     OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://jaeger:4317} \

--- a/justfile
+++ b/justfile
@@ -166,6 +166,10 @@ deploy RPC="http://127.0.0.1:8545":
     mkdir -p contracts/deployments
     cd contracts && GIT_SHA=$(git rev-parse --short HEAD) forge script script/Deploy.s.sol:DeployScript --rpc-url {{RPC}} --broadcast
 
+# Deploy mock WETH+USDC and fund a test trader (anvil key #0 by default)
+fund-trader RPC="http://127.0.0.1:8545":
+    cd contracts && forge script script/FundTrader.s.sol:FundTrader --rpc-url {{RPC}} --broadcast
+
 # Deploy contracts to a remote chain (Alchemy RPC from .env)
 deploy-remote:
     @test -n "${RPC_URL:-}" || { echo "ERROR: RPC_URL not set in .env"; exit 1; }


### PR DESCRIPTION
Fixes #88

## What

Reworked the docker-compose local dev story. Removed the `deployer` container that auto-deployed contracts on `docker compose up` -- contract deployment now goes through `just deploy` so the operator decides when to deploy rather than having it coupled to container startup. The `shared` volume and the shell entrypoint that sourced `contracts.env` are gone; the contract address is a plain env var (`DARKPOOL_CONTRACT_ADDR`).

Added a `FundTrader.s.sol` forge script that deploys mock WETH/USDC and mints 100 WETH + 1M USDC to a test trader. Wired as `just fund-trader`.

Added an optional `frontend` service (behind `--profile frontend`) running `pnpm dev` on port 3000. Activate with `just up-frontend`.

README now has a quickstart: `just up` -> `just deploy` -> `just fund-trader` -> `just up-frontend`. Updated `.env.example` with the new variables.

## Local dev flow

    cp .env.example .env
    just up              # postgres + anvil + dp-api
    just deploy          # contracts to anvil
    just fund-trader     # mock WETH/USDC + mint
    just up-frontend     # optional, Next.js on :3000