### PR TITLE
[I2.4] Document and test orderbook REST flip

### DIFF
--- a/front/.env.local.example
+++ b/front/.env.local.example
@@ -6,6 +6,18 @@
 # Set to false to run against a real dp-api + on-chain contracts.
 NEXT_PUBLIC_USE_MOCKS=true
 
+# Per-RPC override of NEXT_PUBLIC_USE_MOCKS. Each accepts true/1 (force mock)
+# or false/0 (force REST); unset → fall back to NEXT_PUBLIC_USE_MOCKS. Lets
+# Phase 2 migrate one RPC at a time — e.g. flip the orderbook to the real
+# backend while everything else stays on mocks. See front/lib/sdk/client.ts
+# (`methodOverridesFromEnv`) for the routing logic.
+# NEXT_PUBLIC_USE_MOCKS_PLACE_ORDER=
+# NEXT_PUBLIC_USE_MOCKS_CANCEL_ORDER=
+# NEXT_PUBLIC_USE_MOCKS_GET_ORDER=
+# NEXT_PUBLIC_USE_MOCKS_ORDERBOOK=
+# NEXT_PUBLIC_USE_MOCKS_AUCTION_HISTORY=
+# NEXT_PUBLIC_USE_MOCKS_STREAM_AUCTIONS=
+
 # Backend base URL. In `npm run dev` requests to /api/v1/* are proxied here
 # (via next.config.mjs) until C2 lands proper CORS on the REST router.
 # No trailing /v1 — the proxy appends it.

--- a/front/README.md
+++ b/front/README.md
@@ -54,6 +54,23 @@ edit the values. `.env.local` is git-ignored.
 | `NEXT_PUBLIC_USDC_ADDRESS`            | `NEXT_PUBLIC_USE_MOCKS=false`          | `0x` + 40 hex chars.                                             |
 | `NEXT_PUBLIC_WETH_ADDRESS`            | `NEXT_PUBLIC_USE_MOCKS=false`          | `0x` + 40 hex chars.                                             |
 
