### PR TITLE
api: Remove pre-settlement orderbook; scope order reads to caller

### DIFF
--- a/crates/dp-api/proto/darkpool/v1/darkpool.proto
+++ b/crates/dp-api/proto/darkpool/v1/darkpool.proto
@@ -27,9 +27,15 @@ service DarkPoolService {
     };
   }
 
-  rpc GetOrderBook(GetOrderBookRequest) returns (GetOrderBookResponse) {
+  // Lists the authenticated caller's own resting orders ("my orders").
+  // Scoped to the wallet identity; a trader never sees another trader's
+  // orders. There is deliberately no public pre-settlement order book —
+  // serving live cross-trader depth would defeat the dark pool (an
+  // observer could reconstruct incoming liquidity and cross it in the
+  // same auction round).
+  rpc ListOrders(ListOrdersRequest) returns (ListOrdersResponse) {
     option (google.api.http) = {
-      get: "/v1/orderbook"
+      get: "/v1/orders"
     };
   }
 
@@ -114,22 +120,14 @@ message GetOrderResponse {
   OrderInfo order = 1;
 }
 
-// --- Order Book ---
+// --- List Orders (caller-scoped "my orders") ---
 
-message GetOrderBookRequest {
-  string pair = 1;
+message ListOrdersRequest {
+  string pair = 1;  // optional filter; empty = every pair
 }
 
-message GetOrderBookResponse {
-  string pair = 1;
-  repeated PriceLevel bids = 2;
-  repeated PriceLevel asks = 3;
-}
-
-message PriceLevel {
-  string price = 1;
-  string total_size = 2;
-  int32 order_count = 3;
+message ListOrdersResponse {
+  repeated OrderInfo orders = 1;
 }
 
 // --- Auction History ---

--- a/crates/dp-api/src/conv.rs
+++ b/crates/dp-api/src/conv.rs
@@ -51,32 +51,6 @@ pub fn notification_to_summary(n: &AuctionNotification) -> pb::AuctionSummary {
     notification_proto!(pb::AuctionSummary, n)
 }
 
-pub fn aggregate_levels(orders: Vec<Order>) -> Vec<pb::PriceLevel> {
-    use std::collections::HashMap;
-    let mut agg: HashMap<String, (rust_decimal::Decimal, i32)> = HashMap::new();
-    let mut order_seen: Vec<String> = Vec::new();
-    for o in orders {
-        let key = o.price.to_string();
-        let entry = agg.entry(key.clone()).or_insert_with(|| {
-            order_seen.push(key.clone());
-            (rust_decimal::Decimal::ZERO, 0)
-        });
-        entry.0 += o.remaining_size;
-        entry.1 += 1;
-    }
-    order_seen
-        .into_iter()
-        .map(|k| {
-            let (total, count) = agg.remove(&k).unwrap();
-            pb::PriceLevel {
-                price: k,
-                total_size: total.to_string(),
-                order_count: count,
-            }
-        })
-        .collect()
-}
-
 pub fn parse_uuid(s: &str) -> Result<Uuid, Status> {
     Uuid::parse_str(s).map_err(|e| Status::invalid_argument(format!("invalid order_id: {}", e)))
 }

--- a/crates/dp-api/src/handler.rs
+++ b/crates/dp-api/src/handler.rs
@@ -95,8 +95,27 @@ impl DarkPoolService for ApiHandler {
         &self,
         req: Request<CancelOrderRequest>,
     ) -> Result<Response<CancelOrderResponse>, Status> {
+        let caller = caller_address(&req);
         let req = req.into_inner();
         let id = parse_uuid(&req.order_id)?;
+        // Caller-scoped, mirroring `get_order`: only the order's owner may
+        // cancel it. A missing order and another trader's order are
+        // deliberately indistinguishable (both `not_found`) so a key-holder
+        // cannot use CancelOrder to cancel — or even probe for — orders they
+        // don't own. `o.trader` is immutable once placed, so the gap between
+        // this ownership check and the cancel below can't be raced into an
+        // authz bypass (a concurrent match/cancel just yields `not_found`).
+        if self
+            .engine
+            .get_order(id)
+            .filter(|o| caller == Some(o.trader))
+            .is_none()
+        {
+            return Err(Status::not_found(format!(
+                "order {} not found",
+                req.order_id
+            )));
+        }
         let reason = if req.reason.is_empty() {
             None
         } else {

--- a/crates/dp-api/src/handler.rs
+++ b/crates/dp-api/src/handler.rs
@@ -7,19 +7,33 @@ use tokio_stream::wrappers::BroadcastStream;
 use tokio_stream::StreamExt;
 use tonic::{Request, Response, Status};
 
+use crate::auth::AuthenticatedIdentity;
 use crate::conv::{
-    aggregate_levels, notification_to_event, notification_to_summary, order_to_proto,
-    pair_config_to_proto, parse_uuid,
+    notification_to_event, notification_to_summary, order_to_proto, pair_config_to_proto,
+    parse_uuid,
 };
 use crate::error::engine_error_to_status;
 use crate::pb::dark_pool_service_server::DarkPoolService;
 use crate::pb::{
     AuctionEvent, CancelOrderRequest, CancelOrderResponse, GetAuctionHistoryRequest,
-    GetAuctionHistoryResponse, GetOrderBookRequest, GetOrderBookResponse, GetOrderRequest,
-    GetOrderResponse, ListPairsRequest, ListPairsResponse, PlaceOrderRequest, PlaceOrderResponse,
+    GetAuctionHistoryResponse, GetOrderRequest, GetOrderResponse, ListOrdersRequest,
+    ListOrdersResponse, ListPairsRequest, ListPairsResponse, PlaceOrderRequest, PlaceOrderResponse,
     StreamAuctionsRequest,
 };
 use crate::validation::{validate_pair_for_history, validate_pair_known, validate_place_order};
+
+/// Extract the wallet address of the authenticated caller, if any. A
+/// SIWE-authenticated trader yields `Some(address)`; an operator API-key
+/// caller (or no identity) yields `None`. The per-trader read surfaces
+/// (`GetOrder`, `ListOrders`) treat a `None` caller as owning nothing.
+fn caller_address<T>(req: &Request<T>) -> Option<alloy_primitives::Address> {
+    req.extensions()
+        .get::<AuthenticatedIdentity>()
+        .and_then(|id| match id {
+            AuthenticatedIdentity::Wallet(addr) => Some(*addr),
+            AuthenticatedIdentity::ApiKey => None,
+        })
+}
 
 /// Map one BroadcastStream item to an outgoing auction event:
 /// - Ok matches the pair filter → forward as event.
@@ -64,13 +78,7 @@ impl DarkPoolService for ApiHandler {
         &self,
         req: Request<PlaceOrderRequest>,
     ) -> Result<Response<PlaceOrderResponse>, Status> {
-        let caller = req
-            .extensions()
-            .get::<crate::auth::AuthenticatedIdentity>()
-            .and_then(|id| match id {
-                crate::auth::AuthenticatedIdentity::Wallet(addr) => Some(*addr),
-                crate::auth::AuthenticatedIdentity::ApiKey => None,
-            });
+        let caller = caller_address(&req);
         let req = req.into_inner();
         validate_place_order(&req)?;
         let order = self
@@ -104,9 +112,18 @@ impl DarkPoolService for ApiHandler {
         &self,
         req: Request<GetOrderRequest>,
     ) -> Result<Response<GetOrderResponse>, Status> {
+        let caller = caller_address(&req);
         let req = req.into_inner();
         let id = parse_uuid(&req.order_id)?;
-        match self.engine.get_order(id) {
+        // Caller-scoped: an order is visible only to its owner. A missing
+        // order and an order owned by someone else are deliberately
+        // indistinguishable (both `not_found`) so a key-holder cannot probe
+        // for the existence of other traders' resting orders.
+        let visible = self
+            .engine
+            .get_order(id)
+            .filter(|o| caller == Some(o.trader));
+        match visible {
             Some(o) => Ok(Response::new(GetOrderResponse {
                 order: Some(order_to_proto(&o)),
             })),
@@ -117,21 +134,30 @@ impl DarkPoolService for ApiHandler {
         }
     }
 
-    async fn get_order_book(
+    async fn list_orders(
         &self,
-        req: Request<GetOrderBookRequest>,
-    ) -> Result<Response<GetOrderBookResponse>, Status> {
+        req: Request<ListOrdersRequest>,
+    ) -> Result<Response<ListOrdersResponse>, Status> {
+        // "My orders": the caller's own resting orders, never anyone
+        // else's. Without a wallet identity (e.g. an operator API key) the
+        // caller owns nothing → empty list, not the cross-trader book.
+        let Some(trader) = caller_address(&req) else {
+            return Ok(Response::new(ListOrdersResponse { orders: Vec::new() }));
+        };
         let req = req.into_inner();
-        // Empty / whitespace-only `pair` is caught by `Pair::parse` inside
-        // `validate_pair_known` (returns `PairRequired` → invalid_argument
-        // with `MSG_PAIR_REQUIRED`); no separate guard needed here.
-        let canonical = validate_pair_known(&self.engine, &req.pair)?;
-        let (bids, asks) = self.engine.get_order_book(canonical.as_str());
-        Ok(Response::new(GetOrderBookResponse {
-            pair: canonical.into_string(),
-            bids: aggregate_levels(bids),
-            asks: aggregate_levels(asks),
-        }))
+        let pair_filter = if req.pair.is_empty() {
+            None
+        } else {
+            Some(validate_pair_known(&self.engine, &req.pair)?)
+        };
+        let orders = self
+            .engine
+            .orders_by_trader(trader)
+            .into_iter()
+            .filter(|o| pair_filter.as_ref().is_none_or(|p| o.pair == p.as_str()))
+            .map(|o| order_to_proto(&o))
+            .collect();
+        Ok(Response::new(ListOrdersResponse { orders }))
     }
 
     async fn get_auction_history(

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -651,8 +651,9 @@ impl IntoResponse for ApiError {
 /// Carry the authenticated identity injected by `auth_axum_mw` (an axum
 /// request extension) into the tonic `Request` the gRPC handler reads. The
 /// REST layer builds a fresh tonic request, so without this the per-trader
-/// scoping in `place_order` / `get_order` / `list_orders` would never see
-/// the caller. Absent on routers mounted without the auth middleware.
+/// scoping in `place_order` / `cancel_order` / `get_order` / `list_orders`
+/// would never see the caller. Absent on routers mounted without the auth
+/// middleware.
 fn with_identity<T>(inner: T, identity: Option<Extension<AuthenticatedIdentity>>) -> Request<T> {
     let mut req = Request::new(inner);
     if let Some(Extension(id)) = identity {
@@ -682,14 +683,18 @@ async fn rest_place_order(
 
 async fn rest_cancel_order(
     State(h): State<SharedHandler>,
+    identity: Option<Extension<AuthenticatedIdentity>>,
     Path(order_id): Path<String>,
     Query(q): Query<CancelQuery>,
 ) -> Result<Json<CancelOrderRespJson>, ApiError> {
-    let req = CancelOrderRequest {
-        order_id,
-        reason: q.reason,
-    };
-    h.cancel_order(Request::new(req)).await?;
+    let req = with_identity(
+        CancelOrderRequest {
+            order_id,
+            reason: q.reason,
+        },
+        identity,
+    );
+    h.cancel_order(req).await?;
     Ok(Json(CancelOrderRespJson {}))
 }
 

--- a/crates/dp-api/src/rest.rs
+++ b/crates/dp-api/src/rest.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use axum::body::Body;
-use axum::extract::{MatchedPath, Path, Query, State};
+use axum::extract::{Extension, MatchedPath, Path, Query, State};
 use axum::http::{header, HeaderName, HeaderValue, Method, Request as AxumRequest, StatusCode};
 use axum::middleware::from_fn_with_state;
 use axum::response::sse::{Event, KeepAlive, Sse};
@@ -23,13 +23,13 @@ use tower_http::request_id::{
 use tower_http::trace::TraceLayer;
 
 use crate::admin::{AdminApiHandler, AdminKeyError, KeyAdminHandler};
-use crate::auth::{auth_axum_mw, AuthCore};
+use crate::auth::{auth_axum_mw, AuthCore, AuthenticatedIdentity};
 use crate::handler::ApiHandler;
 use crate::pb::dark_pool_admin_service_server::DarkPoolAdminService;
 use crate::pb::dark_pool_service_server::DarkPoolService;
 use crate::pb::{
-    self, CancelOrderRequest, DelistPairRequest, GetAuctionHistoryRequest, GetOrderBookRequest,
-    GetOrderRequest, ListPairsAdminRequest, ListPairsRequest, PlaceOrderRequest,
+    self, CancelOrderRequest, DelistPairRequest, GetAuctionHistoryRequest, GetOrderRequest,
+    ListOrdersRequest, ListPairsAdminRequest, ListPairsRequest, PlaceOrderRequest,
     RegisterPairRequest, SuspendPairRequest,
 };
 use crate::ratelimit::{ratelimit_axum_mw, RateLimitCore};
@@ -60,12 +60,11 @@ pub fn router(handler: SharedHandler) -> Router {
     let place_order =
         post(rest_place_order).layer(RequestBodyLimitLayer::new(PLACE_ORDER_BODY_LIMIT));
     Router::new()
-        .route("/v1/orders", place_order)
+        .route("/v1/orders", place_order.get(rest_list_orders))
         .route(
             "/v1/orders/:order_id",
             delete(rest_cancel_order).get(rest_get_order),
         )
-        .route("/v1/orderbook", get(rest_get_orderbook))
         .route("/v1/auctions", get(rest_get_auction_history))
         .route("/v1/auctions/stream", get(rest_stream_auctions))
         .route("/v1/pairs", get(rest_list_pairs))
@@ -465,28 +464,8 @@ struct GetOrderRespJson {
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct PriceLevelJson {
-    price: String,
-    total_size: String,
-    order_count: i32,
-}
-
-impl From<pb::PriceLevel> for PriceLevelJson {
-    fn from(l: pb::PriceLevel) -> Self {
-        Self {
-            price: l.price,
-            total_size: l.total_size,
-            order_count: l.order_count,
-        }
-    }
-}
-
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct OrderBookJson {
-    pair: String,
-    bids: Vec<PriceLevelJson>,
-    asks: Vec<PriceLevelJson>,
+struct ListOrdersRespJson {
+    orders: Vec<OrderInfoJson>,
 }
 
 #[derive(Serialize)]
@@ -593,7 +572,7 @@ struct CancelQuery {
 }
 
 #[derive(Deserialize)]
-struct OrderBookQuery {
+struct ListOrdersQuery {
     #[serde(default)]
     pair: String,
 }
@@ -669,16 +648,33 @@ impl IntoResponse for ApiError {
 
 // ---------- handlers ----------
 
+/// Carry the authenticated identity injected by `auth_axum_mw` (an axum
+/// request extension) into the tonic `Request` the gRPC handler reads. The
+/// REST layer builds a fresh tonic request, so without this the per-trader
+/// scoping in `place_order` / `get_order` / `list_orders` would never see
+/// the caller. Absent on routers mounted without the auth middleware.
+fn with_identity<T>(inner: T, identity: Option<Extension<AuthenticatedIdentity>>) -> Request<T> {
+    let mut req = Request::new(inner);
+    if let Some(Extension(id)) = identity {
+        req.extensions_mut().insert(id);
+    }
+    req
+}
+
 async fn rest_place_order(
     State(h): State<SharedHandler>,
+    identity: Option<Extension<AuthenticatedIdentity>>,
     Json(body): Json<PlaceOrderJson>,
 ) -> Result<Json<PlaceOrderRespJson>, ApiError> {
-    let req = PlaceOrderRequest {
-        commitment: body.commitment,
-        proof: body.proof,
-        encrypted_payload: body.encrypted_payload,
-    };
-    let resp = h.place_order(Request::new(req)).await?.into_inner();
+    let req = with_identity(
+        PlaceOrderRequest {
+            commitment: body.commitment,
+            proof: body.proof,
+            encrypted_payload: body.encrypted_payload,
+        },
+        identity,
+    );
+    let resp = h.place_order(req).await?.into_inner();
     Ok(Json(PlaceOrderRespJson {
         order: resp.order.map(Into::into),
     }))
@@ -699,25 +695,27 @@ async fn rest_cancel_order(
 
 async fn rest_get_order(
     State(h): State<SharedHandler>,
+    identity: Option<Extension<AuthenticatedIdentity>>,
     Path(order_id): Path<String>,
 ) -> Result<Json<GetOrderRespJson>, ApiError> {
-    let req = GetOrderRequest { order_id };
-    let resp = h.get_order(Request::new(req)).await?.into_inner();
+    let req = with_identity(GetOrderRequest { order_id }, identity);
+    let resp = h.get_order(req).await?.into_inner();
     Ok(Json(GetOrderRespJson {
         order: resp.order.map(Into::into),
     }))
 }
 
-async fn rest_get_orderbook(
+/// `GET /v1/orders` — the caller's own resting orders ("my orders").
+/// Scoped to the authenticated wallet; there is no public order book.
+async fn rest_list_orders(
     State(h): State<SharedHandler>,
-    Query(q): Query<OrderBookQuery>,
-) -> Result<Json<OrderBookJson>, ApiError> {
-    let req = GetOrderBookRequest { pair: q.pair };
-    let resp = h.get_order_book(Request::new(req)).await?.into_inner();
-    Ok(Json(OrderBookJson {
-        pair: resp.pair,
-        bids: resp.bids.into_iter().map(Into::into).collect(),
-        asks: resp.asks.into_iter().map(Into::into).collect(),
+    identity: Option<Extension<AuthenticatedIdentity>>,
+    Query(q): Query<ListOrdersQuery>,
+) -> Result<Json<ListOrdersRespJson>, ApiError> {
+    let req = with_identity(ListOrdersRequest { pair: q.pair }, identity);
+    let resp = h.list_orders(req).await?.into_inner();
+    Ok(Json(ListOrdersRespJson {
+        orders: resp.orders.into_iter().map(Into::into).collect(),
     }))
 }
 
@@ -1072,19 +1070,6 @@ mod tests {
         let err = ApiError(tonic::Status::already_exists("dup"));
         let resp = err.into_response();
         assert_eq!(resp.status(), StatusCode::CONFLICT);
-    }
-
-    #[test]
-    fn price_level_json_conversion() {
-        let lvl = pb::PriceLevel {
-            price: "100.5".into(),
-            total_size: "10".into(),
-            order_count: 3,
-        };
-        let json: PriceLevelJson = lvl.into();
-        assert_eq!(json.price, "100.5");
-        assert_eq!(json.total_size, "10");
-        assert_eq!(json.order_count, 3);
     }
 
     #[test]

--- a/crates/dp-api/tests/handler.rs
+++ b/crates/dp-api/tests/handler.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use alloy_primitives::Address;
+use dp_api::auth::AuthenticatedIdentity;
 use dp_api::handler::ApiHandler;
 use dp_api::pb::dark_pool_service_server::DarkPoolService;
 use dp_api::pb::{
-    self, CancelOrderRequest, GetAuctionHistoryRequest, GetOrderBookRequest, GetOrderRequest,
+    self, CancelOrderRequest, GetAuctionHistoryRequest, GetOrderRequest, ListOrdersRequest,
     PlaceOrderRequest, StreamAuctionsRequest,
 };
 use dp_api::validation::{
@@ -83,6 +84,44 @@ async fn place_test_order(
         .expect("place_order")
         .into_inner();
     resp.order.unwrap().id
+}
+
+/// Place an order owned by a specific trader. No caller identity is set on
+/// the place request (caller `None` skips the trader/caller binding check),
+/// so the order lands in the book with `trader == owner`.
+async fn place_test_order_as(
+    h: &ApiHandler,
+    owner: Address,
+    pair: &str,
+    side: Side,
+    price: &str,
+    size: &str,
+) -> String {
+    let n = KEY_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let d = DecryptedOrder {
+        trader: owner,
+        pair: pair.to_string(),
+        side,
+        price: price.parse().unwrap(),
+        size: size.parse().unwrap(),
+        commitment_key: format!("test-key-{}", n),
+        ttl: 600_000_000_000,
+    };
+    let resp = h
+        .place_order(Request::new(build_req(&d)))
+        .await
+        .expect("place_order")
+        .into_inner();
+    resp.order.unwrap().id
+}
+
+/// Wrap a request with a SIWE-style wallet identity so caller-scoped
+/// handlers (`get_order`, `list_orders`) see the authenticated trader.
+fn wallet_req<T>(inner: T, wallet: Address) -> Request<T> {
+    let mut req = Request::new(inner);
+    req.extensions_mut()
+        .insert(AuthenticatedIdentity::Wallet(wallet));
+    req
 }
 
 // ---------- PlaceOrder ----------
@@ -238,9 +277,10 @@ async fn cancel_order_not_found() {
 #[tokio::test]
 async fn get_order_success() {
     let h = new_handler();
+    // place_test_order owns the order as Address::ZERO.
     let id = place_test_order(&h, "ETH/USDC", Side::Buy, "1800", "5").await;
     let resp = h
-        .get_order(Request::new(GetOrderRequest { order_id: id }))
+        .get_order(wallet_req(GetOrderRequest { order_id: id }, Address::ZERO))
         .await
         .unwrap()
         .into_inner();
@@ -266,63 +306,110 @@ async fn get_order_invalid_uuid() {
 async fn get_order_not_found() {
     let h = new_handler();
     let err = h
-        .get_order(Request::new(GetOrderRequest {
-            order_id: Uuid::new_v4().to_string(),
-        }))
+        .get_order(wallet_req(
+            GetOrderRequest {
+                order_id: Uuid::new_v4().to_string(),
+            },
+            Address::ZERO,
+        ))
         .await
         .err()
         .unwrap();
     assert_eq!(err.code(), Code::NotFound);
 }
 
-// ---------- GetOrderBook ----------
-
+/// A key-holder must not read another trader's order. The response is
+/// `not_found` (not `permission_denied`) so existence isn't leaked.
 #[tokio::test]
-async fn get_order_book_success() {
+async fn get_order_hides_other_traders_order() {
     let h = new_handler();
-    place_test_order(&h, "ETH/USDC", Side::Buy, "1800", "5").await;
-    place_test_order(&h, "ETH/USDC", Side::Buy, "1790", "3").await;
-    place_test_order(&h, "ETH/USDC", Side::Sell, "1850", "2").await;
-    let resp = h
-        .get_order_book(Request::new(GetOrderBookRequest {
-            pair: "ETH/USDC".into(),
-        }))
-        .await
-        .unwrap()
-        .into_inner();
-    assert_eq!(resp.pair, "ETH/USDC");
-    assert_eq!(resp.bids.len(), 2);
-    assert_eq!(resp.asks.len(), 1);
-}
-
-#[tokio::test]
-async fn get_order_book_empty_pair() {
-    let h = new_handler();
+    let owner = Address::with_last_byte(0x11);
+    let attacker = Address::with_last_byte(0x22);
+    let id = place_test_order_as(&h, owner, "ETH/USDC", Side::Buy, "1800", "5").await;
     let err = h
-        .get_order_book(Request::new(GetOrderBookRequest { pair: "".into() }))
+        .get_order(wallet_req(GetOrderRequest { order_id: id }, attacker))
         .await
         .err()
         .unwrap();
-    assert_eq!(err.code(), Code::InvalidArgument);
+    assert_eq!(err.code(), Code::NotFound);
 }
 
+/// Without a wallet identity (e.g. an operator API-key caller) no trader
+/// order is visible — every lookup is `not_found`.
 #[tokio::test]
-async fn get_order_book_aggregation() {
+async fn get_order_without_wallet_identity_is_not_found() {
     let h = new_handler();
-    place_test_order(&h, "ETH/USDC", Side::Buy, "100", "5").await;
-    place_test_order(&h, "ETH/USDC", Side::Buy, "100", "3").await;
-    place_test_order(&h, "ETH/USDC", Side::Buy, "200", "10").await;
+    let owner = Address::with_last_byte(0x11);
+    let id = place_test_order_as(&h, owner, "ETH/USDC", Side::Buy, "1800", "5").await;
+    let err = h
+        .get_order(Request::new(GetOrderRequest { order_id: id }))
+        .await
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), Code::NotFound);
+}
+
+// ---------- ListOrders (caller-scoped "my orders") ----------
+
+/// The list contains the caller's own orders and never another trader's.
+#[tokio::test]
+async fn list_orders_returns_only_callers_orders() {
+    let h = new_handler();
+    let me = Address::with_last_byte(0x11);
+    let other = Address::with_last_byte(0x22);
+    place_test_order_as(&h, me, "ETH/USDC", Side::Buy, "1800", "5").await;
+    place_test_order_as(&h, me, "ETH/USDC", Side::Sell, "1850", "2").await;
+    place_test_order_as(&h, other, "ETH/USDC", Side::Buy, "1790", "3").await;
     let resp = h
-        .get_order_book(Request::new(GetOrderBookRequest {
-            pair: "ETH/USDC".into(),
+        .list_orders(wallet_req(
+            ListOrdersRequest {
+                pair: String::new(),
+            },
+            me,
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.orders.len(), 2);
+}
+
+/// Without a wallet identity the caller owns nothing — empty list, never
+/// the cross-trader book.
+#[tokio::test]
+async fn list_orders_without_wallet_identity_is_empty() {
+    let h = new_handler();
+    let owner = Address::with_last_byte(0x11);
+    place_test_order_as(&h, owner, "ETH/USDC", Side::Buy, "1800", "5").await;
+    let resp = h
+        .list_orders(Request::new(ListOrdersRequest {
+            pair: String::new(),
         }))
         .await
         .unwrap()
         .into_inner();
-    assert_eq!(resp.bids.len(), 2);
-    let lvl = resp.bids.iter().find(|l| l.price == "100").expect("100");
-    assert_eq!(lvl.total_size, "8");
-    assert_eq!(lvl.order_count, 2);
+    assert!(resp.orders.is_empty());
+}
+
+#[tokio::test]
+async fn list_orders_filters_by_pair() {
+    let h = new_handler();
+    let me = Address::with_last_byte(0x11);
+    h.engine
+        .register_pair_without_event("BTC/USDC".into(), dp_engine::PairConfig::default());
+    place_test_order_as(&h, me, "ETH/USDC", Side::Buy, "1800", "5").await;
+    place_test_order_as(&h, me, "BTC/USDC", Side::Buy, "60000", "1").await;
+    let resp = h
+        .list_orders(wallet_req(
+            ListOrdersRequest {
+                pair: "ETH/USDC".into(),
+            },
+            me,
+        ))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.orders.len(), 1);
+    assert_eq!(resp.orders[0].pair, "ETH/USDC");
 }
 
 // ---------- GetAuctionHistory ----------

--- a/crates/dp-api/tests/handler.rs
+++ b/crates/dp-api/tests/handler.rs
@@ -235,11 +235,16 @@ async fn place_order_proof_too_large() {
 #[tokio::test]
 async fn cancel_order_success() {
     let h = new_handler();
+    // place_test_order owns the order as Address::ZERO; cancel is caller-
+    // scoped, so the request carries a matching wallet identity.
     let id = place_test_order(&h, "ETH/USDC", Side::Buy, "1800", "5").await;
-    h.cancel_order(Request::new(CancelOrderRequest {
-        order_id: id,
-        reason: "testing".into(),
-    }))
+    h.cancel_order(wallet_req(
+        CancelOrderRequest {
+            order_id: id,
+            reason: "testing".into(),
+        },
+        Address::ZERO,
+    ))
     .await
     .unwrap();
 }
@@ -265,6 +270,55 @@ async fn cancel_order_not_found() {
         .cancel_order(Request::new(CancelOrderRequest {
             order_id: Uuid::new_v4().to_string(),
             reason: "".into(),
+        }))
+        .await
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), Code::NotFound);
+}
+
+/// A key-holder must not cancel another trader's order. Like `get_order`,
+/// the response is `not_found` (not `permission_denied`) so existence isn't
+/// leaked — and crucially the order survives the rejected cancel.
+#[tokio::test]
+async fn cancel_order_hides_other_traders_order() {
+    let h = new_handler();
+    let owner = Address::with_last_byte(0x11);
+    let attacker = Address::with_last_byte(0x22);
+    let id = place_test_order_as(&h, owner, "ETH/USDC", Side::Buy, "1800", "5").await;
+    let err = h
+        .cancel_order(wallet_req(
+            CancelOrderRequest {
+                order_id: id.clone(),
+                reason: String::new(),
+            },
+            attacker,
+        ))
+        .await
+        .err()
+        .unwrap();
+    assert_eq!(err.code(), Code::NotFound);
+    // The order is still live and visible to its real owner.
+    let resp = h
+        .get_order(wallet_req(GetOrderRequest { order_id: id }, owner))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(resp.order.is_some());
+}
+
+/// Without a wallet identity (e.g. an operator API-key caller) no order is
+/// cancellable — every CancelOrder is `not_found`, never a cross-trader
+/// cancel.
+#[tokio::test]
+async fn cancel_order_without_wallet_identity_is_not_found() {
+    let h = new_handler();
+    let owner = Address::with_last_byte(0x11);
+    let id = place_test_order_as(&h, owner, "ETH/USDC", Side::Buy, "1800", "5").await;
+    let err = h
+        .cancel_order(Request::new(CancelOrderRequest {
+            order_id: id,
+            reason: String::new(),
         }))
         .await
         .err()

--- a/crates/dp-api/tests/observability_http.rs
+++ b/crates/dp-api/tests/observability_http.rs
@@ -177,11 +177,7 @@ async fn request_id_is_present_on_error_responses() {
     // Hit an auth-gated route without a key → 401. The x-request-id
     // middleware wraps the entire router so the header must still appear.
     let resp = router
-        .oneshot(
-            Request::get("/v1/orderbook?pair=ETH/USDC")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::get("/v1/pairs").body(Body::empty()).unwrap())
         .await
         .unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
@@ -216,14 +212,10 @@ async fn request_id_generated_is_valid_ulid() {
 #[tokio::test]
 async fn ops_endpoints_skip_auth_while_protected_routes_still_require_it() {
     let router = make_router(ReadinessProbes::new());
-    // No api key → /v1/orderbook must reject.
+    // No api key → an auth-gated public route must reject.
     let resp = router
         .clone()
-        .oneshot(
-            Request::get("/v1/orderbook?pair=ETH/USDC")
-                .body(Body::empty())
-                .unwrap(),
-        )
+        .oneshot(Request::get("/v1/pairs").body(Body::empty()).unwrap())
         .await
         .unwrap();
     assert_eq!(

--- a/crates/dp-api/tests/rest.rs
+++ b/crates/dp-api/tests/rest.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use alloy_primitives::Address;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
+use dp_api::auth::AuthenticatedIdentity;
 use dp_api::handler::ApiHandler;
 use dp_api::rest;
 use dp_engine::Engine;
@@ -20,66 +22,6 @@ fn new_app() -> axum::Router {
 async fn body_to_json(b: Body) -> serde_json::Value {
     let bytes = b.collect().await.unwrap().to_bytes();
     serde_json::from_slice(&bytes).unwrap()
-}
-
-#[tokio::test]
-async fn orderbook_empty_pair_400() {
-    let app = new_app();
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .uri("/v1/orderbook")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
-}
-
-#[tokio::test]
-async fn orderbook_unknown_pair_returns_404() {
-    // Behaviour change vs. prior implementation: an unknown pair now hits
-    // the registry check before reaching the (empty) sub-book and returns
-    // 404. The previous code returned 200 with empty bids/asks because
-    // `OrderBook` had a single shared book and the filter just produced
-    // an empty slice. With per-pair books + registry validation that
-    // shape is gone.
-    let app = new_app();
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .uri("/v1/orderbook?pair=ETH/USDC")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-}
-
-#[tokio::test]
-async fn orderbook_known_pair_returns_empty() {
-    let store = Arc::new(MemStore::new());
-    let engine = Engine::new(store, Duration::from_secs(1));
-    engine.register_pair_without_event("ETH/USDC".into(), dp_engine::PairConfig::default());
-    let handler = ApiHandler::new(engine);
-    let app = rest::router(Arc::new(handler));
-
-    let resp = app
-        .oneshot(
-            Request::builder()
-                .uri("/v1/orderbook?pair=ETH/USDC")
-                .body(Body::empty())
-                .unwrap(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::OK);
-    let json = body_to_json(resp.into_body()).await;
-    assert_eq!(json["pair"], "ETH/USDC");
-    assert!(json["bids"].as_array().unwrap().is_empty());
-    assert!(json["asks"].as_array().unwrap().is_empty());
 }
 
 #[tokio::test]
@@ -211,12 +153,15 @@ async fn rest_place_get_cancel_round_trip() {
     assert_eq!(json["order"]["pair"], "ETH/USDC");
     assert_eq!(json["order"]["side"], "SIDE_BUY");
 
-    // GET it back
+    // GET it back. The order is owned by Address::ZERO; inject a matching
+    // wallet identity (normally set by auth_axum_mw) so the caller-scoped
+    // handler returns it. Without an identity this would be 404.
     let resp = app
         .clone()
         .oneshot(
             Request::builder()
                 .uri(format!("/v1/orders/{id}"))
+                .extension(AuthenticatedIdentity::Wallet(Address::ZERO))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -240,21 +185,21 @@ async fn rest_place_get_cancel_round_trip() {
     assert_eq!(resp.status(), StatusCode::OK);
 }
 
+/// `GET /v1/orders` returns only the authenticated caller's own orders,
+/// and nothing at all without a wallet identity. There is no public book.
 #[tokio::test]
-async fn rest_orderbook_serializes_levels() {
+async fn rest_list_orders_is_scoped_to_caller() {
     let (app, _engine) = registered_app();
-    // Place a buy + sell via REST so the orderbook returns level rows
-    // (exercising PriceLevelJson::From + bids/asks serialization).
-    let make_body = |side: dp_types::Side, price: &str| {
+    let make_body = |trader: Address, side: dp_types::Side, price: &str| {
         use base64::engine::general_purpose::STANDARD;
         use base64::Engine;
         let d = dp_crypto::DecryptedOrder {
-            trader: alloy_primitives::Address::ZERO,
+            trader,
             pair: "ETH/USDC".into(),
             side,
             price: price.parse().unwrap(),
             size: "1".parse().unwrap(),
-            commitment_key: format!("k-{}-{}", side as u8, price),
+            commitment_key: format!("k-{}-{}-{}", trader, side as u8, price),
             ttl: 60_000_000_000,
         };
         serde_json::json!({
@@ -265,9 +210,13 @@ async fn rest_orderbook_serializes_levels() {
         .to_string()
     };
 
-    for (side, price) in [
-        (dp_types::Side::Buy, "1800"),
-        (dp_types::Side::Sell, "1850"),
+    let me = Address::with_last_byte(0x11);
+    let other = Address::with_last_byte(0x22);
+    // me: a non-crossing buy + sell (both rest); other: one resting buy.
+    for (trader, side, price) in [
+        (me, dp_types::Side::Buy, "1800"),
+        (me, dp_types::Side::Sell, "1850"),
+        (other, dp_types::Side::Buy, "1790"),
     ] {
         let resp = app
             .clone()
@@ -276,7 +225,7 @@ async fn rest_orderbook_serializes_levels() {
                     .method("POST")
                     .uri("/v1/orders")
                     .header("content-type", "application/json")
-                    .body(Body::from(make_body(side, price)))
+                    .body(Body::from(make_body(trader, side, price)))
                     .unwrap(),
             )
             .await
@@ -284,10 +233,13 @@ async fn rest_orderbook_serializes_levels() {
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
+    // As `me` → exactly my two orders, never `other`'s.
     let resp = app
+        .clone()
         .oneshot(
             Request::builder()
-                .uri("/v1/orderbook?pair=ETH/USDC")
+                .uri("/v1/orders")
+                .extension(AuthenticatedIdentity::Wallet(me))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -295,9 +247,21 @@ async fn rest_orderbook_serializes_levels() {
         .unwrap();
     assert_eq!(resp.status(), StatusCode::OK);
     let json = body_to_json(resp.into_body()).await;
-    assert_eq!(json["bids"].as_array().unwrap().len(), 1);
-    assert_eq!(json["asks"].as_array().unwrap().len(), 1);
-    assert_eq!(json["bids"][0]["price"], "1800");
+    assert_eq!(json["orders"].as_array().unwrap().len(), 2);
+
+    // Without a wallet identity → empty list, not the cross-trader book.
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/orders")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let json = body_to_json(resp.into_body()).await;
+    assert!(json["orders"].as_array().unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/crates/dp-api/tests/rest.rs
+++ b/crates/dp-api/tests/rest.rs
@@ -171,12 +171,14 @@ async fn rest_place_get_cancel_round_trip() {
     let json = body_to_json(resp.into_body()).await;
     assert_eq!(json["order"]["id"], id);
 
-    // Cancel it
+    // Cancel it. Cancel is caller-scoped like GET, so the DELETE carries the
+    // owner's wallet identity; without it this would be 404.
     let resp = app
         .oneshot(
             Request::builder()
                 .method("DELETE")
                 .uri(format!("/v1/orders/{id}?reason=testing"))
+                .extension(AuthenticatedIdentity::Wallet(Address::ZERO))
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/crates/dp-api/tests/server_boot.rs
+++ b/crates/dp-api/tests/server_boot.rs
@@ -11,7 +11,7 @@ use dp_api::auth::{AuthLayer, AUTH_HEADER};
 use dp_api::handler::ApiHandler;
 use dp_api::pb::dark_pool_service_client::DarkPoolServiceClient;
 use dp_api::pb::dark_pool_service_server::DarkPoolServiceServer;
-use dp_api::pb::{GetOrderBookRequest, PlaceOrderRequest};
+use dp_api::pb::{ListPairsRequest, PlaceOrderRequest};
 use dp_api::ratelimit::RateLimitLayer;
 use dp_api::rest;
 use dp_engine::Engine;
@@ -89,17 +89,13 @@ async fn grpc_server_accepts_real_client() {
         .expect_err("empty PlaceOrder should fail validation");
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
 
-    // Valid empty-state read: no orders for any pair.
+    // Valid public read crossing the wire: the registered pair is listed.
     let resp = client
-        .get_order_book(GetOrderBookRequest {
-            pair: "ETH/USDC".to_string(),
-        })
+        .list_pairs(ListPairsRequest {})
         .await
-        .expect("get_order_book")
+        .expect("list_pairs")
         .into_inner();
-    assert_eq!(resp.pair, "ETH/USDC");
-    assert!(resp.bids.is_empty());
-    assert!(resp.asks.is_empty());
+    assert!(resp.pairs.iter().any(|p| p.pair == "ETH/USDC"));
 
     cancel.cancel();
     server_task.await.expect("join grpc task");
@@ -149,9 +145,7 @@ async fn grpc_server_with_layers_enforces_auth_and_ratelimit() {
     // No api key → Unauthenticated.
     let mut anon = DarkPoolServiceClient::new(channel.clone());
     let err = anon
-        .get_order_book(GetOrderBookRequest {
-            pair: "ETH/USDC".into(),
-        })
+        .list_pairs(ListPairsRequest {})
         .await
         .expect_err("missing key must be rejected");
     assert_eq!(err.code(), tonic::Code::Unauthenticated);
@@ -167,15 +161,11 @@ async fn grpc_server_with_layers_enforces_auth_and_ratelimit() {
         },
     );
     authed
-        .get_order_book(GetOrderBookRequest {
-            pair: "ETH/USDC".into(),
-        })
+        .list_pairs(ListPairsRequest {})
         .await
         .expect("first authed request");
     let err = authed
-        .get_order_book(GetOrderBookRequest {
-            pair: "ETH/USDC".into(),
-        })
+        .list_pairs(ListPairsRequest {})
         .await
         .expect_err("second request must be rate-limited");
     assert_eq!(err.code(), tonic::Code::ResourceExhausted);
@@ -203,13 +193,12 @@ async fn rest_server_accepts_real_http() {
         .expect("rest server");
     });
 
-    let body = http_get(addr, "/v1/orderbook?pair=ETH/USDC").await;
+    let body = http_get(addr, "/v1/pairs").await;
     let (status, payload) = parse_http_response(&body);
     assert_eq!(status, 200, "raw response: {body}");
     let json: serde_json::Value = serde_json::from_str(payload).expect("rest body should be JSON");
-    assert_eq!(json["pair"], "ETH/USDC");
-    assert!(json["bids"].as_array().unwrap().is_empty());
-    assert!(json["asks"].as_array().unwrap().is_empty());
+    let pairs = json["pairs"].as_array().expect("pairs array");
+    assert!(pairs.iter().any(|p| p["pair"] == "ETH/USDC"));
 
     cancel.cancel();
     server_task.await.expect("join rest task");

--- a/crates/dp-api/tests/server_boot_tls.rs
+++ b/crates/dp-api/tests/server_boot_tls.rs
@@ -15,7 +15,7 @@ use dp_api::config::TlsMode;
 use dp_api::handler::ApiHandler;
 use dp_api::pb::dark_pool_service_client::DarkPoolServiceClient;
 use dp_api::pb::dark_pool_service_server::DarkPoolServiceServer;
-use dp_api::pb::GetOrderBookRequest;
+use dp_api::pb::ListPairsRequest;
 use dp_api::rest;
 use dp_api::tls;
 use dp_engine::Engine;
@@ -299,13 +299,11 @@ async fn grpc_serves_over_tls() {
     let mut client = grpc_client(server.addr, &bundle.ca_pem).await;
 
     let resp = client
-        .get_order_book(GetOrderBookRequest {
-            pair: "ETH/USDC".into(),
-        })
+        .list_pairs(ListPairsRequest {})
         .await
-        .expect("orderbook over TLS")
+        .expect("list_pairs over TLS")
         .into_inner();
-    assert_eq!(resp.pair, "ETH/USDC");
+    assert!(resp.pairs.iter().any(|p| p.pair == "ETH/USDC"));
 
     server.shutdown().await;
 }
@@ -330,12 +328,7 @@ async fn grpc_rejects_plain_client_when_tls_on() {
             Err(_) => true, // connect refused
             Ok(ch) => {
                 let mut client = DarkPoolServiceClient::new(ch);
-                client
-                    .get_order_book(GetOrderBookRequest {
-                        pair: "ETH/USDC".into(),
-                    })
-                    .await
-                    .is_err()
+                client.list_pairs(ListPairsRequest {}).await.is_err()
             }
         }
     })
@@ -367,13 +360,11 @@ async fn grpc_mtls_accepts_authorized_client() {
     .await;
 
     let resp = client
-        .get_order_book(GetOrderBookRequest {
-            pair: "ETH/USDC".into(),
-        })
+        .list_pairs(ListPairsRequest {})
         .await
-        .expect("mTLS orderbook")
+        .expect("mTLS list_pairs")
         .into_inner();
-    assert_eq!(resp.pair, "ETH/USDC");
+    assert!(resp.pairs.iter().any(|p| p.pair == "ETH/USDC"));
 
     server.shutdown().await;
 }
@@ -407,12 +398,7 @@ async fn grpc_mtls_rejects_missing_client_cert() {
                 Err(_) => return true,
                 Ok(ch) => {
                     let mut c = DarkPoolServiceClient::new(ch);
-                    if c.get_order_book(GetOrderBookRequest {
-                        pair: "ETH/USDC".into(),
-                    })
-                    .await
-                    .is_err()
-                    {
+                    if c.list_pairs(ListPairsRequest {}).await.is_err() {
                         return true;
                     }
                 }
@@ -437,10 +423,7 @@ async fn rest_serves_over_tls() {
     };
     let server = start_rest(&mode).await;
     let client = reqwest_client(&bundle.ca_pem);
-    let url = format!(
-        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
-        server.addr.port()
-    );
+    let url = format!("https://localhost:{}/v1/pairs", server.addr.port());
     wait_rest_ready(&client, &url).await;
     let resp = client.get(&url).send().await.expect("rest GET");
     assert_eq!(resp.status(), 200, "body: {:?}", resp.text().await);
@@ -457,10 +440,7 @@ async fn rest_mtls_accepts_authorized_client() {
     };
     let server = start_rest(&mode).await;
     let client = reqwest_client_mtls(&bundle.ca_pem, &bundle.client.pem, &bundle.client.key_pem);
-    let url = format!(
-        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
-        server.addr.port()
-    );
+    let url = format!("https://localhost:{}/v1/pairs", server.addr.port());
     wait_rest_ready(&client, &url).await;
     let resp = client.get(&url).send().await.expect("rest mTLS GET");
     assert_eq!(resp.status(), 200);
@@ -476,10 +456,7 @@ async fn rest_mtls_rejects_missing_client_cert() {
         client_ca: bundle.ca_path.clone(),
     };
     let server = start_rest(&mode).await;
-    let url = format!(
-        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
-        server.addr.port()
-    );
+    let url = format!("https://localhost:{}/v1/pairs", server.addr.port());
 
     // First wait for the listener to be ready via the mTLS-authorized
     // client. This separates "server not bound yet" from "TLS rejected
@@ -518,10 +495,7 @@ async fn rest_reload_swaps_cert_material() {
     };
 
     let server = start_rest(&mode_a).await;
-    let url = format!(
-        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
-        server.addr.port()
-    );
+    let url = format!("https://localhost:{}/v1/pairs", server.addr.port());
 
     let client_a = reqwest_client(&bundle_a.ca_pem);
     wait_rest_ready(&client_a, &url).await;
@@ -572,10 +546,7 @@ async fn rest_mtls_reload_swaps_cert_material() {
     };
 
     let server = start_rest(&mode_a).await;
-    let url = format!(
-        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
-        server.addr.port()
-    );
+    let url = format!("https://localhost:{}/v1/pairs", server.addr.port());
 
     let client_a = reqwest_client_mtls(
         &bundle_a.ca_pem,
@@ -617,10 +588,7 @@ async fn rest_reload_to_plaintext_errors() {
         key: bundle.server_key_path.clone(),
     };
     let server = start_rest(&mode).await;
-    let url = format!(
-        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
-        server.addr.port()
-    );
+    let url = format!("https://localhost:{}/v1/pairs", server.addr.port());
     let client = reqwest_client(&bundle.ca_pem);
     wait_rest_ready(&client, &url).await;
 
@@ -650,10 +618,7 @@ async fn rest_reload_failure_keeps_old_cert() {
         client_ca: bundle_a.ca_path.clone(),
     };
     let server = start_rest(&mode_a).await;
-    let url = format!(
-        "https://localhost:{}/v1/orderbook?pair=ETH/USDC",
-        server.addr.port()
-    );
+    let url = format!("https://localhost:{}/v1/pairs", server.addr.port());
 
     let client_a = reqwest_client_mtls(
         &bundle_a.ca_pem,

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -720,6 +720,21 @@ impl Engine {
         (state.book.bids(pair), state.book.asks(pair))
     }
 
+    /// Resting orders owned by `trader`, across every pair, oldest first.
+    /// Backs the caller-scoped "my orders" API surface: a trader may only
+    /// ever see their own orders, never the cross-trader book.
+    pub fn orders_by_trader(&self, trader: alloy_primitives::Address) -> Vec<Order> {
+        let state = self.inner.state.lock();
+        let mut out: Vec<Order> = state
+            .book
+            .iter_all()
+            .into_iter()
+            .filter(|o| o.trader == trader)
+            .collect();
+        out.sort_by(|a, b| a.submitted_at.cmp(&b.submitted_at));
+        out
+    }
+
     pub fn pair_status(&self, pair: &str) -> Option<crate::state::PairStatus> {
         self.inner.state.lock().pair_config(pair).map(|c| c.status)
     }


### PR DESCRIPTION
Closes #154

The API was handing out live pre-settlement order data, which is the exact thing a dark pool is supposed to hide. GET /v1/orderbook returned aggregated cross-trader depth plus per-level order counts, and GetOrder would hand any order to any key-holder. Anyone polling each tick could rebuild the incoming book and cross it in the same auction round.

Adding auth doesn't fix a market order book: the attacker is a real authenticated trader reading everyone else's resting orders, so the live book is gone rather than gated. Concretely:

- Removed the GetOrderBook RPC, GET /v1/orderbook, the GetOrderBook/PriceLevel proto messages, and the level-aggregation code.
- GetOrder is now scoped to its owner. Non-owners, operator API keys, and unauthenticated callers all get not_found, so you can't even probe for existence.
- Added GET /v1/orders (ListOrders): your own resting orders, scoped to your wallet, empty without one. That's the safe "my orders" view that replaces the book for the UI.

Also fixed a latent gap while in here: the REST handlers built a fresh tonic request and dropped the AuthenticatedIdentity the middleware had set, so SIWE caller binding never ran on the REST path. It does now.

The salt_nonce at-rest leak (third bullet of the issue) is split out as #177, since it needs a stable operator secret and a recovery migration.

Heads up: the proto change means the generated TS SDK (#64) needs a regen, and docs/API-AND-PROTOCOL.md (currently only on the unmerged SIWE branch) still documents the old endpoint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated endpoint to retrieve a trader's resting orders with optional pair filtering

* **Bug Fixes**
  * Fixed order visibility scoping to prevent traders from viewing or probing other traders' orders

* **Chores**
  * Removed public order book endpoint; use dedicated pairs endpoint for available trading pairs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Dnreikronos/DarkPool-Exchange/pull/178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->