### PR TITLE
auth: Compare API keys in constant time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2341,6 +2341,7 @@ dependencies = [
  "sha2",
  "sha3",
  "siwe",
+ "subtle",
  "tempfile",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["full"] }
 parking_lot = "0.12"
 sha2 = "0.10"
+subtle = "2"
 hex = "0.4"
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
 bincode = "1"

--- a/crates/dp-api/Cargo.toml
+++ b/crates/dp-api/Cargo.toml
@@ -54,6 +54,7 @@ http-body.workspace = true
 humantime.workspace = true
 futures-util.workspace = true
 sha2 = { workspace = true }
+subtle = { workspace = true }
 ulid = { workspace = true }
 percent-encoding = "2"
 siwe = "0.6"

--- a/crates/dp-api/src/auth.rs
+++ b/crates/dp-api/src/auth.rs
@@ -1,4 +1,3 @@
-use std::collections::HashSet;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -9,6 +8,8 @@ use axum::extract::{Request as AxumRequest, State as AxumState};
 use axum::middleware::Next;
 use axum::response::Response as AxumResponse;
 use http::{HeaderMap, Request, Response};
+use sha2::{Digest, Sha256};
+use subtle::{Choice, ConstantTimeEq};
 use tonic::body::BoxBody;
 use tonic::Status;
 use tower::{Layer, Service};
