### PR TITLE
[zk] Bind settled matches and trader identity into the IVC proof

### DIFF
--- a/crates/dp-aggregator/src/aggregator.rs
+++ b/crates/dp-aggregator/src/aggregator.rs
@@ -84,8 +84,8 @@ impl ProofAggregator for NoopAggregator {
             use ark_ff::Zero;
             Ok(dp_zk::folding::FinalProof {
                 proof_bytes: vec![0u8; 32],
-                z_0: [Fr::zero(); 3],
-                z_n: [Fr::zero(); 3],
+                z_0: [Fr::zero(); 4],
+                z_n: [Fr::zero(); 4],
                 n_steps: 0,
                 policy_hash: Fr::zero(),
             })

--- a/crates/dp-aggregator/src/inline.rs
+++ b/crates/dp-aggregator/src/inline.rs
@@ -145,15 +145,16 @@ impl ProofAggregator for InlineFoldingAggregator {
     }
 }
 
-/// Compute z_0 = [0, 0, poseidon(min_size, min_price, position_limit)] from
+/// Compute z_0 = [0, 0, poseidon(min_size, min_price, position_limit), 0] from
 /// the external inputs of the first round. This matches the `initial_z` helper
-/// in `dp-zk`'s step circuit tests.
-fn compute_z_0(ext: &AuctionExternalInputs) -> [Fr; 3] {
+/// in `dp-zk`'s step circuit tests. The trailing slot is the empty settlement
+/// hash-chain accumulator (#153).
+fn compute_z_0(ext: &AuctionExternalInputs) -> [Fr; 4] {
     let cfg = poseidon_config();
     let mut s = PoseidonSponge::<Fr>::new(&cfg);
     s.absorb(&vec![ext.min_size, ext.min_price, ext.position_limit]);
     let policy_hash = s.squeeze_field_elements::<Fr>(1)[0];
-    [Fr::zero(), Fr::zero(), policy_hash]
+    [Fr::zero(), Fr::zero(), policy_hash, Fr::zero()]
 }
 
 #[cfg(test)]

--- a/crates/dp-aggregator/tests/zk_e2e.rs
+++ b/crates/dp-aggregator/tests/zk_e2e.rs
@@ -49,10 +49,14 @@ async fn subprocess_aggregator_returns_result() {
         size: Decimal::from(10),
     }];
 
-    let bid_key = "bid_key".to_string();
-    let ask_key = "ask_key".to_string();
-    let bid_trader = hex::encode(dp_zk::pedersen::derive_trader_id_bytes(bid_key.as_bytes()));
-    let ask_trader = hex::encode(dp_zk::pedersen::derive_trader_id_bytes(ask_key.as_bytes()));
+    let bid_addr = "aa".repeat(20);
+    let ask_addr = "bb".repeat(20);
+    let bid_trader = hex::encode(dp_zk::pedersen::derive_trader_id_bytes(
+        &hex::decode(&bid_addr).unwrap(),
+    ));
+    let ask_trader = hex::encode(dp_zk::pedersen::derive_trader_id_bytes(
+        &hex::decode(&ask_addr).unwrap(),
+    ));
     let witness = BatchWitness {
         batch_id,
         auction_id,
@@ -65,7 +69,7 @@ async fn subprocess_aggregator_returns_result() {
                 limit_price: Decimal::from(105),
                 order_size: Decimal::from(10),
                 side: 0,
-                commitment_key: bid_key,
+                trader_addr: bid_addr,
             },
             ask: OrderLegWitness {
                 trader_id: ask_trader,
@@ -75,7 +79,7 @@ async fn subprocess_aggregator_returns_result() {
                 limit_price: Decimal::from(95),
                 order_size: Decimal::from(10),
                 side: 1,
-                commitment_key: ask_key,
+                trader_addr: ask_addr,
             },
         }],
         policy: DEFAULT_POLICY.into_policy(),

--- a/crates/dp-engine/src/batch.rs
+++ b/crates/dp-engine/src/batch.rs
@@ -158,11 +158,24 @@ impl Engine {
             } = payload;
             let matches_hash = compute_matches_hash(auction_id, &settlement_matches)
                 .map_err(EngineError::Submit)?;