+### Per-RPC mock overrides
+
+Phase 2 swaps the mock client for `RestClient` one RPC at a time. Each
+override layers on top of `NEXT_PUBLIC_USE_MOCKS`: `true` / `1` forces the
+mock impl for that RPC, `false` / `0` forces the REST impl, and unset
+falls back to the global flag. Parsing lives in
+[`methodOverridesFromEnv`](./lib/sdk/client.ts).
+
+| Variable                                     | Routes              | Notes                                                                       |
+| -------------------------------------------- | ------------------- | --------------------------------------------------------------------------- |
+| `NEXT_PUBLIC_USE_MOCKS_ORDERBOOK`            | `getOrderBook`      | I2.4 (#93). Hits `GET /v1/orderbook` when `false`.                          |
+| `NEXT_PUBLIC_USE_MOCKS_AUCTION_HISTORY`      | `getAuctionHistory` | I2.5 (#94). Hits `GET /v1/auctions` when `false`.                           |
+| `NEXT_PUBLIC_USE_MOCKS_STREAM_AUCTIONS`      | `streamAuctions`    | I2.6 (#95). Keep `true` until the SSE bridge ships — REST throws otherwise. |
+| `NEXT_PUBLIC_USE_MOCKS_PLACE_ORDER`          | `placeOrder`        | I2.10 (#99). Needs the ZK prover + browser ECIES first.                     |
+| `NEXT_PUBLIC_USE_MOCKS_CANCEL_ORDER`         | `cancelOrder`       | Pair with `placeOrder` so cancels target real orders.                       |
+| `NEXT_PUBLIC_USE_MOCKS_GET_ORDER`            | `getOrder`          | Standalone — flip once `placeOrder` is real.                                |
+
 ### Dev proxy
 
 `next.config.mjs` rewrites `/api/v1/:path*` →

--- a/front/lib/sdk/client.test.ts
+++ b/front/lib/sdk/client.test.ts
@@ -506,6 +506,47 @@ describe('methodOverridesFromEnv', () => {
   })
 })
 
+// ─── I2.4 wire test: NEXT_PUBLIC_USE_MOCKS_ORDERBOOK=false flips just  ──
+//      `getOrderBook` to the live RestClient while everything else stays
+//      on the StoreMockClient. Locks the documented Phase-2 ramp so a
+//      regression in either the env parser or the routing client surfaces
+//      here instead of as a silent mocked response in the browser.
+
+describe('Phase 2 flip — NEXT_PUBLIC_USE_MOCKS_ORDERBOOK=false', () => {
+  it('routes getOrderBook to REST while siblings stay on the StoreMockClient', async () => {
+    const overrides = methodOverridesFromEnv({
+      NEXT_PUBLIC_USE_MOCKS_ORDERBOOK: 'false',
+    })
+    expect(overrides).toEqual({ getOrderBook: false })
+
+    const { fetch, calls } = captureFetch(
+      makeJsonResponse({ pair: 'ETH/USDC', bids: [], asks: [] })
+    )
+    const mockCalls: DarkPoolMethod[] = []
+    const stubMock = makeRecordingClient((m) => mockCalls.push(m))
+
+    const client = createDarkPoolClient({
+      baseUrl: BASE,
+      apiKey: KEY,
+      useMocks: true,
+      mockClient: stubMock,
+      restClient: new RestClient({ baseUrl: BASE, apiKey: KEY, fetch }),
+      methodOverrides: overrides,
+    })
+
+    await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    await client.getAuctionHistory(
+      create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 50 })
+    )
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe(`${BASE}/v1/orderbook?pair=ETH%2FUSDC`)
+    const headers = calls[0].init.headers as Record<string, string>
+    expect(headers['x-api-key']).toBe(KEY)
+    expect(mockCalls).toEqual(['getAuctionHistory'])
+  })
+})
+
 // ─── DarkPoolError ────────────────────────────────────────────────────────
 
 describe('DarkPoolError', () => {


### PR DESCRIPTION
Closes #93.

## Summary

The F0.4 factory already supports per-RPC override of the global mock flag — `methodOverridesFromEnv` reads `NEXT_PUBLIC_USE_MOCKS_ORDERBOOK` and `RoutingClient` routes `getOrderBook` to `RestClient` (which hits `GET /v1/orderbook?pair=...` via the existing CORS-enabled REST handler from C2). This PR makes the flip discoverable and locks it with an end-to-end wire test:

- **`.env.local.example`** — list the six per-RPC override env vars as commented-out scaffolding, pointing at `methodOverridesFromEnv` for the routing semantics. Each layers on top of `NEXT_PUBLIC_USE_MOCKS`: `true`/`1` forces mock, `false`/`0` forces REST, unset falls back to the global flag.
- **`front/README.md`** — new "Per-RPC mock overrides" sub-section under env vars, mapping each variable to its RPC and the Phase 2 issue that ships it. Notes that `STREAM_AUCTIONS` should stay `true` until #95 (SSE bridge) lands or `RestClient.streamAuctions` throws `UNIMPLEMENTED`.
- **`front/lib/sdk/client.test.ts`** — new *Phase 2 flip* describe block that calls `methodOverridesFromEnv({ NEXT_PUBLIC_USE_MOCKS_ORDERBOOK: 'false' })`, hands the factory a real `RestClient` (captured `fetch`) plus a stub mock client, and asserts `getOrderBook` lands on `GET /v1/orderbook?pair=ETH%2FUSDC` with the `x-api-key` header while `getAuctionHistory` still routes to the mock. Acts as the regression guard for the env parser + `RoutingClient` chain.

No runtime code changes — the wiring landed with F0.4 and C2; this PR ships the contract.

## Acceptance criteria (#93)

- [x] `RestClient.getOrderBook` hits `GET /v1/orderbook?pair=ETH/USDC` — covered by the existing `RestClient.getOrderBook` test (line 143 of `client.test.ts`).
- [x] Per-endpoint mock toggle (`NEXT_PUBLIC_USE_MOCKS_ORDERBOOK`) so this can ship independently of I2.5 — locked by the new Phase-2 flip test and documented in `.env.local.example` + README.
- [x] Orderbook still polls at 1 s — `useOrderBook` keeps `ORDERBOOK_POLL_MS = 1000` (unchanged).
- [x] Loading and error states are unchanged from F1.6 — no UI code touched.
- [ ] Network panel inspection in dev — manual verification step; the SDK-level wire is exercised by the new test, but eyeballing the request in the browser still requires the OrderBook panel to be mounted in `Shell` (deferred to a later integration PR).

## Test plan

- [x] `npm test` — 411 tests pass (412 with the new one).
- [x] `npm run typecheck`, `npm run lint`, `npm run format:check` all clean.
- [x] `npm run build` with the CI env vars from `.github/workflows/ci.yml` compiles successfully.
- [ ] After merge: with `NEXT_PUBLIC_USE_MOCKS=true` and `NEXT_PUBLIC_USE_MOCKS_ORDERBOOK=false` against a running `dp-api`, devtools' Network panel shows `GET /v1/orderbook?pair=ETH%2FUSDC` polling every second (manual; needs the panel mounted in `Shell` which is deferred).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-RPC environment variable configuration that allows overriding global mock settings for individual SDK methods (getOrderBook, getAuctionHistory, streamAuctions, placeOrder, cancelOrder, getOrder).

* **Documentation**
  * Updated configuration documentation and examples explaining how per-RPC overrides combine with the global setting, with fallback behavior for unset values.

* **Tests**
  * Added test coverage validating per-RPC override functionality for individual API methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/150?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->