### PR TITLE
api: Add SIWE wallet authentication with JWT sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,6 +2319,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "humantime",
+ "jsonwebtoken",
  "k256",
  "metrics",
  "metrics-exporter-prometheus",
@@ -2338,8 +2339,10 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
+ "siwe",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -6001,6 +6004,22 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "siwe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95bdefc0eedf06440b27092fbfe33f2cb493ad6a3423aa12cfe7f2aac44bd618"
+dependencies = [
+ "hex",
+ "http",
+ "iri-string",
+ "k256",
+ "rand 0.8.6",
+ "sha3",
+ "thiserror 1.0.69",
  "time",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2339,6 +2339,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
+ "sha3",
  "siwe",
  "tempfile",
  "thiserror 2.0.18",

--- a/crates/dp-api/Cargo.toml
+++ b/crates/dp-api/Cargo.toml
@@ -56,6 +56,11 @@ futures-util.workspace = true
 sha2 = { workspace = true }
 ulid = { workspace = true }
 percent-encoding = "2"
+siwe = "0.6"
+jsonwebtoken = "9"
+rand = "0.8"
+hex = { workspace = true }
+time = "0.3"
 
 [dev-dependencies]
 alloy-primitives.workspace = true

--- a/crates/dp-api/Cargo.toml
+++ b/crates/dp-api/Cargo.toml
@@ -71,8 +71,9 @@ tempfile = "3"
 rcgen = "0.13"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-manual-roots", "json"] }
 tokio-rustls.workspace = true
-k256 = "0.13"
+k256 = { version = "0.13", features = ["ecdsa"] }
 rand = "0.8"
+sha3 = "0.10"
 ecies = { workspace = true }
 
 [build-dependencies]

--- a/crates/dp-api/src/auth.rs
+++ b/crates/dp-api/src/auth.rs
@@ -46,20 +46,21 @@ impl AuthCore {
 
     pub fn check(&self, headers: &HeaderMap) -> Result<AuthenticatedIdentity, Status> {
         if let Some(auth_val) = headers.get(http::header::AUTHORIZATION) {
-            if let Some(jwt) = &self.jwt {
-                let auth_str = auth_val
-                    .to_str()
-                    .map_err(|_| Status::unauthenticated("invalid authorization header"))?;
-                if let Some(token) = auth_str.strip_prefix("Bearer ") {
-                    let claims = jwt.verify(token).map_err(|e| {
-                        Status::unauthenticated(format!("invalid token: {e}"))
+            let auth_str = auth_val
+                .to_str()
+                .map_err(|_| Status::unauthenticated("invalid authorization header"))?;
+            if let Some(token) = auth_str.strip_prefix("Bearer ") {
+                let jwt = self.jwt.as_ref().ok_or_else(|| {
+                    Status::unauthenticated("bearer authentication not enabled")
+                })?;
+                let claims = jwt.verify(token).map_err(|e| {
+                    Status::unauthenticated(format!("invalid token: {e}"))
+                })?;
+                let addr = crate::siwe::JwtManager::address_from_claims(&claims)
+                    .ok_or_else(|| {
+                        Status::unauthenticated("invalid address in token")
                     })?;
-                    let addr = crate::siwe::JwtManager::address_from_claims(&claims)
-                        .ok_or_else(|| {
-                            Status::unauthenticated("invalid address in token")
-                        })?;
-                    return Ok(AuthenticatedIdentity::Wallet(addr));
-                }
+                return Ok(AuthenticatedIdentity::Wallet(addr));
             }
         }
 

--- a/crates/dp-api/src/auth.rs
+++ b/crates/dp-api/src/auth.rs
@@ -50,16 +50,15 @@ impl AuthCore {
                 .to_str()
                 .map_err(|_| Status::unauthenticated("invalid authorization header"))?;
             if let Some(token) = auth_str.strip_prefix("Bearer ") {
-                let jwt = self.jwt.as_ref().ok_or_else(|| {
-                    Status::unauthenticated("bearer authentication not enabled")
-                })?;
-                let claims = jwt.verify(token).map_err(|e| {
-                    Status::unauthenticated(format!("invalid token: {e}"))
-                })?;
+                let jwt = self
+                    .jwt
+                    .as_ref()
+                    .ok_or_else(|| Status::unauthenticated("bearer authentication not enabled"))?;
+                let claims = jwt
+                    .verify(token)
+                    .map_err(|e| Status::unauthenticated(format!("invalid token: {e}")))?;
                 let addr = crate::siwe::JwtManager::address_from_claims(&claims)
-                    .ok_or_else(|| {
-                        Status::unauthenticated("invalid address in token")
-                    })?;
+                    .ok_or_else(|| Status::unauthenticated("invalid address in token"))?;
                 return Ok(AuthenticatedIdentity::Wallet(addr));
             }
         }

--- a/crates/dp-api/src/auth.rs
+++ b/crates/dp-api/src/auth.rs
@@ -4,6 +4,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 
+use alloy_primitives::Address;
 use axum::extract::{Request as AxumRequest, State as AxumState};
 use axum::middleware::Next;
 use axum::response::Response as AxumResponse;
@@ -17,23 +18,54 @@ use crate::validation::{MSG_INVALID_API_KEY, MSG_MISSING_API_KEY};
 pub const AUTH_HEADER: &str = "x-api-key";
 
 #[derive(Clone, Debug)]
+pub enum AuthenticatedIdentity {
+    ApiKey,
+    Wallet(Address),
+}
+
+#[derive(Clone, Debug)]
 pub struct AuthCore {
     keys: Arc<HashSet<String>>,
+    jwt: Option<Arc<crate::siwe::JwtManager>>,
 }
 
 impl AuthCore {
     pub fn new(keys: Vec<String>) -> Self {
         Self {
             keys: Arc::new(keys.into_iter().filter(|k| !k.is_empty()).collect()),
+            jwt: None,
         }
     }
 
-    pub fn check(&self, headers: &HeaderMap) -> Result<(), Status> {
-        if self.keys.is_empty() {
-            return Ok(());
+    pub fn new_with_jwt(keys: Vec<String>, jwt: Arc<crate::siwe::JwtManager>) -> Self {
+        Self {
+            keys: Arc::new(keys.into_iter().filter(|k| !k.is_empty()).collect()),
+            jwt: Some(jwt),
         }
-        // All auth failures map to Unauthenticated so clients can branch on
-        // Code alone. The message disambiguates missing-vs-invalid for logs.
+    }
+
+    pub fn check(&self, headers: &HeaderMap) -> Result<AuthenticatedIdentity, Status> {
+        if let Some(auth_val) = headers.get(http::header::AUTHORIZATION) {
+            if let Some(jwt) = &self.jwt {
+                let auth_str = auth_val
+                    .to_str()
+                    .map_err(|_| Status::unauthenticated("invalid authorization header"))?;
+                if let Some(token) = auth_str.strip_prefix("Bearer ") {
+                    let claims = jwt.verify(token).map_err(|e| {
+                        Status::unauthenticated(format!("invalid token: {e}"))
+                    })?;
+                    let addr = crate::siwe::JwtManager::address_from_claims(&claims)
+                        .ok_or_else(|| {
+                            Status::unauthenticated("invalid address in token")
+                        })?;
+                    return Ok(AuthenticatedIdentity::Wallet(addr));
+                }
+            }
+        }
+
+        if self.keys.is_empty() {
+            return Ok(AuthenticatedIdentity::ApiKey);
+        }
         let key = match headers.get(AUTH_HEADER) {
             Some(v) => match v.to_str() {
                 Ok(s) => s,
@@ -47,7 +79,7 @@ impl AuthCore {
         if !self.keys.contains(key) {
             return Err(Status::unauthenticated(MSG_INVALID_API_KEY));
         }
-        Ok(())
+        Ok(AuthenticatedIdentity::ApiKey)
     }
 }
 
@@ -98,15 +130,18 @@ where
         self.inner.poll_ready(cx)
     }
 
-    fn call(&mut self, req: Request<B>) -> Self::Future {
+    fn call(&mut self, mut req: Request<B>) -> Self::Future {
         let clone = self.inner.clone();
         let mut inner = std::mem::replace(&mut self.inner, clone);
         let core = self.core.clone();
         Box::pin(async move {
-            if let Err(status) = core.check(req.headers()) {
-                return Ok(status.into_http());
+            match core.check(req.headers()) {
+                Ok(identity) => {
+                    req.extensions_mut().insert(identity);
+                    inner.call(req).await
+                }
+                Err(status) => Ok(status.into_http()),
             }
-            inner.call(req).await
         })
     }
 }
@@ -124,10 +159,13 @@ pub async fn auth_axum_mw(
             }
         }
     }
-    if let Err(status) = core.check(req.headers()) {
-        return crate::rest::status_to_response(status);
+    match core.check(req.headers()) {
+        Ok(identity) => {
+            req.extensions_mut().insert(identity);
+            next.run(req).await
+        }
+        Err(status) => crate::rest::status_to_response(status),
     }
-    next.run(req).await
 }
 
 fn extract_api_key_from_query(query: Option<&str>) -> Option<String> {

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -179,6 +179,13 @@ pub struct Config {
     /// JWT session token TTL. Defaults to 24 hours.
     #[arg(long, env = "DARKPOOL_SESSION_TTL", default_value = "24h", value_parser = parse_duration)]
     pub session_ttl: Duration,
+
+    /// Expected SIWE message domain (RFC 3986 authority). When set,
+    /// the server rejects SIWE messages whose `domain` field doesn't
+    /// match — prevents cross-site replay attacks. Example:
+    /// `app.darkpool.exchange` or `localhost:3000`.
+    #[arg(long, env = "DARKPOOL_SIWE_DOMAIN", default_value = "")]
+    siwe_domain_raw: String,
 }
 
 impl Config {
@@ -252,6 +259,10 @@ impl Config {
 
     pub fn session_secret(&self) -> Option<&str> {
         opt(&self.session_secret_raw)
+    }
+
+    pub fn siwe_domain(&self) -> Option<&str> {
+        opt(&self.siwe_domain_raw)
     }
 
     pub fn validate_siwe_config(&self) -> Result<(), String> {

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -276,9 +276,7 @@ impl Config {
                 );
             }
             Some(s) if s.len() < 32 => {
-                return Err(
-                    "DARKPOOL_SESSION_SECRET must be at least 32 bytes".into(),
-                );
+                return Err("DARKPOOL_SESSION_SECRET must be at least 32 bytes".into());
             }
             _ => {}
         }

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -164,6 +164,21 @@ pub struct Config {
 
     #[arg(long, env = "DARKPOOL_SUBMIT_GAS", default_value = "500000")]
     pub submit_gas: u64,
+
+    /// Enable SIWE (Sign-In with Ethereum) authentication. When enabled,
+    /// traders can authenticate via wallet signature and receive a JWT.
+    /// Static API keys remain as fallback for programmatic access.
+    #[arg(long, env = "DARKPOOL_SIWE_ENABLED", default_value = "false")]
+    pub siwe_enabled: bool,
+
+    /// Secret used to sign/verify JWT session tokens. Required when
+    /// SIWE is enabled; ignored otherwise.
+    #[arg(long, env = "DARKPOOL_SESSION_SECRET", default_value = "")]
+    session_secret_raw: String,
+
+    /// JWT session token TTL. Defaults to 24 hours.
+    #[arg(long, env = "DARKPOOL_SESSION_TTL", default_value = "24h", value_parser = parse_duration)]
+    pub session_ttl: Duration,
 }
 
 impl Config {
@@ -233,6 +248,19 @@ impl Config {
 
     pub fn contract_address(&self) -> Option<&str> {
         opt(&self.contract_addr)
+    }
+
+    pub fn session_secret(&self) -> Option<&str> {
+        opt(&self.session_secret_raw)
+    }
+
+    pub fn validate_siwe_config(&self) -> Result<(), String> {
+        if self.siwe_enabled && self.session_secret().is_none() {
+            return Err(
+                "DARKPOOL_SIWE_ENABLED is true but DARKPOOL_SESSION_SECRET is not set".into(),
+            );
+        }
+        Ok(())
     }
 
     pub fn tls_cert_path(&self) -> Option<&str> {

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -474,4 +474,55 @@ mod tests {
         let cfg = Config::parse_from(["darkpool-server", "--snapshot-dir", "/var/dp/snaps"]);
         assert_eq!(cfg.snapshot_dir_path(), Some("/var/dp/snaps"));
     }
+
+    fn cfg_with_siwe(enabled: bool, secret: &str, domain: &str) -> Config {
+        let mut args = vec!["darkpool-server".to_string()];
+        if enabled {
+            args.push("--siwe-enabled".into());
+        }
+        if !secret.is_empty() {
+            args.push("--session-secret-raw".into());
+            args.push(secret.into());
+        }
+        if !domain.is_empty() {
+            args.push("--siwe-domain-raw".into());
+            args.push(domain.into());
+        }
+        Config::parse_from(args)
+    }
+
+    #[test]
+    fn siwe_disabled_validates_ok_without_secret() {
+        let cfg = cfg_with_siwe(false, "", "");
+        assert!(cfg.validate_siwe_config().is_ok());
+    }
+
+    #[test]
+    fn siwe_enabled_without_secret_fails() {
+        let cfg = cfg_with_siwe(true, "", "");
+        let err = cfg.validate_siwe_config().unwrap_err();
+        assert!(err.contains("SESSION_SECRET"), "msg: {err}");
+    }
+
+    #[test]
+    fn siwe_enabled_with_short_secret_fails() {
+        let cfg = cfg_with_siwe(true, "tooshort", "");
+        let err = cfg.validate_siwe_config().unwrap_err();
+        assert!(err.contains("32 bytes"), "msg: {err}");
+    }
+
+    #[test]
+    fn siwe_enabled_with_valid_secret_passes() {
+        let cfg = cfg_with_siwe(true, "a]secret-that-is-at-least-32-bytes-long!", "");
+        assert!(cfg.validate_siwe_config().is_ok());
+        assert!(cfg.session_secret().is_some());
+    }
+
+    #[test]
+    fn siwe_domain_accessor() {
+        let cfg = cfg_with_siwe(false, "", "app.darkpool.exchange");
+        assert_eq!(cfg.siwe_domain(), Some("app.darkpool.exchange"));
+        let cfg2 = cfg_with_siwe(false, "", "");
+        assert!(cfg2.siwe_domain().is_none());
+    }
 }

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -255,10 +255,21 @@ impl Config {
     }
 
     pub fn validate_siwe_config(&self) -> Result<(), String> {
-        if self.siwe_enabled && self.session_secret().is_none() {
-            return Err(
-                "DARKPOOL_SIWE_ENABLED is true but DARKPOOL_SESSION_SECRET is not set".into(),
-            );
+        if !self.siwe_enabled {
+            return Ok(());
+        }
+        match self.session_secret() {
+            None => {
+                return Err(
+                    "DARKPOOL_SIWE_ENABLED is true but DARKPOOL_SESSION_SECRET is not set".into(),
+                );
+            }
+            Some(s) if s.len() < 32 => {
+                return Err(
+                    "DARKPOOL_SESSION_SECRET must be at least 32 bytes".into(),
+                );
+            }
+            _ => {}
         }
         Ok(())
     }

--- a/crates/dp-api/src/error.rs
+++ b/crates/dp-api/src/error.rs
@@ -16,6 +16,9 @@ pub fn engine_error_to_status(err: EngineError) -> Status {
         EngineError::Validation(
             e @ (DarkPoolError::PairNotAccepting(_) | DarkPoolError::CannotSuspendDelistedPair(_)),
         ) => Status::failed_precondition(e.to_string()),
+        EngineError::Validation(e @ DarkPoolError::TraderAddressMismatch { .. }) => {
+            Status::permission_denied(e.to_string())
+        }
         EngineError::Validation(
             e @ (DarkPoolError::PairRequired
             | DarkPoolError::PriceMustBePositive

--- a/crates/dp-api/src/error.rs
+++ b/crates/dp-api/src/error.rs
@@ -94,6 +94,17 @@ mod tests {
     }
 
     #[test]
+    fn trader_address_mismatch_maps_to_permission_denied() {
+        let s = engine_error_to_status(EngineError::Validation(
+            DarkPoolError::TraderAddressMismatch {
+                expected: "0x1111".into(),
+                found: "***".into(),
+            },
+        ));
+        assert_eq!(s.code(), Code::PermissionDenied);
+    }
+
+    #[test]
     fn non_validation_engine_error_maps_to_internal() {
         let s = engine_error_to_status(EngineError::WitnessOrderMissing {
             order_id: uuid::Uuid::nil(),

--- a/crates/dp-api/src/handler.rs
+++ b/crates/dp-api/src/handler.rs
@@ -64,11 +64,18 @@ impl DarkPoolService for ApiHandler {
         &self,
         req: Request<PlaceOrderRequest>,
     ) -> Result<Response<PlaceOrderResponse>, Status> {
+        let caller = req
+            .extensions()
+            .get::<crate::auth::AuthenticatedIdentity>()
+            .and_then(|id| match id {
+                crate::auth::AuthenticatedIdentity::Wallet(addr) => Some(*addr),
+                crate::auth::AuthenticatedIdentity::ApiKey => None,
+            });
         let req = req.into_inner();
         validate_place_order(&req)?;
         let order = self
             .engine
-            .place_encrypted_order(req.commitment, req.proof, req.encrypted_payload)
+            .place_encrypted_order(req.commitment, req.proof, req.encrypted_payload, caller)
             .await
             .map_err(engine_error_to_status)?;
         Ok(Response::new(PlaceOrderResponse {

--- a/crates/dp-api/src/lib.rs
+++ b/crates/dp-api/src/lib.rs
@@ -11,5 +11,6 @@ pub mod pb;
 pub mod ratelimit;
 pub mod readiness;
 pub mod rest;
+pub mod siwe;
 pub mod tls;
 pub mod validation;

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -304,10 +304,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             session_ttl = ?cfg.session_ttl,
             "SIWE authentication enabled"
         );
+        let expected_domain = cfg.siwe_domain().map(|s| s.to_string());
         Some(dp_api::siwe::SiweState {
             nonce_store,
             jwt_manager: jwt_manager.clone(),
             chain_id,
+            expected_domain,
         })
     } else {
         info!("SIWE authentication disabled (set --siwe-enabled to activate)");

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -286,7 +286,39 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         None
     };
 
-    let auth_core = AuthCore::new(cfg.api_keys());
+    cfg.validate_siwe_config()
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
+
+    let siwe_state = if cfg.siwe_enabled {
+        let secret = cfg.session_secret().unwrap();
+        let jwt_manager = Arc::new(dp_api::siwe::JwtManager::new(secret, cfg.session_ttl));
+        let nonce_store = Arc::new(dp_api::siwe::NonceStore::new(Duration::from_secs(300)));
+        nonce_store.start_cleanup(cancel.clone(), Duration::from_secs(60));
+        let chain_id = if cfg.chain_id > 0 {
+            Some(cfg.chain_id)
+        } else {
+            None
+        };
+        info!(
+            chain_id = ?chain_id,
+            session_ttl = ?cfg.session_ttl,
+            "SIWE authentication enabled"
+        );
+        Some(dp_api::siwe::SiweState {
+            nonce_store,
+            jwt_manager: jwt_manager.clone(),
+            chain_id,
+        })
+    } else {
+        info!("SIWE authentication disabled (set --siwe-enabled to activate)");
+        None
+    };
+
+    let auth_core = if let Some(ref siwe) = siwe_state {
+        AuthCore::new_with_jwt(cfg.api_keys(), siwe.jwt_manager.clone())
+    } else {
+        AuthCore::new(cfg.api_keys())
+    };
     let operator_keys = cfg.operator_api_keys();
     if operator_keys.is_empty() {
         warn!(
@@ -390,6 +422,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         rl_core,
         ops,
         &cors_origins,
+        siwe_state,
     );
     let http_addr = cfg.http_addr;
     let http_cancel = cancel.clone();

--- a/crates/dp-api/src/ratelimit.rs
+++ b/crates/dp-api/src/ratelimit.rs
@@ -17,7 +17,7 @@ use tonic::transport::server::TcpConnectInfo;
 use tonic::Status;
 use tower::{Layer, Service};
 
-use crate::auth::AUTH_HEADER;
+use crate::auth::{AuthenticatedIdentity, AUTH_HEADER};
 use crate::validation::MSG_RATE_LIMIT_EXCEEDED;
 
 #[derive(Debug)]
@@ -107,7 +107,17 @@ impl RateLimitCore {
     }
 }
 
-pub fn client_key(headers: &HeaderMap, peer: Option<SocketAddr>) -> String {
+pub fn client_key(
+    identity: Option<&AuthenticatedIdentity>,
+    headers: &HeaderMap,
+    peer: Option<SocketAddr>,
+) -> String {
+    if let Some(id) = identity {
+        match id {
+            AuthenticatedIdentity::Wallet(addr) => return format!("{:#x}", addr),
+            AuthenticatedIdentity::ApiKey => {}
+        }
+    }
     if let Some(v) = headers.get(AUTH_HEADER) {
         if let Ok(s) = v.to_str() {
             if !s.is_empty() {
@@ -177,6 +187,7 @@ where
         let mut inner = std::mem::replace(&mut self.inner, clone);
         let core = self.core.clone();
         Box::pin(async move {
+            let identity = req.extensions().get::<AuthenticatedIdentity>().cloned();
             let peer = req
                 .extensions()
                 .get::<TcpConnectInfo>()
@@ -187,7 +198,7 @@ where
                         .get::<ConnectInfo<SocketAddr>>()
                         .map(|ci| ci.0)
                 });
-            let key = client_key(req.headers(), peer);
+            let key = client_key(identity.as_ref(), req.headers(), peer);
             if let Err(status) = core.allow(&key) {
                 return Ok(status.into_http());
             }
@@ -201,12 +212,13 @@ pub async fn ratelimit_axum_mw(
     req: AxumRequest,
     next: Next,
 ) -> AxumResponse {
+    let identity = req.extensions().get::<AuthenticatedIdentity>().cloned();
     let peer = req.extensions().get::<SocketAddr>().copied().or_else(|| {
         req.extensions()
             .get::<ConnectInfo<SocketAddr>>()
             .map(|ci| ci.0)
     });
-    let key = client_key(req.headers(), peer);
+    let key = client_key(identity.as_ref(), req.headers(), peer);
     if let Err(status) = core.allow(&key) {
         return crate::rest::status_to_response(status);
     }

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -278,10 +278,13 @@ struct VerifyResponse {
     address: String,
 }
 
-async fn rest_auth_nonce(State(state): State<SiweState>) -> Json<NonceResponse> {
-    Json(NonceResponse {
-        nonce: state.nonce_store.generate(),
-    })
+async fn rest_auth_nonce(
+    State(state): State<SiweState>,
+) -> Result<Json<NonceResponse>, ApiError> {
+    let nonce = state.nonce_store.generate().ok_or_else(|| {
+        ApiError(tonic::Status::resource_exhausted("nonce store full"))
+    })?;
+    Ok(Json(NonceResponse { nonce }))
 }
 
 async fn rest_auth_verify(

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -25,6 +25,7 @@ use tower_http::trace::TraceLayer;
 use crate::admin::{AdminApiHandler, AdminKeyError, KeyAdminHandler};
 use crate::auth::{auth_axum_mw, AuthCore};
 use crate::handler::ApiHandler;
+use crate::siwe::SiweState;
 use crate::pb::dark_pool_admin_service_server::DarkPoolAdminService;
 use crate::pb::dark_pool_service_server::DarkPoolService;
 use crate::pb::{
@@ -151,6 +152,13 @@ pub fn ops_router(state: OpsState) -> Router {
         .with_state(state)
 }
 
+pub fn auth_router(state: SiweState) -> Router {
+    Router::new()
+        .route("/v1/auth/nonce", get(rest_auth_nonce))
+        .route("/v1/auth/verify", post(rest_auth_verify))
+        .with_state(state)
+}
+
 /// Compose the full server router: public + admin (auth-gated) + ops
 /// (unauthenticated) and apply tracing + x-request-id propagation
 /// across every route so logs and spans share a correlation ID.
@@ -164,8 +172,9 @@ pub fn router_with_ops(
     ratelimit: RateLimitCore,
     ops: OpsState,
     cors_origins: &[String],
+    siwe_state: Option<SiweState>,
 ) -> Router {
-    let base = router_with_admin(
+    let mut base = router_with_admin(
         handler,
         admin_handler,
         key_admin_handler,
@@ -174,6 +183,9 @@ pub fn router_with_ops(
         ratelimit,
     )
     .merge(ops_router(ops));
+    if let Some(siwe) = siwe_state {
+        base = base.merge(auth_router(siwe));
+    }
     // Layers are added bottom-up but execute top-down: the LAST `.layer(...)`
     // wraps everything before it and therefore runs first on the request
     // path. Desired request-side order is SetRequestId → Trace → Propagate,
@@ -209,7 +221,11 @@ pub fn router_with_ops(
             Method::DELETE,
             Method::OPTIONS,
         ])
-        .allow_headers([header::CONTENT_TYPE, HeaderName::from_static("x-api-key")])
+        .allow_headers([
+            header::CONTENT_TYPE,
+            header::AUTHORIZATION,
+            HeaderName::from_static("x-api-key"),
+        ])
         .expose_headers([HeaderName::from_static("x-request-id")])
         .max_age(Duration::from_secs(3600));
 
@@ -240,6 +256,63 @@ fn make_http_span(request: &AxumRequest<Body>) -> tracing::Span {
         path = %path,
         request_id = req_id,
     )
+}
+
+// ---------- SIWE auth handlers ----------
+
+#[derive(Serialize)]
+struct NonceResponse {
+    nonce: String,
+}
+
+#[derive(Deserialize)]
+struct VerifyRequest {
+    message: String,
+    signature: String,
+}
+
+#[derive(Serialize)]
+struct VerifyResponse {
+    token: String,
+    expires_at: u64,
+    address: String,
+}
+
+async fn rest_auth_nonce(State(state): State<SiweState>) -> Json<NonceResponse> {
+    Json(NonceResponse {
+        nonce: state.nonce_store.generate(),
+    })
+}
+
+async fn rest_auth_verify(
+    State(state): State<SiweState>,
+    Json(body): Json<VerifyRequest>,
+) -> Result<Json<VerifyResponse>, ApiError> {
+    let sig_bytes = hex::decode(body.signature.strip_prefix("0x").unwrap_or(&body.signature))
+        .map_err(|_| ApiError(tonic::Status::invalid_argument("invalid signature hex")))?;
+    let sig: [u8; 65] = sig_bytes.try_into().map_err(|_| {
+        ApiError(tonic::Status::invalid_argument(
+            "signature must be 65 bytes",
+        ))
+    })?;
+    let address = crate::siwe::verify_siwe_message(
+        &body.message,
+        &sig,
+        &state.nonce_store,
+        state.chain_id,
+    )
+    .map_err(|e| ApiError(tonic::Status::unauthenticated(e.to_string())))?;
+
+    let (token, expires_at) = state
+        .jwt_manager
+        .issue(address)
+        .map_err(|e| ApiError(tonic::Status::internal(format!("jwt issue: {e}"))))?;
+
+    Ok(Json(VerifyResponse {
+        token,
+        expires_at,
+        address: format!("{:#x}", address),
+    }))
 }
 
 // ---------- ops handlers ----------

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -25,7 +25,6 @@ use tower_http::trace::TraceLayer;
 use crate::admin::{AdminApiHandler, AdminKeyError, KeyAdminHandler};
 use crate::auth::{auth_axum_mw, AuthCore};
 use crate::handler::ApiHandler;
-use crate::siwe::SiweState;
 use crate::pb::dark_pool_admin_service_server::DarkPoolAdminService;
 use crate::pb::dark_pool_service_server::DarkPoolService;
 use crate::pb::{
@@ -35,6 +34,7 @@ use crate::pb::{
 };
 use crate::ratelimit::{ratelimit_axum_mw, RateLimitCore};
 use crate::readiness::ReadinessProbes;
+use crate::siwe::SiweState;
 use crate::validation::{validate_pair_known, MAX_CIPHERTEXT_BYTES, MAX_PROOF_BYTES};
 use dp_crypto::{KeyStatus, MultiKeyDecrypter};
 
@@ -278,12 +278,11 @@ struct VerifyResponse {
     address: String,
 }
 
-async fn rest_auth_nonce(
-    State(state): State<SiweState>,
-) -> Result<Json<NonceResponse>, ApiError> {
-    let nonce = state.nonce_store.generate().ok_or_else(|| {
-        ApiError(tonic::Status::resource_exhausted("nonce store full"))
-    })?;
+async fn rest_auth_nonce(State(state): State<SiweState>) -> Result<Json<NonceResponse>, ApiError> {
+    let nonce = state
+        .nonce_store
+        .generate()
+        .ok_or_else(|| ApiError(tonic::Status::resource_exhausted("nonce store full")))?;
     Ok(Json(NonceResponse { nonce }))
 }
 

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -300,6 +300,7 @@ async fn rest_auth_verify(
         &sig,
         &state.nonce_store,
         state.chain_id,
+        state.expected_domain.as_deref(),
     )
     .map_err(|e| ApiError(tonic::Status::unauthenticated(e.to_string())))?;
 

--- a/crates/dp-api/src/siwe.rs
+++ b/crates/dp-api/src/siwe.rs
@@ -108,8 +108,9 @@ pub fn verify_siwe_message(
     expected_chain_id: Option<u64>,
     expected_domain: Option<&str>,
 ) -> Result<Address, SiweError> {
-    let message: siwe::Message =
-        message_str.parse().map_err(|e| SiweError::Parse(format!("{e}")))?;
+    let message: siwe::Message = message_str
+        .parse()
+        .map_err(|e| SiweError::Parse(format!("{e}")))?;
 
     if let Some(domain) = expected_domain {
         let msg_domain = message.domain.to_string();
@@ -315,8 +316,14 @@ mod tests {
 
     #[test]
     fn jwt_wrong_secret_rejected() {
-        let mgr1 = JwtManager::new("secret-one-xxxxxxxxxxxxxxxxxxxxxxxx", Duration::from_secs(3600));
-        let mgr2 = JwtManager::new("secret-two-xxxxxxxxxxxxxxxxxxxxxxxx", Duration::from_secs(3600));
+        let mgr1 = JwtManager::new(
+            "secret-one-xxxxxxxxxxxxxxxxxxxxxxxx",
+            Duration::from_secs(3600),
+        );
+        let mgr2 = JwtManager::new(
+            "secret-two-xxxxxxxxxxxxxxxxxxxxxxxx",
+            Duration::from_secs(3600),
+        );
         let addr: Address = "0x6Da01670d8fc844e736095918bbE11fE8D564163"
             .parse()
             .unwrap();
@@ -334,6 +341,9 @@ mod tests {
             exp: 0,
         };
         let addr = JwtManager::address_from_claims(&claims).unwrap();
-        assert_eq!(format!("{:#x}", addr), "0x6da01670d8fc844e736095918bbe11fe8d564163");
+        assert_eq!(
+            format!("{:#x}", addr),
+            "0x6da01670d8fc844e736095918bbe11fe8d564163"
+        );
     }
 }

--- a/crates/dp-api/src/siwe.rs
+++ b/crates/dp-api/src/siwe.rs
@@ -13,6 +13,8 @@ use tokio_util::sync::CancellationToken;
 // NonceStore
 // ---------------------------------------------------------------------------
 
+const MAX_NONCES: usize = 10_000;
+
 #[derive(Debug)]
 pub struct NonceStore {
     inner: Arc<Mutex<HashMap<String, Instant>>>,
@@ -27,10 +29,14 @@ impl NonceStore {
         }
     }
 
-    pub fn generate(&self) -> String {
+    pub fn generate(&self) -> Option<String> {
+        let mut map = self.inner.lock();
+        if map.len() >= MAX_NONCES {
+            return None;
+        }
         let nonce = siwe::generate_nonce();
-        self.inner.lock().insert(nonce.clone(), Instant::now());
-        nonce
+        map.insert(nonce.clone(), Instant::now());
+        Some(nonce)
     }
 
     pub fn consume(&self, nonce: &str) -> bool {
@@ -153,9 +159,13 @@ pub fn verify_siwe_message(
 // JWT
 // ---------------------------------------------------------------------------
 
+const JWT_ISSUER: &str = "darkpool";
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Claims {
     pub sub: String,
+    pub iss: String,
+    pub aud: String,
     pub iat: u64,
     pub exp: u64,
 }
@@ -164,6 +174,7 @@ pub struct Claims {
 pub struct JwtManager {
     encoding: Arc<EncodingKey>,
     decoding: Arc<DecodingKey>,
+    validation: Arc<Validation>,
     ttl: Duration,
 }
 
@@ -177,9 +188,13 @@ impl std::fmt::Debug for JwtManager {
 
 impl JwtManager {
     pub fn new(secret: &str, ttl: Duration) -> Self {
+        let mut validation = Validation::default();
+        validation.set_issuer(&[JWT_ISSUER]);
+        validation.set_audience(&[JWT_ISSUER]);
         Self {
             encoding: Arc::new(EncodingKey::from_secret(secret.as_bytes())),
             decoding: Arc::new(DecodingKey::from_secret(secret.as_bytes())),
+            validation: Arc::new(validation),
             ttl,
         }
     }
@@ -192,6 +207,8 @@ impl JwtManager {
         let exp = now + self.ttl.as_secs();
         let claims = Claims {
             sub: format!("{:#x}", address),
+            iss: JWT_ISSUER.to_string(),
+            aud: JWT_ISSUER.to_string(),
             iat: now,
             exp,
         };
@@ -200,7 +217,7 @@ impl JwtManager {
     }
 
     pub fn verify(&self, token: &str) -> Result<Claims, jsonwebtoken::errors::Error> {
-        let data = jsonwebtoken::decode::<Claims>(token, &self.decoding, &Validation::default())?;
+        let data = jsonwebtoken::decode::<Claims>(token, &self.decoding, &self.validation)?;
         Ok(data.claims)
     }
 
@@ -228,14 +245,14 @@ mod tests {
     #[test]
     fn nonce_generate_and_consume() {
         let store = NonceStore::new(Duration::from_secs(300));
-        let nonce = store.generate();
+        let nonce = store.generate().unwrap();
         assert!(store.consume(&nonce));
     }
 
     #[test]
     fn nonce_double_consume_fails() {
         let store = NonceStore::new(Duration::from_secs(300));
-        let nonce = store.generate();
+        let nonce = store.generate().unwrap();
         assert!(store.consume(&nonce));
         assert!(!store.consume(&nonce));
     }
@@ -243,7 +260,7 @@ mod tests {
     #[test]
     fn nonce_expired_fails() {
         let store = NonceStore::new(Duration::from_secs(0));
-        let nonce = store.generate();
+        let nonce = store.generate().unwrap();
         std::thread::sleep(Duration::from_millis(10));
         assert!(!store.consume(&nonce));
     }
@@ -262,6 +279,15 @@ mod tests {
         std::thread::sleep(Duration::from_millis(10));
         store.evict_stale();
         assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn nonce_rejects_when_full() {
+        let store = NonceStore::new(Duration::from_secs(300));
+        for _ in 0..MAX_NONCES {
+            assert!(store.generate().is_some());
+        }
+        assert!(store.generate().is_none());
     }
 
     #[test]
@@ -302,6 +328,8 @@ mod tests {
     fn jwt_address_from_claims() {
         let claims = Claims {
             sub: "0x6da01670d8fc844e736095918bbe11fe8d564163".into(),
+            iss: JWT_ISSUER.into(),
+            aud: JWT_ISSUER.into(),
             iat: 0,
             exp: 0,
         };

--- a/crates/dp-api/src/siwe.rs
+++ b/crates/dp-api/src/siwe.rs
@@ -1,0 +1,287 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use alloy_primitives::Address;
+use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation};
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+
+// ---------------------------------------------------------------------------
+// NonceStore
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub struct NonceStore {
+    inner: Arc<Mutex<HashMap<String, Instant>>>,
+    ttl: Duration,
+}
+
+impl NonceStore {
+    pub fn new(ttl: Duration) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            ttl,
+        }
+    }
+
+    pub fn generate(&self) -> String {
+        let nonce = siwe::generate_nonce();
+        self.inner.lock().insert(nonce.clone(), Instant::now());
+        nonce
+    }
+
+    pub fn consume(&self, nonce: &str) -> bool {
+        let mut map = self.inner.lock();
+        match map.remove(nonce) {
+            Some(created) => created.elapsed() <= self.ttl,
+            None => false,
+        }
+    }
+
+    pub fn evict_stale(&self) {
+        let mut map = self.inner.lock();
+        let ttl = self.ttl;
+        map.retain(|_, created| created.elapsed() <= ttl);
+    }
+
+    pub fn start_cleanup(&self, cancel: CancellationToken, interval: Duration) {
+        let store = Self {
+            inner: Arc::clone(&self.inner),
+            ttl: self.ttl,
+        };
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.tick().await;
+            loop {
+                tokio::select! {
+                    _ = cancel.cancelled() => break,
+                    _ = ticker.tick() => store.evict_stale(),
+                }
+            }
+        });
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.lock().len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SIWE verification
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Error)]
+pub enum SiweError {
+    #[error("failed to parse SIWE message: {0}")]
+    Parse(String),
+    #[error("nonce invalid or expired")]
+    NonceInvalid,
+    #[error("SIWE message expired")]
+    Expired,
+    #[error("chain ID mismatch: expected {expected}, got {got}")]
+    ChainMismatch { expected: u64, got: u64 },
+    #[error("signature verification failed: {0}")]
+    Verification(String),
+}
+
+pub fn verify_siwe_message(
+    message_str: &str,
+    signature: &[u8; 65],
+    nonce_store: &NonceStore,
+    expected_chain_id: Option<u64>,
+) -> Result<Address, SiweError> {
+    let message: siwe::Message =
+        message_str.parse().map_err(|e| SiweError::Parse(format!("{e}")))?;
+
+    if !nonce_store.consume(&message.nonce) {
+        return Err(SiweError::NonceInvalid);
+    }
+
+    if let Some(expected) = expected_chain_id {
+        if message.chain_id != expected {
+            return Err(SiweError::ChainMismatch {
+                expected,
+                got: message.chain_id,
+            });
+        }
+    }
+
+    if let Some(ref exp) = message.expiration_time {
+        if exp < &time::OffsetDateTime::now_utc() {
+            return Err(SiweError::Expired);
+        }
+    }
+
+    message
+        .verify_eip191(signature)
+        .map_err(|e| SiweError::Verification(format!("{e}")))?;
+
+    Ok(Address::from_slice(&message.address))
+}
+
+// ---------------------------------------------------------------------------
+// JWT
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    pub sub: String,
+    pub iat: u64,
+    pub exp: u64,
+}
+
+#[derive(Clone)]
+pub struct JwtManager {
+    encoding: Arc<EncodingKey>,
+    decoding: Arc<DecodingKey>,
+    ttl: Duration,
+}
+
+impl std::fmt::Debug for JwtManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("JwtManager")
+            .field("ttl", &self.ttl)
+            .finish_non_exhaustive()
+    }
+}
+
+impl JwtManager {
+    pub fn new(secret: &str, ttl: Duration) -> Self {
+        Self {
+            encoding: Arc::new(EncodingKey::from_secret(secret.as_bytes())),
+            decoding: Arc::new(DecodingKey::from_secret(secret.as_bytes())),
+            ttl,
+        }
+    }
+
+    pub fn issue(&self, address: Address) -> Result<(String, u64), jsonwebtoken::errors::Error> {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        let exp = now + self.ttl.as_secs();
+        let claims = Claims {
+            sub: format!("{:#x}", address),
+            iat: now,
+            exp,
+        };
+        let token = jsonwebtoken::encode(&Header::default(), &claims, &self.encoding)?;
+        Ok((token, exp))
+    }
+
+    pub fn verify(&self, token: &str) -> Result<Claims, jsonwebtoken::errors::Error> {
+        let data = jsonwebtoken::decode::<Claims>(token, &self.decoding, &Validation::default())?;
+        Ok(data.claims)
+    }
+
+    pub fn address_from_claims(claims: &Claims) -> Option<Address> {
+        claims.sub.parse().ok()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Shared state for auth endpoints
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+pub struct SiweState {
+    pub nonce_store: Arc<NonceStore>,
+    pub jwt_manager: Arc<JwtManager>,
+    pub chain_id: Option<u64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nonce_generate_and_consume() {
+        let store = NonceStore::new(Duration::from_secs(300));
+        let nonce = store.generate();
+        assert!(store.consume(&nonce));
+    }
+
+    #[test]
+    fn nonce_double_consume_fails() {
+        let store = NonceStore::new(Duration::from_secs(300));
+        let nonce = store.generate();
+        assert!(store.consume(&nonce));
+        assert!(!store.consume(&nonce));
+    }
+
+    #[test]
+    fn nonce_expired_fails() {
+        let store = NonceStore::new(Duration::from_secs(0));
+        let nonce = store.generate();
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(!store.consume(&nonce));
+    }
+
+    #[test]
+    fn nonce_unknown_fails() {
+        let store = NonceStore::new(Duration::from_secs(300));
+        assert!(!store.consume("nonexistent"));
+    }
+
+    #[test]
+    fn nonce_evict_stale() {
+        let store = NonceStore::new(Duration::from_secs(0));
+        store.generate();
+        store.generate();
+        std::thread::sleep(Duration::from_millis(10));
+        store.evict_stale();
+        assert_eq!(store.len(), 0);
+    }
+
+    #[test]
+    fn jwt_issue_and_verify_round_trip() {
+        let mgr = JwtManager::new("test-secret-32-bytes-long-xxxxx", Duration::from_secs(3600));
+        let addr: Address = "0x6Da01670d8fc844e736095918bbE11fE8D564163"
+            .parse()
+            .unwrap();
+        let (token, exp) = mgr.issue(addr).unwrap();
+        assert!(exp > 0);
+        let claims = mgr.verify(&token).unwrap();
+        assert_eq!(claims.sub, format!("{:#x}", addr));
+    }
+
+    #[test]
+    fn jwt_tampered_token_rejected() {
+        let mgr = JwtManager::new("test-secret-32-bytes-long-xxxxx", Duration::from_secs(3600));
+        let addr: Address = "0x6Da01670d8fc844e736095918bbE11fE8D564163"
+            .parse()
+            .unwrap();
+        let (mut token, _) = mgr.issue(addr).unwrap();
+        token.push('x');
+        assert!(mgr.verify(&token).is_err());
+    }
+
+    #[test]
+    fn jwt_wrong_secret_rejected() {
+        let mgr1 = JwtManager::new("secret-one-xxxxxxxxxxxxxxxxxxxxxxxx", Duration::from_secs(3600));
+        let mgr2 = JwtManager::new("secret-two-xxxxxxxxxxxxxxxxxxxxxxxx", Duration::from_secs(3600));
+        let addr: Address = "0x6Da01670d8fc844e736095918bbE11fE8D564163"
+            .parse()
+            .unwrap();
+        let (token, _) = mgr1.issue(addr).unwrap();
+        assert!(mgr2.verify(&token).is_err());
+    }
+
+    #[test]
+    fn jwt_address_from_claims() {
+        let claims = Claims {
+            sub: "0x6da01670d8fc844e736095918bbe11fe8d564163".into(),
+            iat: 0,
+            exp: 0,
+        };
+        let addr = JwtManager::address_from_claims(&claims).unwrap();
+        assert_eq!(format!("{:#x}", addr), "0x6da01670d8fc844e736095918bbe11fe8d564163");
+    }
+}

--- a/crates/dp-api/src/siwe.rs
+++ b/crates/dp-api/src/siwe.rs
@@ -85,6 +85,10 @@ pub enum SiweError {
     NonceInvalid,
     #[error("SIWE message expired")]
     Expired,
+    #[error("SIWE message not yet valid")]
+    NotYetValid,
+    #[error("domain mismatch: expected {expected}, got {got}")]
+    DomainMismatch { expected: String, got: String },
     #[error("chain ID mismatch: expected {expected}, got {got}")]
     ChainMismatch { expected: u64, got: u64 },
     #[error("signature verification failed: {0}")]
@@ -96,12 +100,19 @@ pub fn verify_siwe_message(
     signature: &[u8; 65],
     nonce_store: &NonceStore,
     expected_chain_id: Option<u64>,
+    expected_domain: Option<&str>,
 ) -> Result<Address, SiweError> {
     let message: siwe::Message =
         message_str.parse().map_err(|e| SiweError::Parse(format!("{e}")))?;
 
-    if !nonce_store.consume(&message.nonce) {
-        return Err(SiweError::NonceInvalid);
+    if let Some(domain) = expected_domain {
+        let msg_domain = message.domain.to_string();
+        if msg_domain != domain {
+            return Err(SiweError::DomainMismatch {
+                expected: domain.to_string(),
+                got: msg_domain,
+            });
+        }
     }
 
     if let Some(expected) = expected_chain_id {
@@ -113,15 +124,27 @@ pub fn verify_siwe_message(
         }
     }
 
+    let now = time::OffsetDateTime::now_utc();
+
     if let Some(ref exp) = message.expiration_time {
-        if exp < &time::OffsetDateTime::now_utc() {
+        if exp < &now {
             return Err(SiweError::Expired);
+        }
+    }
+
+    if let Some(ref nbf) = message.not_before {
+        if nbf > &now {
+            return Err(SiweError::NotYetValid);
         }
     }
 
     message
         .verify_eip191(signature)
         .map_err(|e| SiweError::Verification(format!("{e}")))?;
+
+    if !nonce_store.consume(&message.nonce) {
+        return Err(SiweError::NonceInvalid);
+    }
 
     Ok(Address::from_slice(&message.address))
 }
@@ -195,6 +218,7 @@ pub struct SiweState {
     pub nonce_store: Arc<NonceStore>,
     pub jwt_manager: Arc<JwtManager>,
     pub chain_id: Option<u64>,
+    pub expected_domain: Option<String>,
 }
 
 #[cfg(test)]

--- a/crates/dp-api/src/siwe.rs
+++ b/crates/dp-api/src/siwe.rs
@@ -346,4 +346,114 @@ mod tests {
             "0x6da01670d8fc844e736095918bbe11fe8d564163"
         );
     }
+
+    fn sign_eip191(msg: &str, sk: &k256::ecdsa::SigningKey) -> [u8; 65] {
+        use k256::ecdsa::signature::hazmat::PrehashSigner;
+        use sha3::{Digest, Keccak256};
+        let prefixed = format!("\x19Ethereum Signed Message:\n{}{}", msg.len(), msg);
+        let hash = Keccak256::digest(prefixed.as_bytes());
+        let (sig, recid): (k256::ecdsa::Signature, k256::ecdsa::RecoveryId) =
+            sk.sign_prehash(hash.as_ref()).unwrap();
+        let mut out = [0u8; 65];
+        out[..64].copy_from_slice(&sig.to_bytes());
+        out[64] = recid.to_byte() + 27;
+        out
+    }
+
+    fn eth_address(sk: &k256::ecdsa::SigningKey) -> String {
+        use sha3::{Digest, Keccak256};
+        let pk = sk.verifying_key();
+        let uncompressed = pk.to_encoded_point(false);
+        let hash = Keccak256::digest(&uncompressed.as_bytes()[1..]);
+        let addr_bytes = &hash[12..];
+        let addr_hex = hex::encode(addr_bytes);
+        let addr_hash = Keccak256::digest(addr_hex.as_bytes());
+        let mut checksummed = String::with_capacity(42);
+        checksummed.push_str("0x");
+        for (i, c) in addr_hex.chars().enumerate() {
+            if c.is_ascii_digit() {
+                checksummed.push(c);
+            } else if addr_hash[i / 2] >> (if i % 2 == 0 { 4 } else { 0 }) & 0xf >= 8 {
+                checksummed.push(c.to_ascii_uppercase());
+            } else {
+                checksummed.push(c);
+            }
+        }
+        checksummed
+    }
+
+    fn make_siwe_message(address: &str, nonce: &str, chain_id: u64) -> String {
+        format!(
+            "localhost wants you to sign in with your Ethereum account:\n\
+             {address}\n\
+             \n\
+             Test statement\n\
+             \n\
+             URI: http://localhost\n\
+             Version: 1\n\
+             Chain ID: {chain_id}\n\
+             Nonce: {nonce}\n\
+             Issued At: 2099-01-01T00:00:00Z"
+        )
+    }
+
+    #[test]
+    fn verify_siwe_round_trip() {
+        let sk = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let addr_str = eth_address(&sk);
+        let store = NonceStore::new(Duration::from_secs(300));
+        let nonce = store.generate().unwrap();
+        let msg = make_siwe_message(&addr_str, &nonce, 1);
+        let sig = sign_eip191(&msg, &sk);
+        let result = verify_siwe_message(&msg, &sig, &store, Some(1), None);
+        assert!(result.is_ok(), "verify failed: {result:?}");
+    }
+
+    #[test]
+    fn verify_siwe_wrong_chain_rejected() {
+        let sk = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let addr_str = eth_address(&sk);
+        let store = NonceStore::new(Duration::from_secs(300));
+        let nonce = store.generate().unwrap();
+        let msg = make_siwe_message(&addr_str, &nonce, 1);
+        let sig = sign_eip191(&msg, &sk);
+        let result = verify_siwe_message(&msg, &sig, &store, Some(42), None);
+        assert!(matches!(result, Err(SiweError::ChainMismatch { .. })));
+    }
+
+    #[test]
+    fn verify_siwe_wrong_domain_rejected() {
+        let sk = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let addr_str = eth_address(&sk);
+        let store = NonceStore::new(Duration::from_secs(300));
+        let nonce = store.generate().unwrap();
+        let msg = make_siwe_message(&addr_str, &nonce, 1);
+        let sig = sign_eip191(&msg, &sk);
+        let result = verify_siwe_message(&msg, &sig, &store, None, Some("evil.com"));
+        assert!(matches!(result, Err(SiweError::DomainMismatch { .. })));
+    }
+
+    #[test]
+    fn verify_siwe_bad_nonce_rejected() {
+        let sk = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let addr_str = eth_address(&sk);
+        let store = NonceStore::new(Duration::from_secs(300));
+        let msg = make_siwe_message(&addr_str, "unknownnonce12345", 1);
+        let sig = sign_eip191(&msg, &sk);
+        let result = verify_siwe_message(&msg, &sig, &store, None, None);
+        assert!(matches!(result, Err(SiweError::NonceInvalid)));
+    }
+
+    #[test]
+    fn verify_siwe_bad_signature_rejected() {
+        let sk = k256::ecdsa::SigningKey::random(&mut rand::thread_rng());
+        let addr_str = eth_address(&sk);
+        let store = NonceStore::new(Duration::from_secs(300));
+        let nonce = store.generate().unwrap();
+        let msg = make_siwe_message(&addr_str, &nonce, 1);
+        let mut sig = sign_eip191(&msg, &sk);
+        sig[0] ^= 0xff;
+        let result = verify_siwe_message(&msg, &sig, &store, None, None);
+        assert!(matches!(result, Err(SiweError::Verification(_))));
+    }
 }

--- a/crates/dp-api/tests/auth.rs
+++ b/crates/dp-api/tests/auth.rs
@@ -1,4 +1,8 @@
-use dp_api::auth::AuthCore;
+use std::sync::Arc;
+use std::time::Duration;
+
+use dp_api::auth::{AuthCore, AuthenticatedIdentity};
+use dp_api::siwe::JwtManager;
 use http::{HeaderMap, HeaderValue};
 use tonic::Code;
 
@@ -41,4 +45,72 @@ fn empty_keys_filter() {
     h.insert("x-api-key", HeaderValue::from_static(""));
     let err = core.check(&h).err().unwrap();
     assert_eq!(err.code(), Code::Unauthenticated);
+}
+
+fn jwt_manager() -> Arc<JwtManager> {
+    Arc::new(JwtManager::new(
+        "test-secret-32-bytes-long-xxxxx",
+        Duration::from_secs(3600),
+    ))
+}
+
+#[test]
+fn bearer_token_returns_wallet_identity() {
+    let jwt = jwt_manager();
+    let addr: alloy_primitives::Address = "0x6Da01670d8fc844e736095918bbE11fE8D564163"
+        .parse()
+        .unwrap();
+    let (token, _) = jwt.issue(addr).unwrap();
+    let core = AuthCore::new_with_jwt(vec!["k1".into()], jwt);
+    let mut h = HeaderMap::new();
+    h.insert(
+        http::header::AUTHORIZATION,
+        HeaderValue::from_str(&format!("Bearer {token}")).unwrap(),
+    );
+    match core.check(&h).unwrap() {
+        AuthenticatedIdentity::Wallet(a) => assert_eq!(a, addr),
+        other => panic!("expected Wallet, got {other:?}"),
+    }
+}
+
+#[test]
+fn bearer_rejected_when_siwe_disabled() {
+    let core = AuthCore::new(vec!["k1".into()]);
+    let mut h = HeaderMap::new();
+    h.insert(
+        http::header::AUTHORIZATION,
+        HeaderValue::from_static("Bearer fake.jwt.token"),
+    );
+    let err = core.check(&h).err().unwrap();
+    assert_eq!(err.code(), Code::Unauthenticated);
+    assert!(
+        err.message().contains("not enabled"),
+        "msg: {}",
+        err.message()
+    );
+}
+
+#[test]
+fn invalid_bearer_token_rejected() {
+    let jwt = jwt_manager();
+    let core = AuthCore::new_with_jwt(vec![], jwt);
+    let mut h = HeaderMap::new();
+    h.insert(
+        http::header::AUTHORIZATION,
+        HeaderValue::from_static("Bearer invalid.token.here"),
+    );
+    let err = core.check(&h).err().unwrap();
+    assert_eq!(err.code(), Code::Unauthenticated);
+}
+
+#[test]
+fn api_key_still_works_with_jwt_enabled() {
+    let jwt = jwt_manager();
+    let core = AuthCore::new_with_jwt(vec!["k1".into()], jwt);
+    let mut h = HeaderMap::new();
+    h.insert("x-api-key", HeaderValue::from_static("k1"));
+    match core.check(&h).unwrap() {
+        AuthenticatedIdentity::ApiKey => {}
+        other => panic!("expected ApiKey, got {other:?}"),
+    }
 }

--- a/crates/dp-api/tests/observability_http.rs
+++ b/crates/dp-api/tests/observability_http.rs
@@ -56,6 +56,7 @@ fn make_router(probes: ReadinessProbes) -> axum::Router {
             multi: dp_crypto::MultiKeyDecrypter::new(),
         },
         &[],
+        None,
     )
 }
 

--- a/crates/dp-api/tests/ratelimit.rs
+++ b/crates/dp-api/tests/ratelimit.rs
@@ -56,20 +56,44 @@ fn key_precedence_api_key() {
     let mut h = HeaderMap::new();
     h.insert("x-api-key", HeaderValue::from_static("kkk"));
     let peer = Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 1234));
-    assert_eq!(client_key(&h, peer), "kkk");
+    assert_eq!(client_key(None, &h, peer), "kkk");
 }
 
 #[test]
 fn key_precedence_peer_when_no_header() {
     let h = HeaderMap::new();
     let peer = Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 1234));
-    assert_eq!(client_key(&h, peer), "1.2.3.4");
+    assert_eq!(client_key(None, &h, peer), "1.2.3.4");
 }
 
 #[test]
 fn key_precedence_anonymous() {
     let h = HeaderMap::new();
-    assert_eq!(client_key(&h, None), "anonymous");
+    assert_eq!(client_key(None, &h, None), "anonymous");
+}
+
+#[test]
+fn key_precedence_wallet_identity() {
+    use dp_api::auth::AuthenticatedIdentity;
+    let addr: alloy_primitives::Address = "0x6Da01670d8fc844e736095918bbE11fE8D564163"
+        .parse()
+        .unwrap();
+    let identity = AuthenticatedIdentity::Wallet(addr);
+    let mut h = HeaderMap::new();
+    h.insert("x-api-key", HeaderValue::from_static("kkk"));
+    let peer = Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 1234));
+    let key = client_key(Some(&identity), &h, peer);
+    assert_eq!(key, format!("{:#x}", addr));
+}
+
+#[test]
+fn key_precedence_apikey_identity_falls_through() {
+    use dp_api::auth::AuthenticatedIdentity;
+    let identity = AuthenticatedIdentity::ApiKey;
+    let mut h = HeaderMap::new();
+    h.insert("x-api-key", HeaderValue::from_static("kkk"));
+    let peer = Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)), 1234));
+    assert_eq!(client_key(Some(&identity), &h, peer), "kkk");
 }
 
 #[tokio::test]

--- a/crates/dp-api/tests/siwe_auth.rs
+++ b/crates/dp-api/tests/siwe_auth.rs
@@ -1,0 +1,141 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use dp_api::rest::auth_router;
+use dp_api::siwe::{JwtManager, NonceStore, SiweState};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+fn siwe_app() -> (axum::Router, SiweState) {
+    let nonce_store = Arc::new(NonceStore::new(Duration::from_secs(300)));
+    let jwt_manager = Arc::new(JwtManager::new(
+        "test-secret-32-bytes-long-xxxxx",
+        Duration::from_secs(3600),
+    ));
+    let state = SiweState {
+        nonce_store,
+        jwt_manager,
+        chain_id: None,
+        expected_domain: None,
+    };
+    (auth_router(state.clone()), state)
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = resp.into_body().collect().await.expect("body").to_bytes();
+    serde_json::from_slice(&bytes).expect("json")
+}
+
+#[tokio::test]
+async fn nonce_returns_200_with_nonce_string() {
+    let (app, _) = siwe_app();
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/auth/nonce")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert!(v["nonce"].is_string());
+    assert!(!v["nonce"].as_str().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn verify_rejects_invalid_signature_hex() {
+    let (app, _) = siwe_app();
+    let body = serde_json::json!({
+        "message": "test",
+        "signature": "not-hex"
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/auth/verify")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn verify_rejects_wrong_length_signature() {
+    let (app, _) = siwe_app();
+    let body = serde_json::json!({
+        "message": "test",
+        "signature": "0xaabb"
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/auth/verify")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn verify_rejects_unparseable_siwe_message() {
+    let (app, _) = siwe_app();
+    let sig_hex = format!("0x{}", "ab".repeat(65));
+    let body = serde_json::json!({
+        "message": "not a SIWE message",
+        "signature": sig_hex
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/auth/verify")
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn nonce_store_cap_returns_429() {
+    let nonce_store = Arc::new(NonceStore::new(Duration::from_secs(300)));
+    for _ in 0..10_000 {
+        nonce_store.generate();
+    }
+    let state = SiweState {
+        nonce_store,
+        jwt_manager: Arc::new(JwtManager::new(
+            "test-secret-32-bytes-long-xxxxx",
+            Duration::from_secs(3600),
+        )),
+        chain_id: None,
+        expected_domain: None,
+    };
+    let app = auth_router(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/v1/auth/nonce")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+}

--- a/crates/dp-engine/benches/recover.rs
+++ b/crates/dp-engine/benches/recover.rs
@@ -78,7 +78,7 @@ async fn populate_store(engine: &Engine, n: usize) {
         // Engine recomputes the commitment internally; supplying an
         // empty placeholder here is allowed by `place_encrypted_order`.
         engine
-            .place_encrypted_order(vec![0u8; 32], vec![], ct)
+            .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
             .await
             .expect("place");
     }

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -454,7 +454,7 @@ impl Engine {
 
     #[tracing::instrument(
         name = "dp_engine.place_encrypted_order",
-        skip(self, _client_commitment, proof, ciphertext),
+        skip(self, _client_commitment, proof, ciphertext, caller),
         fields(
             ciphertext_bytes = ciphertext.len(),
             proof_bytes = proof.len(),
@@ -465,12 +465,24 @@ impl Engine {
         _client_commitment: Vec<u8>,
         proof: Vec<u8>,
         ciphertext: Vec<u8>,
+        caller: Option<alloy_primitives::Address>,
     ) -> Result<Order, EngineError> {
         let decrypter = self.inner.decrypter.read().clone();
         let decrypted = decrypter
             .decrypt(&ciphertext)
             .await
             .map_err(EngineError::Decrypt)?;
+
+        if let Some(expected) = caller {
+            if decrypted.trader != expected {
+                return Err(EngineError::Validation(
+                    DarkPoolError::TraderAddressMismatch {
+                        expected: format!("{:#x}", expected),
+                        found: format!("{:#x}", decrypted.trader),
+                    },
+                ));
+            }
+        }
 
         // Client-supplied commitment is accepted (proto requires it) but no
         // longer verified content-wise: the engine recomputes the canonical

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -478,7 +478,7 @@ impl Engine {
                 return Err(EngineError::Validation(
                     DarkPoolError::TraderAddressMismatch {
                         expected: format!("{:#x}", expected),
-                        found: format!("{:#x}", decrypted.trader),
+                        found: "***".to_string(),
                     },
                 ));
             }

--- a/crates/dp-engine/src/test_helpers.rs
+++ b/crates/dp-engine/src/test_helpers.rs
@@ -330,5 +330,5 @@ pub async fn place_plaintext_order(
         commitment_key,
         ttl,
     );
-    engine.place_encrypted_order(commit, vec![], ct).await
+    engine.place_encrypted_order(commit, vec![], ct, None).await
 }

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -335,6 +335,30 @@ async fn place_encrypted_order_bad_ciphertext() {
     assert!(r.is_err());
 }
 
+#[tokio::test]
+async fn place_encrypted_order_rejects_caller_address_mismatch() {
+    let (engine, _) = make_engine();
+    let d = DecryptedOrder {
+        trader: Address::ZERO,
+        pair: "BTC-USD".into(),
+        side: Side::Buy,
+        price: dec(100),
+        size: dec(1),
+        commitment_key: "k".into(),
+        ttl: 60_000_000_000,
+    };
+    let ct = serde_json::to_vec(&d).unwrap();
+    let wrong_caller: Address = "0x0000000000000000000000000000000000000001"
+        .parse()
+        .unwrap();
+    let r = engine
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, Some(wrong_caller))
+        .await;
+    assert!(r.is_err());
+    let msg = r.unwrap_err().to_string();
+    assert!(msg.contains("trader address mismatch"), "got: {msg}");
+}
+
 /// Regression: admin registers via `Pair::parse` (canonical upper-case),
 /// but traders may send any casing. The trader path must canonicalise
 /// before the registry lookup — otherwise `eth/usdc` 404s against an

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -359,6 +359,26 @@ async fn place_encrypted_order_rejects_caller_address_mismatch() {
     assert!(msg.contains("trader address mismatch"), "got: {msg}");
 }
 
+#[tokio::test]
+async fn place_encrypted_order_accepts_matching_caller() {
+    let (engine, _) = make_engine();
+    let d = DecryptedOrder {
+        trader: Address::ZERO,
+        pair: "BTC-USD".into(),
+        side: Side::Buy,
+        price: dec(100),
+        size: dec(1),
+        commitment_key: "k".into(),
+        ttl: 60_000_000_000,
+    };
+    let ct = serde_json::to_vec(&d).unwrap();
+    let order = engine
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, Some(Address::ZERO))
+        .await
+        .expect("matching caller should succeed");
+    assert_eq!(order.trader, Address::ZERO);
+}
+
 /// Regression: admin registers via `Pair::parse` (canonical upper-case),
 /// but traders may send any casing. The trader path must canonicalise
 /// before the registry lookup — otherwise `eth/usdc` 404s against an

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -269,7 +269,7 @@ async fn place_encrypted_order_noop_round_trip() {
     };
     let ct = serde_json::to_vec(&d).unwrap();
     let order = engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct)
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
         .unwrap();
     assert_eq!(order.pair, "BTC-USD");
@@ -289,7 +289,7 @@ async fn place_encrypted_order_uses_engine_derived_commitment() {
     };
     let ct = serde_json::to_vec(&d).unwrap();
     let order = engine
-        .place_encrypted_order(vec![0xAB; 32], vec![], ct)
+        .place_encrypted_order(vec![0xAB; 32], vec![], ct, None)
         .await
         .expect("engine no longer rejects on client commitment");
 
@@ -330,7 +330,7 @@ async fn place_encrypted_order_uses_engine_derived_commitment() {
 async fn place_encrypted_order_bad_ciphertext() {
     let (engine, _) = make_engine();
     let r = engine
-        .place_encrypted_order(vec![0u8; 32], vec![], b"not json".to_vec())
+        .place_encrypted_order(vec![0u8; 32], vec![], b"not json".to_vec(), None)
         .await;
     assert!(r.is_err());
 }
@@ -358,7 +358,7 @@ async fn place_encrypted_order_canonicalises_lowercase_pair() {
     };
     let ct = serde_json::to_vec(&d).unwrap();
     let order = engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct)
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
         .expect("lowercase pair canonicalises and matches registry");
 
@@ -390,7 +390,7 @@ async fn event_store_contains_no_plaintext() {
     let plain = serde_json::to_vec(&d).unwrap();
     let ct = xor.encrypt(&plain);
     engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct)
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
         .unwrap();
 
@@ -1044,11 +1044,11 @@ async fn full_pipeline_encrypted_order_to_settlement() {
     let (ask_commit, ask_ct) = encrypt_order(Side::Sell, dec(1900), "ask-key");
 
     let bid_order = engine
-        .place_encrypted_order(bid_commit, vec![], bid_ct)
+        .place_encrypted_order(bid_commit, vec![], bid_ct, None)
         .await
         .unwrap();
     let ask_order = engine
-        .place_encrypted_order(ask_commit, vec![], ask_ct)
+        .place_encrypted_order(ask_commit, vec![], ask_ct, None)
         .await
         .unwrap();
     assert_eq!(bid_order.pair, "ETH-USD");

--- a/crates/dp-engine/tests/coverage_paths.rs
+++ b/crates/dp-engine/tests/coverage_paths.rs
@@ -145,7 +145,7 @@ async fn place(engine: &Engine, pair: &str, side: Side, price: &str, size: &str,
     };
     let ct = serde_json::to_vec(&d).unwrap();
     engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct)
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
         .unwrap();
 }
@@ -173,7 +173,7 @@ async fn tick_collects_and_emits_expired_orders() {
     };
     let ct = serde_json::to_vec(&d).unwrap();
     engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct)
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
         .unwrap();
 
@@ -293,7 +293,7 @@ async fn recover_uses_default_ttl_when_decrypted_ttl_is_zero() {
     };
     let ct = serde_json::to_vec(&d).unwrap();
     engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct)
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
         .unwrap();
 

--- a/crates/dp-engine/tests/multi_pair.rs
+++ b/crates/dp-engine/tests/multi_pair.rs
@@ -51,7 +51,7 @@ async fn place(
     };
     let ct = serde_json::to_vec(&d).unwrap();
     engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct)
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
 }
 

--- a/crates/dp-engine/tests/zk_pipeline.rs
+++ b/crates/dp-engine/tests/zk_pipeline.rs
@@ -44,7 +44,7 @@ async fn place(engine: &Engine, side: Side, price: i64, key: &str) {
     };
     let ct = serde_json::to_vec(&d).unwrap();
     engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct)
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
         .unwrap();
 }

--- a/crates/dp-types/src/error.rs
+++ b/crates/dp-types/src/error.rs
@@ -33,6 +33,8 @@ pub enum DarkPoolError {
     PairAlreadyRegistered(String),
     #[error("cannot suspend delisted pair: {0}")]
     CannotSuspendDelistedPair(String),
+    #[error("trader address mismatch: expected {expected}, found {found}")]
+    TraderAddressMismatch { expected: String, found: String },
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Closes #147

The backend only knows about static API keys right now. There's no per-user identity, so the contract tracks traders by address but the API layer is blind to who's calling. This adds Sign-In with Ethereum so traders can authenticate by wallet signature.

New `siwe.rs` module handles the full flow: `NonceStore` (in-memory, 5-min TTL, reaper task mirroring `RateLimitCore`), EIP-4361 message verification via the `siwe` crate, and HS256 JWT issuance/verification via `jsonwebtoken`. Two unauthenticated endpoints go on the REST router outside the auth layer: `GET /v1/auth/nonce` returns a fresh nonce, `POST /v1/auth/verify` takes a signed SIWE message and hands back a JWT + expiry + address.

`AuthCore::check()` now returns `AuthenticatedIdentity` (either `ApiKey` or `Wallet(Address)`) instead of `()`. When a `Bearer` token is present and the JWT manager is wired, it verifies and extracts the wallet address. Otherwise falls through to the existing API key path. Both the axum middleware and the Tower gRPC service insert the identity into request extensions so downstream handlers can read it. The rate limiter keys on wallet address when available, falling back to API key then IP.

On the engine side, `place_encrypted_order` takes an optional `caller: Option<Address>`. When a wallet session places an order, the handler extracts the address from extensions and passes it in. After ECIES decryption, the engine checks `decrypted.trader == caller` and rejects mismatches with `TraderAddressMismatch` (mapped to `permission_denied`). API key callers pass `None`, skipping the check. All existing call sites (~15 across tests, benches, integration tests) just pass `None`.

Feature-gated behind `DARKPOOL_SIWE_ENABLED` (default false). When off, `AuthCore::new()` has no JWT manager and behavior is identical to before. DB migration for `traders`/`sessions`/`api_keys` tables is deferred per the issue's migration path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sign-In with Ethereum (SIWE) wallet authentication with nonce flow and verification endpoints
  * JWT session tokens for wallet users and optional SIWE configuration
  * REST router exposes auth endpoints; CORS updated to allow relevant headers
  * Rate limiting now accounts for authenticated wallet identity

* **Bug Fixes**
  * Orders are validated against caller identity to prevent mismatched-trader placements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/149?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->