+            // TODO(#153 Phase 4): widen SubmitSessionParams + the contract's
+            // submitSession ABI to carry z[3] (settlement_acc) and recompute it
+            // on-chain in settleSession. Until then only the first three state
+            // elements are sent; the stub Decider verifier ignores public IO,
+            // so the on-chain binding check is not yet enforced.
             let session_params = SubmitSessionParams {
                 session_id: batch_id,
                 proof: proof_bytes,
-                z_0: z_0.map(U256::from_be_bytes),
-                z_n: z_n.map(U256::from_be_bytes),
+                z_0: [
+                    U256::from_be_bytes(z_0[0]),
+                    U256::from_be_bytes(z_0[1]),
+                    U256::from_be_bytes(z_0[2]),
+                ],
+                z_n: [
+                    U256::from_be_bytes(z_n[0]),
+                    U256::from_be_bytes(z_n[1]),
+                    U256::from_be_bytes(z_n[2]),
+                ],
                 n_steps,
                 policy_hash: B256::from(policy_hash),
                 matches_hash,

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -578,6 +578,7 @@ impl Engine {
         let nonce = &self.inner.salt_nonce;
         let secrets = derive_order_secrets(
             order.id,
+            order.trader.as_slice(),
             &order.commitment_key,
             order.side as u8,
             order.price,
@@ -777,7 +778,9 @@ fn leg_witness_from(
         limit_price: order.price,
         order_size: order.size,
         side,
-        commitment_key: order.commitment_key,
+        // The circuit identity is the on-chain settlement address; `trader_id`
+        // above is `poseidon(this)` (#153).
+        trader_addr: hex::encode(order.trader),
     }
 }
 
@@ -790,8 +793,12 @@ fn leg_witness_from(
 /// `order_id` — from reconstructing the salt. The nonce is persisted
 /// alongside each `OrderPlaced` event so recovery can recompute the
 /// commitment.
+// Internal helper threading the full secret-derivation inputs; the argument
+// list is intentionally flat rather than a one-off params struct.
+#[allow(clippy::too_many_arguments)]
 fn derive_order_secrets(
     order_id: Uuid,
+    trader_addr: &[u8],
     commitment_key: &str,
     side: u8,
     price: Decimal,
@@ -799,7 +806,10 @@ fn derive_order_secrets(
     oracle: &dyn BalanceOracle,
     nonce: &[u8; 32],
 ) -> Result<OrderSecrets, EngineError> {
-    let trader_id = dp_zk::pedersen::derive_trader_id_bytes(commitment_key.as_bytes());
+    // Identity is bound to the verified on-chain address, not the client-
+    // chosen commitment_key (#153). The commitment_key is retained below only
+    // as blinding entropy for the salt.
+    let trader_id = dp_zk::pedersen::derive_trader_id_bytes(trader_addr);
     let salt = derive_salt(commitment_key, order_id, nonce);
     let commitment = compute_poseidon_commitment(&trader_id, side, price, size, &salt)?;
 
@@ -818,13 +828,14 @@ fn derive_order_secrets(
 /// `OrderPlaced` events without keeping any state in memory.
 pub(crate) fn recompute_persisted_commitment(
     order_id: Uuid,
+    trader_addr: &[u8],
     commitment_key: &str,
     side: u8,
     price: Decimal,
     size: Decimal,
     nonce: &[u8; 32],
 ) -> Result<[u8; 32], EngineError> {
-    let trader_id = dp_zk::pedersen::derive_trader_id_bytes(commitment_key.as_bytes());
+    let trader_id = dp_zk::pedersen::derive_trader_id_bytes(trader_addr);
     let salt = derive_salt(commitment_key, order_id, nonce);
     compute_poseidon_commitment(&trader_id, side, price, size, &salt)
 }

--- a/crates/dp-engine/src/recover.rs
+++ b/crates/dp-engine/src/recover.rs
@@ -391,6 +391,7 @@ impl Engine {
                 })?;
                 let recomputed = crate::engine::recompute_persisted_commitment(
                     *order_id,
+                    decrypted.trader.as_slice(),
                     &decrypted.commitment_key,
                     decrypted.side as u8,
                     decrypted.price,

--- a/crates/dp-engine/src/state.rs
+++ b/crates/dp-engine/src/state.rs
@@ -107,8 +107,12 @@ impl Default for PairConfig {
 pub enum ProofPayload {
     IvcFinal {
         proof_bytes: Vec<u8>,
-        z_0: [[u8; 32]; 3],
-        z_n: [[u8; 32]; 3],
+        // 4 elements: [state_hash, round_nonce, policy_hash, settlement_acc].
+        // The trailing settlement_acc (#153) binds the settled matches and is
+        // carried here at full fidelity. Plumbing it on-chain + the recompute
+        // is Phase 4.
+        z_0: [[u8; 32]; 4],
+        z_n: [[u8; 32]; 4],
         n_steps: u64,
         policy_hash: [u8; 32],
     },

--- a/crates/dp-engine/src/test_helpers.rs
+++ b/crates/dp-engine/src/test_helpers.rs
@@ -128,8 +128,8 @@ impl ProofAggregator for StubAggregator {
         Box::pin(async move {
             Ok(dp_zk::folding::FinalProof {
                 proof_bytes,
-                z_0: [Fr::zero(); 3],
-                z_n: [Fr::zero(); 3],
+                z_0: [Fr::zero(); 4],
+                z_n: [Fr::zero(); 4],
                 n_steps: 1,
                 policy_hash: Fr::zero(),
             })
@@ -218,8 +218,8 @@ impl ProofAggregator for BlockingAggregator {
         Box::pin(async move {
             Ok(dp_zk::folding::FinalProof {
                 proof_bytes: vec![0u8; 32],
-                z_0: [Fr::zero(); 3],
-                z_n: [Fr::zero(); 3],
+                z_0: [Fr::zero(); 4],
+                z_n: [Fr::zero(); 4],
                 n_steps: 1,
                 policy_hash: Fr::zero(),
             })

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -311,6 +311,7 @@ async fn place_encrypted_order_uses_engine_derived_commitment() {
 
     let expected = crate::engine::recompute_persisted_commitment(
         order.id,
+        d.trader.as_slice(),
         &d.commitment_key,
         d.side as u8,
         d.price,

--- a/crates/dp-engine/src/tick.rs
+++ b/crates/dp-engine/src/tick.rs
@@ -615,8 +615,8 @@ mod ivc_tests {
                 use ark_ff::Zero;
                 Ok(dp_zk::folding::FinalProof {
                     proof_bytes: vec![0u8; 32],
-                    z_0: [Fr::zero(); 3],
-                    z_n: [Fr::zero(); 3],
+                    z_0: [Fr::zero(); 4],
+                    z_n: [Fr::zero(); 4],
                     n_steps: 1,
                     policy_hash: Fr::zero(),
                 })

--- a/crates/dp-engine/tests/zk_pipeline.rs
+++ b/crates/dp-engine/tests/zk_pipeline.rs
@@ -32,9 +32,15 @@ fn cli_bin() -> PathBuf {
     workspace.join("target/debug/dp-zk-cli")
 }
 
-async fn place(engine: &Engine, side: Side, price: i64, key: &str) {
+async fn place(
+    engine: &Engine,
+    side: Side,
+    price: i64,
+    key: &str,
+    trader: alloy_primitives::Address,
+) {
     let d = dp_crypto::DecryptedOrder {
-        trader: alloy_primitives::Address::ZERO,
+        trader,
         pair: "BTC-USD".into(),
         side,
         price: Decimal::from(price),
@@ -65,8 +71,10 @@ async fn engine_subprocess_zk_pipeline() {
         .with_env("DARKPOOL_ZK_BATCH_SIZE", "2");
     engine.set_aggregator(Arc::new(agg));
 
-    place(&engine, Side::Buy, 105, "secret_bid").await;
-    place(&engine, Side::Sell, 95, "secret_ask").await;
+    let bid_addr = alloy_primitives::Address::from([0x11u8; 20]);
+    let ask_addr = alloy_primitives::Address::from([0x22u8; 20]);
+    place(&engine, Side::Buy, 105, "secret_bid", bid_addr).await;
+    place(&engine, Side::Sell, 95, "secret_ask", ask_addr).await;
 
     let notifications = engine.run_auction_tick().await;
     assert_eq!(notifications.len(), 1, "expected one auction");
@@ -88,7 +96,7 @@ async fn engine_subprocess_zk_pipeline() {
     // (Plaintext orders themselves use NoopDecrypter here so their JSON
     // body is in OrderPlaced::ciphertext — that's covered by the
     // dedicated XOR/event-store canary in `tests.rs`.)
-    let trader_id_bid = dp_zk::pedersen::derive_trader_id_bytes(b"secret_bid");
+    let trader_id_bid = dp_zk::pedersen::derive_trader_id_bytes(bid_addr.as_slice());
     let raw = bincode::serialize(&events).unwrap();
     let leaked = raw.windows(trader_id_bid.len()).any(|w| w == trader_id_bid);
     assert!(!leaked, "ZK trader_id leaked into event log");

--- a/crates/dp-engine/tests/zk_pipeline.rs
+++ b/crates/dp-engine/tests/zk_pipeline.rs
@@ -97,7 +97,11 @@ async fn engine_subprocess_zk_pipeline() {
     // body is in OrderPlaced::ciphertext — that's covered by the
     // dedicated XOR/event-store canary in `tests.rs`.)
     let trader_id_bid = dp_zk::pedersen::derive_trader_id_bytes(bid_addr.as_slice());
+    let trader_id_bid_hex = hex::encode(trader_id_bid);
     let raw = bincode::serialize(&events).unwrap();
-    let leaked = raw.windows(trader_id_bid.len()).any(|w| w == trader_id_bid);
+    let leaked = raw.windows(trader_id_bid.len()).any(|w| w == trader_id_bid)
+        || raw
+            .windows(trader_id_bid_hex.len())
+            .any(|w| w == trader_id_bid_hex.as_bytes());
     assert!(!leaked, "ZK trader_id leaked into event log");
 }

--- a/crates/dp-zk-cli/src/lib.rs
+++ b/crates/dp-zk-cli/src/lib.rs
@@ -205,7 +205,7 @@ mod tests {
             limit_price: Decimal::new(100, 0),
             order_size: Decimal::new(10, 0),
             side: 0,
-            commitment_key: "ck".into(),
+            trader_addr: "cc".repeat(20),
         }
     }
 

--- a/crates/dp-zk/CIRCUIT.md
+++ b/crates/dp-zk/CIRCUIT.md
@@ -28,12 +28,13 @@ uses `2^58`.
 | 1 | Side bit-form               | All rows     | `side * (1 - side) == 0` per leg.                   |
 | 2 | Opposite sides              | Active rows  | `(bid_side + ask_side - 1) * is_active == 0`.       |
 | 3 | Crossing                    | Active rows  | `bid_lp - match_price` and `match_price - ask_lp` non-negative via 60-bit range. |
+| 3b| Uniform clearing price      | Active rows  | `(match_price - clearing_price) * is_active == 0` — every active row settles at the single auction clearing price (#163). |
 | 4 | Min-size, min-price         | All / active | 60-bit ranges on `size`, `price`; diff to floors gated by `is_active`. |
 | 5 | Leg commitment binding      | All rows     | In-circuit Poseidon over `(trader_id, side, lp, size, salt)` reconstructs the commitment, accumulated into `commitments_root`. |
 | 6 | Notional binding            | All rows     | `match_price * match_size` accumulates into `notionals_root`. |
 | 7 | Solvency                    | Active rows  | `balance < 2^60` (60-bit range) AND `balance * 1e8 - notional` fits 120-bit range. |
 | 8 | Position-limit (two-sided)  | Active rows  | For `new_pos = position ± match_size`, `(limit - new_pos)` and `(limit + new_pos)` each fit in 60 bits → `\|new_pos\| ≤ position_limit`. |
-| 9 | Trader-id binding           | Active rows  | `(poseidon(commitment_key_scalar) - trader_id) * is_active == 0`. |
+| 9 | Trader-id binding           | Active rows  | `(poseidon(trader_addr_scalar) - trader_id) * is_active == 0` — identity is the on-chain settlement address, binding the proof to the account the contract debits/credits (#153). |
 
 The two-sided range trick avoids an explicit absolute-value gadget:
 because the Poseidon-friendly `signed_to_scalar` representation puts

--- a/crates/dp-zk/src/folding.rs
+++ b/crates/dp-zk/src/folding.rs
@@ -42,7 +42,7 @@ pub struct HyperNovaPublicParams {
 /// Mutable accumulator holding the live HyperNova IVC state.
 pub struct FoldingAccumulator {
     pub(crate) hn: HN,
-    pub z_0: [Fr; 3],
+    pub z_0: [Fr; 4],
     pub n_steps: u64,
 }
 
@@ -51,8 +51,8 @@ pub struct FoldingAccumulator {
 pub struct FinalProof {
     /// Serialized `HN::IVCProof` bytes.
     pub proof_bytes: Vec<u8>,
-    pub z_0: [Fr; 3],
-    pub z_n: [Fr; 3],
+    pub z_0: [Fr; 4],
+    pub z_n: [Fr; 4],
     pub n_steps: u64,
     /// Convenience copy of `z_n[2]` (policy_hash, invariant across rounds).
     pub policy_hash: Fr,
@@ -77,7 +77,7 @@ pub fn generate_params<R: RngCore + CryptoRng>(
 pub fn init_accumulator(
     params: &HyperNovaPublicParams,
     batch_size: usize,
-    z_0: [Fr; 3],
+    z_0: [Fr; 4],
 ) -> Result<FoldingAccumulator, ZkError> {
     let circuit = AuctionStepCircuit { batch_size };
     let params_tuple = (params.prover.clone(), params.verifier.clone());
@@ -106,7 +106,7 @@ pub fn fold_step<R: RngCore + CryptoRng>(
 /// Finalize the IVC chain into a serialized proof.
 pub fn compress_and_finalize(acc: &FoldingAccumulator) -> Result<FinalProof, ZkError> {
     let ivc_proof = acc.hn.ivc_proof();
-    let z_n: [Fr; 3] = ivc_proof.z_i.as_slice().try_into().map_err(|_| {
+    let z_n: [Fr; 4] = ivc_proof.z_i.as_slice().try_into().map_err(|_| {
         ZkError::Ivc(format!(
             "z_i has wrong length (got {})",
             ivc_proof.z_i.len()

--- a/crates/dp-zk/src/folding.rs
+++ b/crates/dp-zk/src/folding.rs
@@ -137,7 +137,33 @@ pub fn verify_final(params: &HyperNovaPublicParams, proof: &FinalProof) -> Resul
     )
     .map_err(|e| ZkError::Serialize(format!("deserialize ivc_proof: {e}")))?;
 
+    // The authenticated public IO carried inside the proof. `HN::verify` binds
+    // the proof to exactly these `z_0` / `z_i` values (via the running-instance
+    // hash `H(i, z_0, z_i, U_i)`), so capture them before `verify` moves the
+    // proof. The `FinalProof` convenience copies — which flow on-chain through
+    // `ProofPayload::IvcFinal` — must equal them, otherwise a caller could
+    // rewrite the settlement-binding metadata (`z_n[3]`, `policy_hash`) while
+    // still presenting a valid `proof_bytes`.
+    let authentic_z_0 = ivc_proof.z_0.clone();
+    let authentic_z_n = ivc_proof.z_i.clone();
+
     HN::verify(params.verifier.clone(), ivc_proof)
         .map_err(|e| ZkError::Ivc(format!("verify: {e}")))?;
+
+    if authentic_z_0.as_slice() != proof.z_0.as_slice() {
+        return Err(ZkError::Ivc(
+            "z_0 mismatch: FinalProof.z_0 does not match the verified proof".into(),
+        ));
+    }
+    if authentic_z_n.as_slice() != proof.z_n.as_slice() {
+        return Err(ZkError::Ivc(
+            "z_n mismatch: FinalProof.z_n does not match the verified proof".into(),
+        ));
+    }
+    if proof.policy_hash != proof.z_n[2] {
+        return Err(ZkError::Ivc(
+            "policy_hash mismatch: FinalProof.policy_hash does not equal z_n[2]".into(),
+        ));
+    }
     Ok(())
 }

--- a/crates/dp-zk/src/step_circuit.rs
+++ b/crates/dp-zk/src/step_circuit.rs
@@ -84,7 +84,7 @@ pub struct AuctionExternalInputs {
     pub position_limit: Fr,
     /// The single uniform clearing price for this auction round. Every active
     /// match row must settle at this price (#163). Derived from the first
-    /// match in [`from_witness`]; the honest engine applies one volume-
+    /// match in [`Self::from_witness`]; the honest engine applies one volume-
     /// maximizing price to every match, so all rows already equal it.
     pub clearing_price: Fr,
     pub matches: Vec<CircuitMatchNative>,

--- a/crates/dp-zk/src/step_circuit.rs
+++ b/crates/dp-zk/src/step_circuit.rs
@@ -305,15 +305,18 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
 
 /// IVC step circuit for HyperNova.
 ///
-/// IVC state: `z_i = [state_hash, round_nonce, policy_hash]` (3 Fr elements).
+/// IVC state: `z_i = [state_hash, round_nonce, policy_hash, settlement_acc]`
+/// (4 Fr elements).
 ///
-/// Each step folds one auction batch, enforcing the same 9 constraint families
-/// as `BatchProofCircuit`, then updates the state:
+/// Each step folds one auction batch, enforcing the constraint families, then
+/// updates the state:
 /// ```text
 /// policy_hash_computed = poseidon(min_size, min_price, position_limit)
 /// // checked == z_i[2]
 /// new_state_hash = poseidon(z_i[0], commitments_root, notionals_root, active_count)
-/// z_{i+1} = [new_state_hash, z_i[1] + 1, z_i[2]]
+/// // settlement_acc folds each active row's tuple (bid_addr, ask_addr,
+/// // match_price, match_size) into a running Poseidon chain (#153)
+/// z_{i+1} = [new_state_hash, z_i[1] + 1, z_i[2], settlement_acc']
 /// ```
 #[derive(Clone, Debug)]
 pub struct AuctionStepCircuit {
@@ -330,7 +333,7 @@ impl FCircuit<Fr> for AuctionStepCircuit {
     }
 
     fn state_len(&self) -> usize {
-        3 // [state_hash, round_nonce, policy_hash]
+        4 // [state_hash, round_nonce, policy_hash, settlement_acc]
     }
 
     fn generate_step_constraints(
@@ -343,6 +346,14 @@ impl FCircuit<Fr> for AuctionStepCircuit {
         let prev_state_hash = z_i[0].clone();
         let round_nonce = z_i[1].clone();
         let policy_hash = z_i[2].clone();
+        // Running Poseidon hash-chain over the plaintext settlement tuples of
+        // every active match across the whole session, in order. The contract
+        // recomputes the identical chain over the settled `matches[]` and
+        // requires it equal `z_n[3]` — this is what binds on-chain settlement
+        // to the proof (#153). A chain (not a sponge over a padded vector)
+        // means the contract folds only real matches, with no padding-length
+        // coupling to the circuit's fixed `batch_size`.
+        let mut settlement_acc = z_i[3].clone();
 
         let cfg = poseidon_config();
         let one = FpVar::<Fr>::one();
@@ -548,6 +559,26 @@ impl FCircuit<Fr> for AuctionStepCircuit {
             let ask_derived = ask_id_sponge.squeeze_field_elements(1)?[0].clone();
             ((&ask_derived - &ask_trader) * &is_active).enforce_equal(&zero)?;
 
+            // ── Settlement-tuple chain (#153) ────────────────────────────────
+            // Fold this row's plaintext settlement tuple into the running
+            // chain on active rows; inactive (padding) rows pass the
+            // accumulator through unchanged. `bid_addr`/`ask_addr` are the
+            // settlement addresses as field elements (== uint256(address)),
+            // matching what the contract hashes from `matches[]`.
+            let mut settle_sponge = PoseidonSpongeVar::<Fr>::new(cs.clone(), &cfg);
+            settle_sponge.absorb(
+                &[
+                    settlement_acc.clone(),
+                    bid_addr.clone(),
+                    ask_addr.clone(),
+                    m_price.clone(),
+                    m_size.clone(),
+                ]
+                .as_ref(),
+            )?;
+            let settle_next = settle_sponge.squeeze_field_elements(1)?[0].clone();
+            settlement_acc = &settle_next * &is_active + &settlement_acc * (&one - &is_active);
+
             all_leaves.push(&bid_commit * &is_active);
             all_leaves.push(&ask_commit * &is_active);
             all_notionals.push(&notional * &is_active);
@@ -580,7 +611,12 @@ impl FCircuit<Fr> for AuctionStepCircuit {
 
         let new_round_nonce = &round_nonce + &one;
 
-        Ok(vec![new_state_hash, new_round_nonce, policy_hash])
+        Ok(vec![
+            new_state_hash,
+            new_round_nonce,
+            policy_hash,
+            settlement_acc,
+        ])
     }
 }
 
@@ -687,7 +723,52 @@ mod tests {
         let mut s = PoseidonSponge::<Fr>::new(&cfg);
         s.absorb(&vec![ext.min_size, ext.min_price, ext.position_limit]);
         let policy_hash = s.squeeze_field_elements::<Fr>(1)[0];
-        vec![Fr::zero(), Fr::zero(), policy_hash]
+        // [state_hash, round_nonce, policy_hash, settlement_acc]
+        vec![Fr::zero(), Fr::zero(), policy_hash, Fr::zero()]
+    }
+
+    /// Native mirror of the in-circuit settlement hash-chain (#153): folds
+    /// each active match's `(bid_addr, ask_addr, price_8, size_8)` tuple into a
+    /// running Poseidon chain starting from `acc0`. This is the value the
+    /// on-chain `settleSession` must reproduce from `matches[]`.
+    fn settlement_chain(ext: &AuctionExternalInputs, acc0: Fr) -> Fr {
+        let cfg = poseidon_config();
+        let mut acc = acc0;
+        for m in &ext.matches {
+            if m.is_active != Fr::one() {
+                continue;
+            }
+            let mut s = PoseidonSponge::<Fr>::new(&cfg);
+            s.absorb(&vec![
+                acc,
+                m.bid_trader_addr,
+                m.ask_trader_addr,
+                m.match_price,
+                m.match_size,
+            ]);
+            acc = s.squeeze_field_elements::<Fr>(1)[0];
+        }
+        acc
+    }
+
+    #[test]
+    fn settlement_acc_matches_native_chain() {
+        let (w, prices, sizes) = two_match_witness(Decimal::from(100), Decimal::from(100));
+        let ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 3).unwrap();
+        let z_0 = initial_z(&ext);
+        let expected = settlement_chain(&ext, z_0[3]);
+        let circuit = AuctionStepCircuit::new(3).unwrap();
+        let (satisfied, z_next) = run_step(&circuit, z_0, ext);
+        assert!(satisfied, "valid two-match batch must satisfy");
+        assert_eq!(
+            z_next[3], expected,
+            "in-circuit settlement_acc must equal the native hash-chain the contract recomputes"
+        );
+        assert_ne!(
+            z_next[3],
+            Fr::zero(),
+            "non-empty batch must advance the chain"
+        );
     }
 
     #[test]

--- a/crates/dp-zk/src/step_circuit.rs
+++ b/crates/dp-zk/src/step_circuit.rs
@@ -31,7 +31,7 @@ pub struct CircuitMatchNative {
     pub bid_side: Fr,
     pub bid_balance: Fr,
     pub bid_position: Fr,
-    pub bid_commitment_key: Fr,
+    pub bid_trader_addr: Fr,
     pub bid_order_size: Fr,
 
     pub ask_trader: Fr,
@@ -40,7 +40,7 @@ pub struct CircuitMatchNative {
     pub ask_side: Fr,
     pub ask_balance: Fr,
     pub ask_position: Fr,
-    pub ask_commitment_key: Fr,
+    pub ask_trader_addr: Fr,
     pub ask_order_size: Fr,
 
     pub match_price: Fr,
@@ -59,7 +59,7 @@ impl Default for CircuitMatchNative {
             bid_side: zero,
             bid_balance: zero,
             bid_position: zero,
-            bid_commitment_key: zero,
+            bid_trader_addr: zero,
             bid_order_size: zero,
             ask_trader: zero,
             ask_salt: zero,
@@ -67,7 +67,7 @@ impl Default for CircuitMatchNative {
             ask_side: one, // ask side = 1 for inactive rows (valid bit)
             ask_balance: zero,
             ask_position: zero,
-            ask_commitment_key: zero,
+            ask_trader_addr: zero,
             ask_order_size: zero,
             match_price: zero,
             match_size: zero,
@@ -166,7 +166,10 @@ impl AuctionExternalInputs {
                 bid_side: Fr::from(m.bid.side as u64),
                 bid_balance: m.bid.balance_scalar()?,
                 bid_position: m.bid.position_scalar()?,
-                bid_commitment_key: m.bid.commitment_key_scalar(),
+                bid_trader_addr: m
+                    .bid
+                    .trader_addr_scalar()
+                    .map_err(|e| ZkError::Witness(format!("bid trader_addr: {e}")))?,
                 bid_order_size: m.bid.order_size_scalar()?,
                 ask_trader,
                 ask_salt,
@@ -174,7 +177,10 @@ impl AuctionExternalInputs {
                 ask_side: Fr::from(m.ask.side as u64),
                 ask_balance: m.ask.balance_scalar()?,
                 ask_position: m.ask.position_scalar()?,
-                ask_commitment_key: m.ask.commitment_key_scalar(),
+                ask_trader_addr: m
+                    .ask
+                    .trader_addr_scalar()
+                    .map_err(|e| ZkError::Witness(format!("ask trader_addr: {e}")))?,
                 ask_order_size: m.ask.order_size_scalar()?,
                 match_price: decimal_to_scalar(match_prices[i])?,
                 match_size: decimal_to_scalar(match_sizes[i])?,
@@ -217,7 +223,7 @@ pub struct CircuitMatchVar {
     pub bid_side: FpVar<Fr>,
     pub bid_balance: FpVar<Fr>,
     pub bid_position: FpVar<Fr>,
-    pub bid_commitment_key: FpVar<Fr>,
+    pub bid_trader_addr: FpVar<Fr>,
     pub bid_order_size: FpVar<Fr>,
 
     pub ask_trader: FpVar<Fr>,
@@ -226,7 +232,7 @@ pub struct CircuitMatchVar {
     pub ask_side: FpVar<Fr>,
     pub ask_balance: FpVar<Fr>,
     pub ask_position: FpVar<Fr>,
-    pub ask_commitment_key: FpVar<Fr>,
+    pub ask_trader_addr: FpVar<Fr>,
     pub ask_order_size: FpVar<Fr>,
 
     pub match_price: FpVar<Fr>,
@@ -269,11 +275,7 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
                 bid_side: FpVar::new_variable(cs.clone(), || Ok(cm.bid_side), mode)?,
                 bid_balance: FpVar::new_variable(cs.clone(), || Ok(cm.bid_balance), mode)?,
                 bid_position: FpVar::new_variable(cs.clone(), || Ok(cm.bid_position), mode)?,
-                bid_commitment_key: FpVar::new_variable(
-                    cs.clone(),
-                    || Ok(cm.bid_commitment_key),
-                    mode,
-                )?,
+                bid_trader_addr: FpVar::new_variable(cs.clone(), || Ok(cm.bid_trader_addr), mode)?,
                 bid_order_size: FpVar::new_variable(cs.clone(), || Ok(cm.bid_order_size), mode)?,
                 ask_trader: FpVar::new_variable(cs.clone(), || Ok(cm.ask_trader), mode)?,
                 ask_salt: FpVar::new_variable(cs.clone(), || Ok(cm.ask_salt), mode)?,
@@ -281,11 +283,7 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
                 ask_side: FpVar::new_variable(cs.clone(), || Ok(cm.ask_side), mode)?,
                 ask_balance: FpVar::new_variable(cs.clone(), || Ok(cm.ask_balance), mode)?,
                 ask_position: FpVar::new_variable(cs.clone(), || Ok(cm.ask_position), mode)?,
-                ask_commitment_key: FpVar::new_variable(
-                    cs.clone(),
-                    || Ok(cm.ask_commitment_key),
-                    mode,
-                )?,
+                ask_trader_addr: FpVar::new_variable(cs.clone(), || Ok(cm.ask_trader_addr), mode)?,
                 ask_order_size: FpVar::new_variable(cs.clone(), || Ok(cm.ask_order_size), mode)?,
                 match_price: FpVar::new_variable(cs.clone(), || Ok(cm.match_price), mode)?,
                 match_size: FpVar::new_variable(cs.clone(), || Ok(cm.match_size), mode)?,
@@ -381,7 +379,7 @@ impl FCircuit<Fr> for AuctionStepCircuit {
                 bid_side,
                 bid_balance,
                 bid_position,
-                bid_ck,
+                bid_addr,
                 bid_order_size,
                 ask_trader,
                 ask_salt,
@@ -389,7 +387,7 @@ impl FCircuit<Fr> for AuctionStepCircuit {
                 ask_side,
                 ask_balance,
                 ask_position,
-                ask_ck,
+                ask_addr,
                 ask_order_size,
                 m_price,
                 m_size,
@@ -403,7 +401,7 @@ impl FCircuit<Fr> for AuctionStepCircuit {
                     cm.bid_side.clone(),
                     cm.bid_balance.clone(),
                     cm.bid_position.clone(),
-                    cm.bid_commitment_key.clone(),
+                    cm.bid_trader_addr.clone(),
                     cm.bid_order_size.clone(),
                     cm.ask_trader.clone(),
                     cm.ask_salt.clone(),
@@ -411,7 +409,7 @@ impl FCircuit<Fr> for AuctionStepCircuit {
                     cm.ask_side.clone(),
                     cm.ask_balance.clone(),
                     cm.ask_position.clone(),
-                    cm.ask_commitment_key.clone(),
+                    cm.ask_trader_addr.clone(),
                     cm.ask_order_size.clone(),
                     cm.match_price.clone(),
                     cm.match_size.clone(),
@@ -534,14 +532,19 @@ impl FCircuit<Fr> for AuctionStepCircuit {
             enforce_range_60(&ask_pos_lo)?;
             enforce_range_60(&ask_pos_hi)?;
 
-            // ── Family 9: trader_id == poseidon(commitment_key) on active rows
+            // ── Family 9: trader_id == poseidon(trader_addr) on active rows ──
+            // Binds the in-circuit identity to the trader's on-chain settlement
+            // address, so a proven match maps to the exact account the contract
+            // debits/credits (#153). `trader_addr` is the address bytes as a
+            // field element; the engine derives `trader_id` the same way from
+            // the *verified* caller address, so a lying client cannot rebind.
             let mut bid_id_sponge = PoseidonSpongeVar::<Fr>::new(cs.clone(), &cfg);
-            bid_id_sponge.absorb(&[bid_ck.clone()].as_ref())?;
+            bid_id_sponge.absorb(&[bid_addr.clone()].as_ref())?;
             let bid_derived = bid_id_sponge.squeeze_field_elements(1)?[0].clone();
             ((&bid_derived - &bid_trader) * &is_active).enforce_equal(&zero)?;
 
             let mut ask_id_sponge = PoseidonSpongeVar::<Fr>::new(cs.clone(), &cfg);
-            ask_id_sponge.absorb(&[ask_ck.clone()].as_ref())?;
+            ask_id_sponge.absorb(&[ask_addr.clone()].as_ref())?;
             let ask_derived = ask_id_sponge.squeeze_field_elements(1)?[0].clone();
             ((&ask_derived - &ask_trader) * &is_active).enforce_equal(&zero)?;
 
@@ -610,8 +613,11 @@ mod tests {
     use rust_decimal::Decimal;
     use uuid::Uuid;
 
-    fn trader_id_hex(commitment_key: &str) -> String {
-        let f = derive_trader_id(commitment_key.as_bytes()).unwrap();
+    /// Trader id for a hex-encoded address, matching `trader_addr_scalar`'s
+    /// projection: `poseidon(from_be_bytes_mod_order(addr_bytes))`.
+    fn trader_id_hex(addr_hex: &str) -> String {
+        let addr = hex::decode(addr_hex.trim_start_matches("0x")).unwrap();
+        let f = derive_trader_id(&addr).unwrap();
         let mut bytes = f.into_bigint().to_bytes_be();
         while bytes.len() < 32 {
             bytes.insert(0, 0);
@@ -620,28 +626,28 @@ mod tests {
     }
 
     fn sample_witness() -> (BatchWitness, Vec<Decimal>, Vec<Decimal>) {
-        let bid_key = "bid_key".to_string();
-        let ask_key = "ask_key".to_string();
+        let bid_addr = "aa".repeat(20);
+        let ask_addr = "bb".repeat(20);
         let m = MatchWitness {
             bid: OrderLegWitness {
-                trader_id: trader_id_hex(&bid_key),
+                trader_id: trader_id_hex(&bid_addr),
                 salt: "22".repeat(32),
                 balance: Decimal::from(1_000_000),
                 position: "0".into(),
                 limit_price: Decimal::from(105),
                 order_size: Decimal::from(10),
                 side: 0,
-                commitment_key: bid_key,
+                trader_addr: bid_addr,
             },
             ask: OrderLegWitness {
-                trader_id: trader_id_hex(&ask_key),
+                trader_id: trader_id_hex(&ask_addr),
                 salt: "44".repeat(32),
                 balance: Decimal::from(1_000_000),
                 position: "0".into(),
                 limit_price: Decimal::from(95),
                 order_size: Decimal::from(10),
                 side: 1,
-                commitment_key: ask_key,
+                trader_addr: ask_addr,
             },
         };
         let w = BatchWitness {
@@ -787,32 +793,35 @@ mod tests {
         price0: Decimal,
         price1: Decimal,
     ) -> (BatchWitness, Vec<Decimal>, Vec<Decimal>) {
-        let mk = |bid_key: &str, ask_key: &str| MatchWitness {
+        let mk = |bid_addr: &str, ask_addr: &str| MatchWitness {
             bid: OrderLegWitness {
-                trader_id: trader_id_hex(bid_key),
+                trader_id: trader_id_hex(bid_addr),
                 salt: "22".repeat(32),
                 balance: Decimal::from(1_000_000),
                 position: "0".into(),
                 limit_price: Decimal::from(105),
                 order_size: Decimal::from(10),
                 side: 0,
-                commitment_key: bid_key.to_string(),
+                trader_addr: bid_addr.to_string(),
             },
             ask: OrderLegWitness {
-                trader_id: trader_id_hex(ask_key),
+                trader_id: trader_id_hex(ask_addr),
                 salt: "44".repeat(32),
                 balance: Decimal::from(1_000_000),
                 position: "0".into(),
                 limit_price: Decimal::from(95),
                 order_size: Decimal::from(10),
                 side: 1,
-                commitment_key: ask_key.to_string(),
+                trader_addr: ask_addr.to_string(),
             },
         };
         let w = BatchWitness {
             batch_id: Uuid::nil(),
             auction_id: Uuid::nil(),
-            matches: vec![mk("bid0", "ask0"), mk("bid1", "ask1")],
+            matches: vec![
+                mk(&"a1".repeat(20), &"a2".repeat(20)),
+                mk(&"b1".repeat(20), &"b2".repeat(20)),
+            ],
             policy: DEFAULT_POLICY.into_policy(),
         };
         (

--- a/crates/dp-zk/src/step_circuit.rs
+++ b/crates/dp-zk/src/step_circuit.rs
@@ -82,6 +82,11 @@ pub struct AuctionExternalInputs {
     pub min_size: Fr,
     pub min_price: Fr,
     pub position_limit: Fr,
+    /// The single uniform clearing price for this auction round. Every active
+    /// match row must settle at this price (#163). Derived from the first
+    /// match in [`from_witness`]; the honest engine applies one volume-
+    /// maximizing price to every match, so all rows already equal it.
+    pub clearing_price: Fr,
     pub matches: Vec<CircuitMatchNative>,
 }
 
@@ -91,6 +96,7 @@ impl Default for AuctionExternalInputs {
             min_size: Fr::zero(),
             min_price: Fr::zero(),
             position_limit: Fr::zero(),
+            clearing_price: Fr::zero(),
             matches: Vec::new(),
         }
     }
@@ -181,10 +187,20 @@ impl AuctionExternalInputs {
             matches.push(CircuitMatchNative::default());
         }
 
+        // The clearing price is the single price every match settles at. The
+        // engine applies one clearing price to all matches, so the first
+        // match's price is that value; the circuit then enforces every active
+        // row equals it.
+        let clearing_price = match match_prices.first() {
+            Some(p) => decimal_to_scalar(*p)?,
+            None => Fr::zero(),
+        };
+
         Ok(Self {
             min_size,
             min_price,
             position_limit,
+            clearing_price,
             matches,
         })
     }
@@ -224,6 +240,7 @@ pub struct AuctionExternalInputsVar {
     pub min_size: FpVar<Fr>,
     pub min_price: FpVar<Fr>,
     pub position_limit: FpVar<Fr>,
+    pub clearing_price: FpVar<Fr>,
     pub matches: Vec<CircuitMatchVar>,
 }
 
@@ -241,6 +258,7 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
         let min_size = FpVar::new_variable(cs.clone(), || Ok(native.min_size), mode)?;
         let min_price = FpVar::new_variable(cs.clone(), || Ok(native.min_price), mode)?;
         let position_limit = FpVar::new_variable(cs.clone(), || Ok(native.position_limit), mode)?;
+        let clearing_price = FpVar::new_variable(cs.clone(), || Ok(native.clearing_price), mode)?;
 
         let mut matches = Vec::with_capacity(native.matches.len());
         for cm in &native.matches {
@@ -279,6 +297,7 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
             min_size,
             min_price,
             position_limit,
+            clearing_price,
             matches,
         })
     }
@@ -451,6 +470,12 @@ impl FCircuit<Fr> for AuctionStepCircuit {
             enforce_range_60(&bid_cross)?;
             let ask_cross = (&m_price - &ask_lp) * &is_active;
             enforce_range_60(&ask_cross)?;
+
+            // ── Family 3b: uniform clearing price ───────────────────────────
+            // Every active row must settle at the single auction clearing
+            // price. Without this the proof accepts a batch where the operator
+            // gives different prices to different traders (#163).
+            ((&m_price - &external_inputs.clearing_price) * &is_active).enforce_equal(&zero)?;
 
             // ── Family 5: commitment binding ─────────────────────────────────
             enforce_range_60(&bid_order_size)?;
@@ -752,6 +777,74 @@ mod tests {
         assert_ne!(
             z_next[0], z_0[0],
             "state_hash must change after a non-trivial step"
+        );
+    }
+
+    /// Two crossing matches at two different prices. Each crosses
+    /// individually, so without the uniform-price constraint the batch is
+    /// accepted — exactly the per-match price-discrimination gap (#163).
+    fn two_match_witness(
+        price0: Decimal,
+        price1: Decimal,
+    ) -> (BatchWitness, Vec<Decimal>, Vec<Decimal>) {
+        let mk = |bid_key: &str, ask_key: &str| MatchWitness {
+            bid: OrderLegWitness {
+                trader_id: trader_id_hex(bid_key),
+                salt: "22".repeat(32),
+                balance: Decimal::from(1_000_000),
+                position: "0".into(),
+                limit_price: Decimal::from(105),
+                order_size: Decimal::from(10),
+                side: 0,
+                commitment_key: bid_key.to_string(),
+            },
+            ask: OrderLegWitness {
+                trader_id: trader_id_hex(ask_key),
+                salt: "44".repeat(32),
+                balance: Decimal::from(1_000_000),
+                position: "0".into(),
+                limit_price: Decimal::from(95),
+                order_size: Decimal::from(10),
+                side: 1,
+                commitment_key: ask_key.to_string(),
+            },
+        };
+        let w = BatchWitness {
+            batch_id: Uuid::nil(),
+            auction_id: Uuid::nil(),
+            matches: vec![mk("bid0", "ask0"), mk("bid1", "ask1")],
+            policy: DEFAULT_POLICY.into_policy(),
+        };
+        (
+            w,
+            vec![price0, price1],
+            vec![Decimal::from(10), Decimal::from(10)],
+        )
+    }
+
+    #[test]
+    fn step_rejects_non_uniform_clearing_price() {
+        let (w, prices, sizes) = two_match_witness(Decimal::from(100), Decimal::from(101));
+        let ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 2).unwrap();
+        let z_0 = initial_z(&ext);
+        let circuit = AuctionStepCircuit::new(2).unwrap();
+        let (satisfied, _) = run_step(&circuit, z_0, ext);
+        assert!(
+            !satisfied,
+            "expected unsatisfied: matches at different prices must be rejected"
+        );
+    }
+
+    #[test]
+    fn step_accepts_uniform_clearing_price() {
+        let (w, prices, sizes) = two_match_witness(Decimal::from(100), Decimal::from(100));
+        let ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 2).unwrap();
+        let z_0 = initial_z(&ext);
+        let circuit = AuctionStepCircuit::new(2).unwrap();
+        let (satisfied, _) = run_step(&circuit, z_0, ext);
+        assert!(
+            satisfied,
+            "expected satisfied: two active matches at the same price"
         );
     }
 }

--- a/crates/dp-zk/src/step_circuit.rs
+++ b/crates/dp-zk/src/step_circuit.rs
@@ -20,6 +20,17 @@ use crate::ZkError;
 const SIZE_BITS: usize = 60;
 const SOLVENCY_DIFF_BITS: usize = 120;
 
+/// Fixed number of match rows the IVC step circuit processes every round.
+///
+/// HyperNova derives the constraint system once, during preprocessing, by
+/// running the step circuit on [`AuctionExternalInputs::default`]. That CCS
+/// must be byte-for-byte the same shape as the one used while proving, so the
+/// circuit width cannot depend on how many real matches a given round carries.
+/// Every round is therefore padded to exactly `IVC_BATCH_SIZE` rows (inactive
+/// rows pass all constraints and contribute nothing to the state). A round's
+/// `batch_size` is a per-round capacity hint and must not exceed this width.
+pub const IVC_BATCH_SIZE: usize = 8;
+
 // ─── Native data types ───────────────────────────────────────────────────────
 
 /// Per-match native witness: 19 Fr fields.
@@ -266,8 +277,13 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
         let position_limit = FpVar::new_variable(cs.clone(), || Ok(native.position_limit), mode)?;
         let clearing_price = FpVar::new_variable(cs.clone(), || Ok(native.clearing_price), mode)?;
 
-        let mut matches = Vec::with_capacity(native.matches.len());
-        for cm in &native.matches {
+        // Always allocate a fixed `IVC_BATCH_SIZE` rows so the constraint system
+        // is identical whether `native` is the empty `default()` (used by
+        // HyperNova preprocessing to derive the CCS) or a real, padded witness.
+        // Short inputs are backfilled with inactive rows.
+        let mut matches = Vec::with_capacity(IVC_BATCH_SIZE);
+        for i in 0..IVC_BATCH_SIZE {
+            let cm = native.matches.get(i).cloned().unwrap_or_default();
             matches.push(CircuitMatchVar {
                 bid_trader: FpVar::new_variable(cs.clone(), || Ok(cm.bid_trader), mode)?,
                 bid_salt: FpVar::new_variable(cs.clone(), || Ok(cm.bid_salt), mode)?,
@@ -375,84 +391,42 @@ impl FCircuit<Fr> for AuctionStepCircuit {
             computed_policy_hash.enforce_equal(&policy_hash)?;
         }
 
-        let mut all_leaves: Vec<FpVar<Fr>> = Vec::with_capacity(self.batch_size * 2);
-        let mut all_notionals: Vec<FpVar<Fr>> = Vec::with_capacity(self.batch_size);
+        debug_assert!(
+            self.batch_size <= IVC_BATCH_SIZE,
+            "batch_size {} exceeds IVC_BATCH_SIZE {}",
+            self.batch_size,
+            IVC_BATCH_SIZE
+        );
+
+        let mut all_leaves: Vec<FpVar<Fr>> = Vec::with_capacity(IVC_BATCH_SIZE * 2);
+        let mut all_notionals: Vec<FpVar<Fr>> = Vec::with_capacity(IVC_BATCH_SIZE);
         let mut active_count = FpVar::<Fr>::zero();
 
-        for idx in 0..self.batch_size {
-            // Either use a real match row or allocate a zero-filled inactive row
-            // so the constraint count is constant regardless of how many real
-            // matches external_inputs carries.
-            let (
-                bid_trader,
-                bid_salt,
-                bid_lp,
-                bid_side,
-                bid_balance,
-                bid_position,
-                bid_addr,
-                bid_order_size,
-                ask_trader,
-                ask_salt,
-                ask_lp,
-                ask_side,
-                ask_balance,
-                ask_position,
-                ask_addr,
-                ask_order_size,
-                m_price,
-                m_size,
-                is_active,
-            ) = if idx < external_inputs.matches.len() {
-                let cm = &external_inputs.matches[idx];
-                (
-                    cm.bid_trader.clone(),
-                    cm.bid_salt.clone(),
-                    cm.bid_limit_price.clone(),
-                    cm.bid_side.clone(),
-                    cm.bid_balance.clone(),
-                    cm.bid_position.clone(),
-                    cm.bid_trader_addr.clone(),
-                    cm.bid_order_size.clone(),
-                    cm.ask_trader.clone(),
-                    cm.ask_salt.clone(),
-                    cm.ask_limit_price.clone(),
-                    cm.ask_side.clone(),
-                    cm.ask_balance.clone(),
-                    cm.ask_position.clone(),
-                    cm.ask_trader_addr.clone(),
-                    cm.ask_order_size.clone(),
-                    cm.match_price.clone(),
-                    cm.match_size.clone(),
-                    cm.is_active.clone(),
-                )
-            } else {
-                // Pad with an inactive row (ask_side=1 so Family 2 is satisfied
-                // when is_active=0, which it is).
-                let z = || Ok(Fr::zero());
-                let o = || Ok(Fr::one());
-                (
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), o)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                    FpVar::new_witness(cs.clone(), z)?,
-                )
-            };
+        // `external_inputs.matches` always holds exactly `IVC_BATCH_SIZE` rows
+        // (allocated by `AuctionExternalInputsVar`), so every row is a real
+        // variable. Inactive padding rows carry `is_active = 0` and satisfy each
+        // gated constraint trivially.
+        for idx in 0..IVC_BATCH_SIZE {
+            let cm = &external_inputs.matches[idx];
+            let bid_trader = cm.bid_trader.clone();
+            let bid_salt = cm.bid_salt.clone();
+            let bid_lp = cm.bid_limit_price.clone();
+            let bid_side = cm.bid_side.clone();
+            let bid_balance = cm.bid_balance.clone();
+            let bid_position = cm.bid_position.clone();
+            let bid_addr = cm.bid_trader_addr.clone();
+            let bid_order_size = cm.bid_order_size.clone();
+            let ask_trader = cm.ask_trader.clone();
+            let ask_salt = cm.ask_salt.clone();
+            let ask_lp = cm.ask_limit_price.clone();
+            let ask_side = cm.ask_side.clone();
+            let ask_balance = cm.ask_balance.clone();
+            let ask_position = cm.ask_position.clone();
+            let ask_addr = cm.ask_trader_addr.clone();
+            let ask_order_size = cm.ask_order_size.clone();
+            let m_price = cm.match_price.clone();
+            let m_size = cm.match_size.clone();
+            let is_active = cm.is_active.clone();
 
             // ── Family 1: side bits ∈ {0,1}, is_active ∈ {0,1} ────────────
             (&bid_side * (&one - &bid_side)).enforce_equal(&zero)?;

--- a/crates/dp-zk/src/step_circuit.rs
+++ b/crates/dp-zk/src/step_circuit.rs
@@ -124,6 +124,11 @@ impl AuctionExternalInputs {
     ) -> Result<Self, ZkError> {
         use crate::encoding::{decimal_to_scalar, signed_to_scalar};
 
+        if batch_size > IVC_BATCH_SIZE {
+            return Err(ZkError::Witness(format!(
+                "batch_size {batch_size} exceeds circuit width IVC_BATCH_SIZE {IVC_BATCH_SIZE}"
+            )));
+        }
         if witness.matches.len() > batch_size {
             return Err(ZkError::Witness(format!(
                 "{} matches > circuit batch_size {}",
@@ -280,7 +285,15 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
         // Always allocate a fixed `IVC_BATCH_SIZE` rows so the constraint system
         // is identical whether `native` is the empty `default()` (used by
         // HyperNova preprocessing to derive the CCS) or a real, padded witness.
-        // Short inputs are backfilled with inactive rows.
+        // Short inputs are backfilled with inactive rows; over-long inputs would
+        // be silently truncated by the loop below, so reject them outright — a
+        // dropped match would settle on-chain without ever being proven.
+        assert!(
+            native.matches.len() <= IVC_BATCH_SIZE,
+            "AuctionExternalInputs carries {} matches, exceeds circuit width IVC_BATCH_SIZE {}",
+            native.matches.len(),
+            IVC_BATCH_SIZE
+        );
         let mut matches = Vec::with_capacity(IVC_BATCH_SIZE);
         for i in 0..IVC_BATCH_SIZE {
             let cm = native.matches.get(i).cloned().unwrap_or_default();
@@ -391,7 +404,7 @@ impl FCircuit<Fr> for AuctionStepCircuit {
             computed_policy_hash.enforce_equal(&policy_hash)?;
         }
 
-        debug_assert!(
+        assert!(
             self.batch_size <= IVC_BATCH_SIZE,
             "batch_size {} exceeds IVC_BATCH_SIZE {}",
             self.batch_size,

--- a/crates/dp-zk/src/step_circuit.rs
+++ b/crates/dp-zk/src/step_circuit.rs
@@ -771,6 +771,50 @@ mod tests {
         );
     }
 
+    /// The #153 binding property: if the operator settles a DIFFERENT set of
+    /// matches than the one proved, the chain the contract recomputes over
+    /// `matches[]` no longer equals the proof's `z_n[3]`, so settlement is
+    /// rejected. We model the contract's recompute with `settlement_chain`
+    /// over operator-supplied (tampered) tuples and assert it diverges from the
+    /// proved value.
+    #[test]
+    fn settlement_chain_detects_match_substitution() {
+        // Honest batch → the value bound into z_n[3] by the proof.
+        let (w, prices, sizes) = two_match_witness(Decimal::from(100), Decimal::from(100));
+        let ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 3).unwrap();
+        let z_0 = initial_z(&ext);
+        let circuit = AuctionStepCircuit::new(3).unwrap();
+        let (ok, z_next) = run_step(&circuit, z_0.clone(), ext);
+        assert!(ok);
+        let bound = z_next[3];
+
+        // Operator swaps a settled counterparty to a colluding address.
+        let (mut w_addr, p_a, s_a) = two_match_witness(Decimal::from(100), Decimal::from(100));
+        w_addr.matches[0].ask.trader_addr = "cc".repeat(20);
+        let ext_addr = AuctionExternalInputs::from_witness(&w_addr, &p_a, &s_a, 3).unwrap();
+        assert_ne!(
+            settlement_chain(&ext_addr, z_0[3]),
+            bound,
+            "substituting a settled address must break the bound chain"
+        );
+
+        // Operator settles at a different price than was proved.
+        let (w_px, p_x, s_x) = two_match_witness(Decimal::from(100), Decimal::from(100));
+        let ext_px = AuctionExternalInputs::from_witness(
+            &w_px,
+            &[Decimal::from(100), Decimal::from(99)],
+            &s_x,
+            3,
+        )
+        .unwrap();
+        let _ = p_x;
+        assert_ne!(
+            settlement_chain(&ext_px, z_0[3]),
+            bound,
+            "substituting a settled price must break the bound chain"
+        );
+    }
+
     #[test]
     fn step_satisfied_with_valid_witness() {
         let (w, prices, sizes) = sample_witness();

--- a/crates/dp-zk/src/witness.rs
+++ b/crates/dp-zk/src/witness.rs
@@ -12,7 +12,9 @@ use ark_bn254::Fr;
 /// One leg (bid or ask) of a matched pair.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct OrderLegWitness {
-    /// Hex-encoded 32-byte trader id (BE bytes of `poseidon(commitment_key_scalar)`).
+    /// Hex-encoded 32-byte trader id (BE bytes of `poseidon(trader_addr_scalar)`).
+    /// The identity is the trader's on-chain settlement address, so a proven
+    /// match binds to the exact account the contract debits/credits (#153).
     pub trader_id: String,
     /// Hex-encoded 32-byte commitment salt.
     pub salt: String,
@@ -28,10 +30,14 @@ pub struct OrderLegWitness {
     pub order_size: Decimal,
     /// 0 = bid (buy), 1 = ask (sell).
     pub side: u8,
-    /// Trader's commitment-key string. Bound into the circuit so the
-    /// prover proves `trader_id == poseidon(commitment_key_scalar)`.
+    /// Hex-encoded trader settlement address (the 20-byte on-chain address).
+    /// Bound into the circuit so the prover proves
+    /// `trader_id == poseidon(trader_addr_scalar)` — this is what ties the
+    /// proof to the address the contract settles. The per-order blinding key
+    /// lives on `Order.commitment_key` and only feeds the salt; it is not the
+    /// identity.
     #[serde(default)]
-    pub commitment_key: String,
+    pub trader_addr: String,
 }
 
 /// One matched pair.
@@ -119,10 +125,14 @@ impl OrderLegWitness {
             .map_err(|_| EncodingError::Overflow(Decimal::ZERO))?;
         signed_to_scalar(p)
     }
-    /// Map the commitment-key string to an Fr via `from_be_bytes_mod_order`.
-    /// Mirrors `pedersen::derive_trader_id`'s input projection.
-    pub fn commitment_key_scalar(&self) -> Fr {
-        crate::pedersen::bytes_to_scalar(self.commitment_key.as_bytes())
+    pub fn trader_addr_bytes(&self) -> Result<Vec<u8>, hex::FromHexError> {
+        hex::decode(self.trader_addr.trim_start_matches("0x"))
+    }
+    /// Map the trader's address bytes to an Fr via `from_be_bytes_mod_order`.
+    /// Mirrors `pedersen::derive_trader_id`'s input projection, so the circuit
+    /// derives the same `trader_id` the engine commits to.
+    pub fn trader_addr_scalar(&self) -> Result<Fr, hex::FromHexError> {
+        Ok(crate::pedersen::bytes_to_scalar(&self.trader_addr_bytes()?))
     }
 }
 
@@ -144,7 +154,7 @@ mod tests {
                     limit_price: Decimal::from(100),
                     order_size: Decimal::from(10),
                     side: 0,
-                    commitment_key: "bid_key".into(),
+                    trader_addr: "11".repeat(20),
                 },
                 ask: OrderLegWitness {
                     trader_id: "22".repeat(32),
@@ -154,7 +164,7 @@ mod tests {
                     limit_price: Decimal::from(99),
                     order_size: Decimal::from(10),
                     side: 1,
-                    commitment_key: "ask_key".into(),
+                    trader_addr: "22".repeat(20),
                 },
             }],
             policy: DEFAULT_POLICY.into_policy(),

--- a/crates/dp-zk/tests/ivc.rs
+++ b/crates/dp-zk/tests/ivc.rs
@@ -84,14 +84,15 @@ fn sample_ext(batch_size: usize) -> AuctionExternalInputs {
         .expect("sample_ext: from_witness")
 }
 
-/// Compute `z_0 = [0, 0, policy_hash]` where
-/// `policy_hash = poseidon(min_size, min_price, position_limit)`.
-fn z_0_for(ext: &AuctionExternalInputs) -> [Fr; 3] {
+/// Compute `z_0 = [0, 0, policy_hash, 0]` where
+/// `policy_hash = poseidon(min_size, min_price, position_limit)` and the
+/// trailing slot is the empty settlement hash-chain accumulator.
+fn z_0_for(ext: &AuctionExternalInputs) -> [Fr; 4] {
     let cfg = poseidon_config();
     let mut s = PoseidonSponge::<Fr>::new(&cfg);
     s.absorb(&vec![ext.min_size, ext.min_price, ext.position_limit]);
     let policy_hash = s.squeeze_field_elements::<Fr>(1)[0];
-    [Fr::zero(), Fr::zero(), policy_hash]
+    [Fr::zero(), Fr::zero(), policy_hash, Fr::zero()]
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/dp-zk/tests/ivc.rs
+++ b/crates/dp-zk/tests/ivc.rs
@@ -33,9 +33,10 @@ fn make_rng() -> ark_std::rand::rngs::StdRng {
     ark_std::rand::rngs::StdRng::seed_from_u64(42)
 }
 
-fn trader_id_hex(commitment_key: &str) -> String {
+fn trader_id_hex(addr_hex: &str) -> String {
     use ark_ff::{BigInteger, PrimeField};
-    let f = derive_trader_id(commitment_key.as_bytes()).unwrap();
+    let addr = hex::decode(addr_hex.trim_start_matches("0x")).unwrap();
+    let f = derive_trader_id(&addr).unwrap();
     let mut bytes = f.into_bigint().to_bytes_be();
     while bytes.len() < 32 {
         bytes.insert(0, 0);
@@ -44,28 +45,28 @@ fn trader_id_hex(commitment_key: &str) -> String {
 }
 
 fn sample_witness() -> (BatchWitness, Vec<Decimal>, Vec<Decimal>) {
-    let bid_key = "bid_key".to_string();
-    let ask_key = "ask_key".to_string();
+    let bid_addr = "aa".repeat(20);
+    let ask_addr = "bb".repeat(20);
     let m = MatchWitness {
         bid: OrderLegWitness {
-            trader_id: trader_id_hex(&bid_key),
+            trader_id: trader_id_hex(&bid_addr),
             salt: "22".repeat(32),
             balance: Decimal::from(1_000_000),
             position: "0".into(),
             limit_price: Decimal::from(105),
             order_size: Decimal::from(10),
             side: 0,
-            commitment_key: bid_key,
+            trader_addr: bid_addr,
         },
         ask: OrderLegWitness {
-            trader_id: trader_id_hex(&ask_key),
+            trader_id: trader_id_hex(&ask_addr),
             salt: "44".repeat(32),
             balance: Decimal::from(1_000_000),
             position: "0".into(),
             limit_price: Decimal::from(95),
             order_size: Decimal::from(10),
             side: 1,
-            commitment_key: ask_key,
+            trader_addr: ask_addr,
         },
     };
     let w = BatchWitness {

--- a/crates/dp-zk/tests/ivc.rs
+++ b/crates/dp-zk/tests/ivc.rs
@@ -142,6 +142,13 @@ fn fold_single_step_verifies() {
     );
     // policy_hash must be invariant
     assert_eq!(proof.z_n[2], z_0[2], "policy_hash must remain invariant");
+    // settlement_acc must survive the end-to-end fold/finalize path: folding
+    // one active match advances the hash-chain off its zero seed.
+    assert_ne!(
+        proof.z_n[3],
+        Fr::zero(),
+        "settlement_acc must change after folding an active match"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Closes #163
Refs #153, #157

The matching proof is supposed to pin the operator to honest execution. A couple of things undercut that today: the settled `matches[]` never gets tied back to the proof, and the circuit's idea of a trader's identity has no link to the address the contract actually pays. Nothing holds a batch to one clearing price either. This sorts out the price and gets the other two most of the way there from the circuit side.

`clearing_price` is now a single input every active row has to equal, so one batch can't quietly settle different prices to different traders (#163).

Identity used to come from a client-picked `commitment_key` with no relation to the on-chain address `_settleMatch` credits and debits. It's now `poseidon(address)`, built in the engine from `decrypted.trader`, which already gets checked against the caller, so a client can't claim someone else's account. `commitment_key` stays on only as salt blinding. That's also what #168 wants, so self-trade prevention can key on the real address.

For #153, `z_n` gains a fourth element that chains a Poseidon hash over each active match's settlement tuple (`bid_addr`, `ask_addr`, `match_price`, `match_size`) across the session. Once the contract recomputes that chain over the submitted matches and checks it against `z_n[3]`, the operator can't settle a set other than the one proved. It's a running chain rather than a sponge over padded rows, so the contract only folds the real matches. A test swaps a settled address and then a price and confirms the bound value moves.

Still open, so this shouldn't close #153 or #157 on merge. The `settleSession` half of the check isn't written yet: it needs a Solidity Poseidon matching arkworks' constants and sponge, not circomlib's, generated from the exported `ark`/`mds` and cross-checked against Rust vectors. The Decider verifier is also still a stub until the trusted setup runs, so the public outputs aren't verified on-chain and the binding won't bite until that lands. #157's input-set root and membership aren't here at all.

Bumping `state_len` from 3 to 4 touches the folding API, the engine's proof payload, and the aggregator. End-to-end IVC proving still passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced uniform clearing price so all matches in a batch settle at a single price.

* **Refactor**
  * Trader identity now binds to verified on‑chain settlement addresses instead of client-provided keys.
  * ZK proof state widened to include an additional settlement accumulator element; witnesses now carry trader addresses.

* **Documentation**
  * Circuit docs updated to describe the new clearing-price constraint and identity binding.

* **Tests**
  * Tests and fixtures adjusted to use trader addresses and verify settlement-accumulator behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->