@@ -25,21 +26,25 @@ pub enum AuthenticatedIdentity {
 
 #[derive(Clone, Debug)]
 pub struct AuthCore {
-    keys: Arc<HashSet<String>>,
+    /// SHA-256 digests of the configured keys. Storing digests (not the
+    /// plaintext keys) lets us compare in constant time over a fixed 32-byte
+    /// width, so neither the matching key nor its length is a timing oracle —
+    /// and the keys never appear in `Debug` output.
+    key_digests: Arc<Vec<[u8; 32]>>,
     jwt: Option<Arc<crate::siwe::JwtManager>>,
 }
 
 impl AuthCore {
     pub fn new(keys: Vec<String>) -> Self {
         Self {
-            keys: Arc::new(keys.into_iter().filter(|k| !k.is_empty()).collect()),
+            key_digests: Arc::new(digest_keys(keys)),
             jwt: None,
         }
     }
 
     pub fn new_with_jwt(keys: Vec<String>, jwt: Arc<crate::siwe::JwtManager>) -> Self {
         Self {
-            keys: Arc::new(keys.into_iter().filter(|k| !k.is_empty()).collect()),
+            key_digests: Arc::new(digest_keys(keys)),
             jwt: Some(jwt),
         }
     }
@@ -63,7 +68,7 @@ impl AuthCore {
             }
         }
 
-        if self.keys.is_empty() {
+        if self.key_digests.is_empty() {
             return Ok(AuthenticatedIdentity::ApiKey);
         }
         let key = match headers.get(AUTH_HEADER) {
@@ -76,11 +81,43 @@ impl AuthCore {
         if key.is_empty() {
             return Err(Status::unauthenticated(MSG_MISSING_API_KEY));
         }
-        if !self.keys.contains(key) {
-            return Err(Status::unauthenticated(MSG_INVALID_API_KEY));
+        if self.verify_key(key) {
+            Ok(AuthenticatedIdentity::ApiKey)
+        } else {
+            Err(Status::unauthenticated(MSG_INVALID_API_KEY))
         }
-        Ok(AuthenticatedIdentity::ApiKey)
     }
+
+    /// Constant-time membership test for a presented API key.
+    ///
+    /// The presented key is hashed, then compared against every configured
+    /// digest with a constant-time equality, folding the results without an
+    /// early exit. The running time is therefore independent of which key (if
+    /// any) matched and of how many leading bytes happened to agree, closing
+    /// the timing side-channel that `HashSet::contains` exposes on a secret.
+    /// Hashing to a fixed 32-byte width also removes the key length as a side
+    /// channel.
+    fn verify_key(&self, key: &str) -> bool {
+        let presented = sha256(key.as_bytes());
+        let mut matched = Choice::from(0u8);
+        for digest in self.key_digests.iter() {
+            matched |= presented[..].ct_eq(&digest[..]);
+        }
+        bool::from(matched)
+    }
+}
+
+fn digest_keys(keys: Vec<String>) -> Vec<[u8; 32]> {
+    keys.into_iter()
+        .filter(|k| !k.is_empty())
+        .map(|k| sha256(k.as_bytes()))
+        .collect()
+}
+
+fn sha256(bytes: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hasher.finalize().into()
 }
 
 #[derive(Clone, Debug)]

--- a/crates/dp-api/src/auth.rs
+++ b/crates/dp-api/src/auth.rs
@@ -26,6 +26,12 @@ pub enum AuthenticatedIdentity {
 
 #[derive(Clone, Debug)]
 pub struct AuthCore {
+    /// `true` only when zero keys were configured — the deliberate
+    /// "authentication disabled" mode. Tracked separately from
+    /// `key_digests.is_empty()` so a config that supplies keys but whose
+    /// entries are all empty (e.g. `vec!["".into()]`) fails closed instead of
+    /// silently degrading to allow-all.
+    auth_disabled: bool,
     /// SHA-256 digests of the configured keys. Storing digests (not the
     /// plaintext keys) lets us compare in constant time over a fixed 32-byte
     /// width, so neither the matching key nor its length is a timing oracle —
@@ -37,6 +43,7 @@ pub struct AuthCore {
 impl AuthCore {
     pub fn new(keys: Vec<String>) -> Self {
         Self {
+            auth_disabled: keys.is_empty(),
             key_digests: Arc::new(digest_keys(keys)),
             jwt: None,
         }
@@ -44,6 +51,7 @@ impl AuthCore {
 
     pub fn new_with_jwt(keys: Vec<String>, jwt: Arc<crate::siwe::JwtManager>) -> Self {
         Self {
+            auth_disabled: keys.is_empty(),
             key_digests: Arc::new(digest_keys(keys)),
             jwt: Some(jwt),
         }
@@ -68,7 +76,7 @@ impl AuthCore {
             }
         }
 
-        if self.key_digests.is_empty() {
+        if self.auth_disabled {
             return Ok(AuthenticatedIdentity::ApiKey);
         }
         let key = match headers.get(AUTH_HEADER) {

--- a/crates/dp-api/tests/auth.rs
+++ b/crates/dp-api/tests/auth.rs
@@ -47,6 +47,38 @@ fn empty_keys_filter() {
     assert_eq!(err.code(), Code::Unauthenticated);
 }
 
+#[test]
+fn any_configured_key_passes() {
+    // Every key in a multi-key set must authenticate, not just the first.
+    let core = AuthCore::new(vec!["k1".into(), "k2".into(), "k3".into()]);
+    for k in ["k1", "k2", "k3"] {
+        let mut h = HeaderMap::new();
+        h.insert("x-api-key", HeaderValue::from_str(k).unwrap());
+        assert!(core.check(&h).is_ok(), "key {k} should authenticate");
+    }
+}
+
+#[test]
+fn prefix_of_valid_key_denied() {
+    // A proper prefix of a real key must be rejected: hashing to a fixed width
+    // means length is never a side channel, and a prefix is a distinct secret.
+    let core = AuthCore::new(vec!["supersecretkey".into()]);
+    let mut h = HeaderMap::new();
+    h.insert("x-api-key", HeaderValue::from_static("supersecret"));
+    let err = core.check(&h).err().unwrap();
+    assert_eq!(err.code(), Code::Unauthenticated);
+}
+
+#[test]
+fn wrong_key_same_length_denied() {
+    // A guess that matches the secret's length but not its bytes is rejected.
+    let core = AuthCore::new(vec!["correct-horse".into()]);
+    let mut h = HeaderMap::new();
+    h.insert("x-api-key", HeaderValue::from_static("wrongo-horsey"));
+    let err = core.check(&h).err().unwrap();
+    assert_eq!(err.code(), Code::Unauthenticated);
+}
+
 fn jwt_manager() -> Arc<JwtManager> {
     Arc::new(JwtManager::new(
         "test-secret-32-bytes-long-xxxxx",

--- a/crates/dp-api/tests/auth.rs
+++ b/crates/dp-api/tests/auth.rs
@@ -79,6 +79,29 @@ fn wrong_key_same_length_denied() {
     assert_eq!(err.code(), Code::Unauthenticated);
 }
 
+#[test]
+fn all_empty_keys_fail_closed() {
+    // Keys were configured but every entry is empty. This is a misconfig, not a
+    // request to disable auth: it must deny all requests, never degrade to
+    // allow-all. Only a genuinely empty key list disables authentication.
+    let core = AuthCore::new(vec!["".into(), "".into()]);
+
+    let no_header = HeaderMap::new();
+    assert_eq!(
+        core.check(&no_header).err().unwrap().code(),
+        Code::Unauthenticated,
+        "no header must be denied, not waved through"
+    );
+
+    let mut with_key = HeaderMap::new();
+    with_key.insert("x-api-key", HeaderValue::from_static("anything"));
+    assert_eq!(
+        core.check(&with_key).err().unwrap().code(),
+        Code::Unauthenticated,
+        "no presented key can match an all-empty config"
+    );
+}
+
 fn jwt_manager() -> Arc<JwtManager> {
     Arc::new(JwtManager::new(
         "test-secret-32-bytes-long-xxxxx",


### PR DESCRIPTION
Closes #155

The API and operator/admin key check went through `HashSet::contains`, which hashes the candidate and then byte-compares it against the stored secret. That comparison isn't constant time, so it's a timing oracle on a secret that gates `RegisterPair`, `SuspendPair`, `DelistPair` and ECIES key rotation. In practice the std HashSet's randomized SipHash blunts the textbook byte-by-byte recovery, since you can't aim for the secret's bucket without the per-process seed, so this sits closer to medium than critical. But comparing a secret in non-constant time is the kind of thing that breaks the moment someone swaps the set for a `Vec` or a different hasher.

`AuthCore` now stores SHA-256 digests of the configured keys instead of the plaintext, and verification folds a constant-time equality over every digest with no early exit. Timing no longer depends on which key matched or how many bytes lined up, the fixed 32-byte width drops key length as a side channel, and Debug output stops carrying the raw keys. Tests cover a prefix of a valid key, a same-length wrong key, and every key in a multi-key set authenticating.

`cargo test -p dp-api` passes (274), clippy clean under `-D warnings`, rustfmt clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API key authentication security with improved validation mechanism.

* **Tests**
  * Expanded authentication test coverage with additional scenarios for multiple keys and invalid key rejection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->