### PR TITLE
zk: Bind input-completeness to the IVC matching proof

### DIFF
--- a/crates/dp-aggregator/src/aggregator.rs
+++ b/crates/dp-aggregator/src/aggregator.rs
@@ -84,8 +84,8 @@ impl ProofAggregator for NoopAggregator {
             use ark_ff::Zero;
             Ok(dp_zk::folding::FinalProof {
                 proof_bytes: vec![0u8; 32],
-                z_0: [Fr::zero(); 4],
-                z_n: [Fr::zero(); 4],
+                z_0: [Fr::zero(); 5],
+                z_n: [Fr::zero(); 5],
                 n_steps: 0,
                 policy_hash: Fr::zero(),
             })

--- a/crates/dp-aggregator/src/inline.rs
+++ b/crates/dp-aggregator/src/inline.rs
@@ -145,16 +145,17 @@ impl ProofAggregator for InlineFoldingAggregator {
     }
 }
 
-/// Compute z_0 = [0, 0, poseidon(min_size, min_price, position_limit), 0] from
-/// the external inputs of the first round. This matches the `initial_z` helper
-/// in `dp-zk`'s step circuit tests. The trailing slot is the empty settlement
-/// hash-chain accumulator (#153).
-fn compute_z_0(ext: &AuctionExternalInputs) -> [Fr; 4] {
+/// Compute z_0 = [0, 0, poseidon(min_size, min_price, position_limit), 0, 0]
+/// from the external inputs of the first round. This matches the `initial_z`
+/// helper in `dp-zk`'s step circuit tests. The two trailing slots are the empty
+/// settlement hash-chain accumulator (#153) and the empty admitted-set chain
+/// (#157).
+fn compute_z_0(ext: &AuctionExternalInputs) -> [Fr; 5] {
     let cfg = poseidon_config();
     let mut s = PoseidonSponge::<Fr>::new(&cfg);
     s.absorb(&vec![ext.min_size, ext.min_price, ext.position_limit]);
     let policy_hash = s.squeeze_field_elements::<Fr>(1)[0];
-    [Fr::zero(), Fr::zero(), policy_hash, Fr::zero()]
+    [Fr::zero(), Fr::zero(), policy_hash, Fr::zero(), Fr::zero()]
 }
 
 #[cfg(test)]

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -643,6 +643,27 @@ impl Engine {
         })
     }
 
+    /// Commitment leaves for the orders admitted to a round — every order that
+    /// was live in the book at tick time (#157). These form the round's
+    /// admitted-set Merkle tree; membership of each settled leg is proven
+    /// against its root, binding the operator to the publicly admitted input.
+    ///
+    /// Reads only the `secrets` lock, so it must never be called while holding
+    /// the `state` lock: the established lock order is secrets→state (see
+    /// [`Self::prune_dead_secrets`]), and inverting it risks deadlock. The tick
+    /// captures the admitted order ids under the state lock and resolves their
+    /// commitments here, on the lock-free async proof path. An order whose
+    /// secret has already been pruned is skipped; a *matched* leg that ends up
+    /// absent is caught downstream by `from_witness_with_admitted`.
+    pub(crate) fn admitted_commitments(&self, order_ids: &[Uuid]) -> Vec<ark_bn254::Fr> {
+        let secrets = self.inner.secrets.lock();
+        order_ids
+            .iter()
+            .filter_map(|id| secrets.get(id))
+            .map(|s| dp_zk::pedersen::bytes_to_scalar(&s.commitment))
+            .collect()
+    }
+
     /// Drop ZK secrets whose backing order has left the book. Bounds the
     /// `secrets` map so it does not grow with every placed order.
     pub(crate) fn prune_dead_secrets(&self) {

--- a/crates/dp-engine/src/state.rs
+++ b/crates/dp-engine/src/state.rs
@@ -107,12 +107,14 @@ impl Default for PairConfig {
 pub enum ProofPayload {
     IvcFinal {
         proof_bytes: Vec<u8>,
-        // 4 elements: [state_hash, round_nonce, policy_hash, settlement_acc].
-        // The trailing settlement_acc (#153) binds the settled matches and is
-        // carried here at full fidelity. Plumbing it on-chain + the recompute
-        // is Phase 4.
-        z_0: [[u8; 32]; 4],
-        z_n: [[u8; 32]; 4],
+        // 5 elements:
+        // [state_hash, round_nonce, policy_hash, settlement_acc, admit_chain].
+        // settlement_acc (#153) binds the settled matches; admit_chain (#157)
+        // binds the per-round admitted-set roots so a watcher can confirm the
+        // operator matched only publicly admitted orders. Both are carried here
+        // at full fidelity. Plumbing them on-chain + the recompute is Phase 4.
+        z_0: [[u8; 32]; 5],
+        z_n: [[u8; 32]; 5],
         n_steps: u64,
         policy_hash: [u8; 32],
     },

--- a/crates/dp-engine/src/test_helpers.rs
+++ b/crates/dp-engine/src/test_helpers.rs
@@ -128,8 +128,8 @@ impl ProofAggregator for StubAggregator {
         Box::pin(async move {
             Ok(dp_zk::folding::FinalProof {
                 proof_bytes,
-                z_0: [Fr::zero(); 4],
-                z_n: [Fr::zero(); 4],
+                z_0: [Fr::zero(); 5],
+                z_n: [Fr::zero(); 5],
                 n_steps: 1,
                 policy_hash: Fr::zero(),
             })
@@ -218,8 +218,8 @@ impl ProofAggregator for BlockingAggregator {
         Box::pin(async move {
             Ok(dp_zk::folding::FinalProof {
                 proof_bytes: vec![0u8; 32],
-                z_0: [Fr::zero(); 4],
-                z_n: [Fr::zero(); 4],
+                z_0: [Fr::zero(); 5],
+                z_n: [Fr::zero(); 5],
                 n_steps: 1,
                 policy_hash: Fr::zero(),
             })

--- a/crates/dp-engine/src/tick.rs
+++ b/crates/dp-engine/src/tick.rs
@@ -34,6 +34,11 @@ pub(crate) struct PendingAggregation {
     /// for a fully-consumed order it disappears from the book, so we
     /// cannot rely on `book.find_order` later when building the witness.
     pub orders: HashMap<Uuid, Order>,
+    /// Ids of every order live in the book when this auction ran — the round's
+    /// admitted set (#157). Captured under the state lock; the async proof path
+    /// resolves these to commitment leaves (via the secrets lock) to build the
+    /// admitted-set Merkle root that membership is proven against.
+    pub admitted_order_ids: Vec<Uuid>,
     pub auction_at: chrono::DateTime<Utc>,
 }
 
@@ -60,11 +65,16 @@ impl Engine {
 
             let match_prices: Vec<_> = p.matches.iter().map(|m| m.price).collect();
             let match_sizes: Vec<_> = p.matches.iter().map(|m| m.size).collect();
-            let ext = match dp_zk::step_circuit::AuctionExternalInputs::from_witness(
+            // Resolve the round's admitted set (#157) to commitment leaves off
+            // the state lock, then bind every settled leg's membership against
+            // the resulting root.
+            let admitted = self.admitted_commitments(&p.admitted_order_ids);
+            let ext = match dp_zk::step_circuit::AuctionExternalInputs::from_witness_with_admitted(
                 &witness,
                 &match_prices,
                 &match_sizes,
                 self.inner.batch_size,
+                &admitted,
             ) {
                 Ok(e) => e,
                 Err(e) => {
@@ -75,6 +85,9 @@ impl Engine {
                     continue;
                 }
             };
+            // Capture the admitted-set root before `ext` is moved into the
+            // fold; published in BatchFolded so a watcher can recompute it.
+            let input_root = dp_zk::fr_to_bytes32(ext.admitted_root).to_vec();
 
             if let Err(e) = aggregator.fold_step(p.pair.clone(), ext).await {
                 tracing::warn!(
@@ -101,6 +114,7 @@ impl Engine {
                     batch_id: p.batch_id,
                     round_index,
                     pair: p.pair.clone(),
+                    input_root: input_root.clone(),
                 },
             }]) {
                 tracing::warn!(
@@ -278,6 +292,13 @@ impl Engine {
             let bids: Vec<_> = state.book.bids(&pair);
             let asks: Vec<_> = state.book.asks(&pair);
 
+            // The admitted set for this round (#157): every order live in the
+            // book right now, before this tick's fills are applied. Snapshot
+            // the ids here under the state lock; commitments are resolved later
+            // off the lock (secrets→state ordering, see prune_dead_secrets).
+            let admitted_order_ids: Vec<Uuid> =
+                bids.iter().chain(asks.iter()).map(|o| o.id).collect();
+
             let auction_id = Uuid::new_v4();
             let auction_start = Instant::now();
             let result = match dp_auction::run(auction_id, &pair, &bids, &asks) {
@@ -367,6 +388,7 @@ impl Engine {
                     .map(|m| order_matched_to_match(m.bid.clone(), m.ask.clone(), m.price, m.size))
                     .collect(),
                 orders: order_snapshot,
+                admitted_order_ids,
                 auction_at: now,
             });
         }
@@ -447,6 +469,7 @@ mod tests {
                 price: Decimal::ONE,
                 size: Decimal::ONE,
             }],
+            admitted_order_ids: orders.keys().copied().collect(),
             orders,
             auction_at: Utc::now(),
         }

--- a/crates/dp-engine/src/tick.rs
+++ b/crates/dp-engine/src/tick.rs
@@ -615,8 +615,8 @@ mod ivc_tests {
                 use ark_ff::Zero;
                 Ok(dp_zk::folding::FinalProof {
                     proof_bytes: vec![0u8; 32],
-                    z_0: [Fr::zero(); 4],
-                    z_n: [Fr::zero(); 4],
+                    z_0: [Fr::zero(); 5],
+                    z_n: [Fr::zero(); 5],
                     n_steps: 1,
                     policy_hash: Fr::zero(),
                 })

--- a/crates/dp-event/src/event.rs
+++ b/crates/dp-event/src/event.rs
@@ -95,6 +95,13 @@ pub enum EventData {
         batch_id: Uuid,
         round_index: u64,
         pair: String,
+        /// Canonical Merkle root over the commitments of every order admitted
+        /// to this round's auction (#157). Folded into the proof's `z[4]`
+        /// chain; published here so a watcher can recompute it from the public
+        /// `OrderPlaced` log and confirm the operator matched only orders that
+        /// were publicly admitted. Empty for events stored before #157.
+        #[serde(default)]
+        input_root: Vec<u8>,
     },
 }
 
@@ -229,6 +236,7 @@ mod tests {
                     batch_id,
                     round_index: 0,
                     pair: "ETH/USDC".into(),
+                    input_root: Vec::new(),
                 },
                 EventType::BatchFolded,
             ),

--- a/crates/dp-zk/CIRCUIT.md
+++ b/crates/dp-zk/CIRCUIT.md
@@ -21,7 +21,7 @@ The `position_limit` is encoded via `signed_to_scalar`: positive integers
 go in the canonical range, negatives via `Fr - x`. The default policy
 uses `2^58`.
 
-## Constraint families (v2)
+## Constraint families (v4)
 
 | # | Family                      | Active-only? | Mechanism                                           |
 |---|-----------------------------|--------------|-----------------------------------------------------|

--- a/crates/dp-zk/CIRCUIT.md
+++ b/crates/dp-zk/CIRCUIT.md
@@ -31,6 +31,7 @@ uses `2^58`.
 | 3b| Uniform clearing price      | Active rows  | `(match_price - clearing_price) * is_active == 0` — every active row settles at the single auction clearing price (#163). |
 | 4 | Min-size, min-price         | All / active | 60-bit ranges on `size`, `price`; diff to floors gated by `is_active`. |
 | 5 | Leg commitment binding      | All rows     | In-circuit Poseidon over `(trader_id, side, lp, size, salt)` reconstructs the commitment, accumulated into `commitments_root`. |
+| 5b| Input-completeness membership (IVC step circuit, #157) | Active rows | Each active leg's reconstructed commitment is proven a leaf of the round's admitted-set Merkle root: `(merkle_root(leg_commit, path) - admitted_root) * is_active == 0`. Ties every settled order to the publicly admitted input set. |
 | 6 | Notional binding            | All rows     | `match_price * match_size` accumulates into `notionals_root`. |
 | 7 | Solvency                    | Active rows  | `balance < 2^60` (60-bit range) AND `balance * 1e8 - notional` fits 120-bit range. |
 | 8 | Position-limit (two-sided)  | Active rows  | For `new_pos = position ± match_size`, `(limit - new_pos)` and `(limit + new_pos)` each fit in 60 bits → `\|new_pos\| ≤ position_limit`. |
@@ -41,6 +42,47 @@ because the Poseidon-friendly `signed_to_scalar` representation puts
 positive integers in `[0, 2^60)` and negatives in `Fr - [1, 2^60]`, both
 range checks together pin `new_pos` to the signed integer interval
 `[-position_limit, position_limit]`.
+
+## IVC state vector (`AuctionStepCircuit`)
+
+The HyperNova step circuit carries a 5-element public state across rounds:
+
+| # | Slot             | Meaning                                                        |
+|---|------------------|----------------------------------------------------------------|
+| 0 | `state_hash`     | Running `poseidon(prev, commitments_root, notionals_root, active_count)`. |
+| 1 | `round_nonce`    | Increments by 1 each folded round.                             |
+| 2 | `policy_hash`    | `poseidon(min_size, min_price, position_limit)`; invariant.    |
+| 3 | `settlement_acc` | Hash-chain over each active match's `(bid_addr, ask_addr, price, size)` — binds on-chain settlement to the proof (#153). |
+| 4 | `admit_chain`    | Hash-chain over each round's admitted-set Merkle root — binds the input set to the proof (#157). |
+
+`z_0 = [0, 0, policy_hash, 0, 0]`. `verify_final` re-checks the whole
+authenticated `z_0`/`z_n` slice, so neither chain can be rewritten while
+presenting a valid proof.
+
+## Input-completeness binding (#157)
+
+The matching proof binds *match validity* and *which orders were settled*,
+but on its own says nothing about *which orders were eligible*. A semi-trusted
+operator could therefore match an order it never published (an off-log
+phantom) against a victim. To close that, each round commits to the
+**admitted set** — the commitments of every order live in the book when the
+auction ran — as a canonical fixed-depth (`2^MERKLE_DEPTH`) Poseidon Merkle
+root (`merkle::admitted_set_root`: leaves sorted by field value, padded with
+the empty leaf). Family 5b proves every settled leg is a member of that root,
+and the root is folded into `admit_chain` (`z[4]`).
+
+A watcher reconstructs the same root from the public `OrderPlaced` /
+`OrderCancelled` / expiry log (the per-round root is also published in the
+`BatchFolded` event) and folds the chain; if it matches the proof's `z_n[4]`,
+no off-log order was matched and the operator did not misrepresent the
+admitted set.
+
+**Scope boundary.** This binds *matched ⊆ admitted set* (no injection) and
+makes the input set transparent. It does **not** force the operator to match
+*every* crossing order — full maximal-matching is prohibitively expensive in
+circuit. Censorship-by-omission (declining to match an order that crosses)
+therefore remains detectable only by an external observer comparing the
+public book against the clearing price, not enforced by the proof.
 
 ## Poseidon vs. Pedersen
 

--- a/crates/dp-zk/src/folding.rs
+++ b/crates/dp-zk/src/folding.rs
@@ -42,7 +42,7 @@ pub struct HyperNovaPublicParams {
 /// Mutable accumulator holding the live HyperNova IVC state.
 pub struct FoldingAccumulator {
     pub(crate) hn: HN,
-    pub z_0: [Fr; 4],
+    pub z_0: [Fr; 5],
     pub n_steps: u64,
 }
 
@@ -51,8 +51,8 @@ pub struct FoldingAccumulator {
 pub struct FinalProof {
     /// Serialized `HN::IVCProof` bytes.
     pub proof_bytes: Vec<u8>,
-    pub z_0: [Fr; 4],
-    pub z_n: [Fr; 4],
+    pub z_0: [Fr; 5],
+    pub z_n: [Fr; 5],
     pub n_steps: u64,
     /// Convenience copy of `z_n[2]` (policy_hash, invariant across rounds).
     pub policy_hash: Fr,
@@ -77,7 +77,7 @@ pub fn generate_params<R: RngCore + CryptoRng>(
 pub fn init_accumulator(
     params: &HyperNovaPublicParams,
     batch_size: usize,
-    z_0: [Fr; 4],
+    z_0: [Fr; 5],
 ) -> Result<FoldingAccumulator, ZkError> {
     let circuit = AuctionStepCircuit { batch_size };
     let params_tuple = (params.prover.clone(), params.verifier.clone());
@@ -106,7 +106,7 @@ pub fn fold_step<R: RngCore + CryptoRng>(
 /// Finalize the IVC chain into a serialized proof.
 pub fn compress_and_finalize(acc: &FoldingAccumulator) -> Result<FinalProof, ZkError> {
     let ivc_proof = acc.hn.ivc_proof();
-    let z_n: [Fr; 4] = ivc_proof.z_i.as_slice().try_into().map_err(|_| {
+    let z_n: [Fr; 5] = ivc_proof.z_i.as_slice().try_into().map_err(|_| {
         ZkError::Ivc(format!(
             "z_i has wrong length (got {})",
             ivc_proof.z_i.len()
@@ -142,8 +142,9 @@ pub fn verify_final(params: &HyperNovaPublicParams, proof: &FinalProof) -> Resul
     // hash `H(i, z_0, z_i, U_i)`), so capture them before `verify` moves the
     // proof. The `FinalProof` convenience copies — which flow on-chain through
     // `ProofPayload::IvcFinal` — must equal them, otherwise a caller could
-    // rewrite the settlement-binding metadata (`z_n[3]`, `policy_hash`) while
-    // still presenting a valid `proof_bytes`.
+    // rewrite the binding metadata (`z_n[3]` settlement chain, `z_n[4]`
+    // admitted-set chain, `policy_hash`) while still presenting a valid
+    // `proof_bytes`. The full-slice equality below covers every state element.
     let authentic_z_0 = ivc_proof.z_0.clone();
     let authentic_z_n = ivc_proof.z_i.clone();
 

--- a/crates/dp-zk/src/lib.rs
+++ b/crates/dp-zk/src/lib.rs
@@ -19,6 +19,7 @@ pub mod commitment_circuit;
 pub mod encoding;
 #[cfg(feature = "ivc")]
 pub mod folding;
+pub mod merkle;
 #[cfg(feature = "ivc")]
 pub mod params;
 pub mod pedersen;
@@ -31,6 +32,10 @@ pub use encoding::{decimal_to_scalar, fr_to_bytes32, EncodingError};
 pub use folding::{
     compress_and_finalize, fold_step, generate_params, init_accumulator, verify_final, FinalProof,
     FoldingAccumulator, HyperNovaPublicParams,
+};
+pub use merkle::{
+    admitted_chain_step, admitted_set_proof, admitted_set_root, root_from_proof, MerkleProof,
+    MERKLE_DEPTH, MERKLE_LEAVES,
 };
 pub use pedersen::{commit_native, OrderCommitmentInput};
 #[cfg(feature = "ivc")]

--- a/crates/dp-zk/src/lib.rs
+++ b/crates/dp-zk/src/lib.rs
@@ -63,4 +63,5 @@ pub enum ZkError {
 }
 
 /// Bumped any time the IVC circuit constraints change.
-pub const CIRCUIT_VERSION: &str = "v3-hypernova";
+/// v4: input-completeness membership + admitted-set chain in `z[4]` (#157).
+pub const CIRCUIT_VERSION: &str = "v4-hypernova";

--- a/crates/dp-zk/src/merkle.rs
+++ b/crates/dp-zk/src/merkle.rs
@@ -1,0 +1,237 @@
+//! Native fixed-depth Poseidon Merkle tree over admitted-order commitments
+//! (input-completeness binding, #157).
+//!
+//! Each auction round commits to the full multiset of order commitments
+//! admitted to that round as a canonical Merkle root. The matching proof
+//! proves every settled leg's commitment is a member of that committed set,
+//! and the per-round root is folded into the IVC state (`z[4]`). A watcher
+//! recomputes the identical root from the public `OrderPlaced` log and checks
+//! it against the proof-bound chain, so a semi-trusted operator cannot match
+//! an order that was never publicly admitted, nor lie about the admitted input
+//! set, without detection.
+//!
+//! The tree is *canonical*: leaves are sorted ascending by field value and the
+//! frontier is padded to `1 << MERKLE_DEPTH` with the empty leaf, so the
+//! operator and any independent watcher derive the same root from the same set
+//! regardless of insertion order. The node hash is `poseidon(left, right)` via
+//! [`hash_two_native`], identical to the in-circuit gadget so engine, prover,
+//! and watcher agree byte-for-byte.
+
+use ark_bn254::Fr;
+use ark_ff::{PrimeField, Zero};
+
+use crate::pedersen::hash_two_native;
+use crate::ZkError;
+
+/// Tree depth. Caps a single round's admitted set at `1 << MERKLE_DEPTH`
+/// orders. `2^8 = 256` is ample for the single-pair MVP; raising it widens the
+/// in-circuit membership cost (one extra Poseidon hash per matched leg per
+/// level) and must be changed in lockstep with the in-circuit gadget in
+/// `step_circuit`.
+pub const MERKLE_DEPTH: usize = 8;
+
+/// Number of leaves in a full tree.
+pub const MERKLE_LEAVES: usize = 1 << MERKLE_DEPTH;
+
+/// The padding leaf for unused slots. Poseidon commitments are ~never zero,
+/// and the watcher pads identically, so zero is an unambiguous "empty" marker.
+#[inline]
+pub fn empty_leaf() -> Fr {
+    Fr::zero()
+}
+
+/// A membership path: the sibling at each level bottom-up, plus the leaf's
+/// position bit at each level (`true` = the current node is the right child,
+/// so the sibling sits on the left).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MerkleProof {
+    pub siblings: [Fr; MERKLE_DEPTH],
+    pub index_bits: [bool; MERKLE_DEPTH],
+}
+
+impl Default for MerkleProof {
+    fn default() -> Self {
+        Self {
+            siblings: [Fr::zero(); MERKLE_DEPTH],
+            index_bits: [false; MERKLE_DEPTH],
+        }
+    }
+}
+
+/// Canonicalize a set of leaves: sort ascending by field value and pad to a
+/// full tree with the empty leaf. Errors if the set exceeds the tree capacity.
+fn canonical_leaves(commitments: &[Fr]) -> Result<Vec<Fr>, ZkError> {
+    if commitments.len() > MERKLE_LEAVES {
+        return Err(ZkError::Witness(format!(
+            "admitted set of {} orders exceeds Merkle capacity {MERKLE_LEAVES} (depth {MERKLE_DEPTH})",
+            commitments.len()
+        )));
+    }
+    let mut leaves = commitments.to_vec();
+    leaves.sort_by_key(|a| a.into_bigint());
+    leaves.resize(MERKLE_LEAVES, empty_leaf());
+    Ok(leaves)
+}
+
+/// Build every tree level bottom-up; `levels[0]` is the padded leaves,
+/// `levels[MERKLE_DEPTH]` is `[root]`.
+fn build_levels(padded_leaves: Vec<Fr>) -> Vec<Vec<Fr>> {
+    let mut levels = Vec::with_capacity(MERKLE_DEPTH + 1);
+    levels.push(padded_leaves);
+    for d in 0..MERKLE_DEPTH {
+        let prev = &levels[d];
+        let mut next = Vec::with_capacity(prev.len() / 2);
+        for pair in prev.chunks(2) {
+            next.push(hash_two_native(pair[0], pair[1]));
+        }
+        levels.push(next);
+    }
+    levels
+}
+
+/// Compute the canonical admitted-set root over `commitments`.
+pub fn admitted_set_root(commitments: &[Fr]) -> Result<Fr, ZkError> {
+    let leaves = canonical_leaves(commitments)?;
+    let levels = build_levels(leaves);
+    Ok(levels[MERKLE_DEPTH][0])
+}
+
+/// Compute the root and a membership proof for `leaf` within `commitments`.
+/// Returns `Ok(None)` if `leaf` is not present in the set.
+pub fn admitted_set_proof(
+    commitments: &[Fr],
+    leaf: Fr,
+) -> Result<Option<(Fr, MerkleProof)>, ZkError> {
+    let leaves = canonical_leaves(commitments)?;
+    let idx = match leaves.iter().position(|&l| l == leaf) {
+        Some(i) => i,
+        None => return Ok(None),
+    };
+    let levels = build_levels(leaves);
+    let root = levels[MERKLE_DEPTH][0];
+
+    let mut siblings = [Fr::zero(); MERKLE_DEPTH];
+    let mut index_bits = [false; MERKLE_DEPTH];
+    let mut node = idx;
+    for (d, sibling) in siblings.iter_mut().enumerate() {
+        let is_right = node & 1 == 1;
+        let sib = if is_right { node - 1 } else { node + 1 };
+        *sibling = levels[d][sib];
+        index_bits[d] = is_right;
+        node /= 2;
+    }
+    Ok(Some((
+        root,
+        MerkleProof {
+            siblings,
+            index_bits,
+        },
+    )))
+}
+
+/// Recompute a root from a leaf and its membership proof — the verifier-side
+/// mirror of the in-circuit gadget. A leaf is a member of the tree with root
+/// `r` iff `root_from_proof(leaf, proof) == r`.
+pub fn root_from_proof(leaf: Fr, proof: &MerkleProof) -> Fr {
+    let mut cur = leaf;
+    for d in 0..MERKLE_DEPTH {
+        cur = if proof.index_bits[d] {
+            hash_two_native(proof.siblings[d], cur)
+        } else {
+            hash_two_native(cur, proof.siblings[d])
+        };
+    }
+    cur
+}
+
+/// Fold one round's admitted-set root into the running chain carried in
+/// `z[4]`. Mirrors the in-circuit `poseidon(prev, root)`. The empty chain
+/// starts at `Fr::zero()` (matching `z_0[4]`), so a watcher reconstructs
+/// `z_n[4]` by folding each settled round's recomputed root in order.
+pub fn admitted_chain_step(prev: Fr, root: Fr) -> Fr {
+    hash_two_native(prev, root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn leaves(vals: &[u64]) -> Vec<Fr> {
+        vals.iter().map(|v| Fr::from(*v)).collect()
+    }
+
+    #[test]
+    fn root_is_independent_of_insertion_order() {
+        let a = admitted_set_root(&leaves(&[3, 1, 2, 9, 7])).unwrap();
+        let b = admitted_set_root(&leaves(&[9, 7, 2, 1, 3])).unwrap();
+        assert_eq!(a, b, "canonical root must not depend on input order");
+    }
+
+    #[test]
+    fn membership_proof_recomputes_the_root() {
+        let set = leaves(&[10, 20, 30, 40, 50]);
+        let (root, _) = admitted_set_proof(&set, Fr::from(30u64))
+            .unwrap()
+            .expect("30 is a member");
+        // The proof for every member must reproduce the single canonical root.
+        for v in [10u64, 20, 30, 40, 50] {
+            let (r, proof) = admitted_set_proof(&set, Fr::from(v)).unwrap().unwrap();
+            assert_eq!(r, root, "all members share one root");
+            assert_eq!(
+                root_from_proof(Fr::from(v), &proof),
+                root,
+                "membership path for {v} must recompute the root"
+            );
+        }
+    }
+
+    #[test]
+    fn root_matches_standalone_root_helper() {
+        let set = leaves(&[5, 6, 7]);
+        let (root, _) = admitted_set_proof(&set, Fr::from(6u64)).unwrap().unwrap();
+        assert_eq!(root, admitted_set_root(&set).unwrap());
+    }
+
+    #[test]
+    fn non_member_yields_no_proof() {
+        let set = leaves(&[1, 2, 3]);
+        assert!(admitted_set_proof(&set, Fr::from(99u64)).unwrap().is_none());
+    }
+
+    #[test]
+    fn wrong_leaf_does_not_verify_against_a_members_path() {
+        let set = leaves(&[1, 2, 3, 4]);
+        let (root, proof) = admitted_set_proof(&set, Fr::from(2u64)).unwrap().unwrap();
+        // A different leaf threaded through the same path must not hit the root.
+        assert_ne!(root_from_proof(Fr::from(7u64), &proof), root);
+    }
+
+    #[test]
+    fn single_element_set_has_a_valid_path() {
+        let set = leaves(&[42]);
+        let (root, proof) = admitted_set_proof(&set, Fr::from(42u64)).unwrap().unwrap();
+        assert_eq!(root_from_proof(Fr::from(42u64), &proof), root);
+    }
+
+    #[test]
+    fn capacity_overflow_is_rejected() {
+        let set: Vec<Fr> = (0..(MERKLE_LEAVES as u64 + 1)).map(Fr::from).collect();
+        assert!(admitted_set_root(&set).is_err());
+        assert!(admitted_set_proof(&set, Fr::from(0u64)).is_err());
+    }
+
+    #[test]
+    fn chain_is_deterministic_and_order_sensitive() {
+        let r1 = Fr::from(111u64);
+        let r2 = Fr::from(222u64);
+        let z0 = Fr::zero();
+        let forward = admitted_chain_step(admitted_chain_step(z0, r1), r2);
+        let reordered = admitted_chain_step(admitted_chain_step(z0, r2), r1);
+        assert_eq!(
+            forward,
+            admitted_chain_step(admitted_chain_step(z0, r1), r2),
+            "chain must be deterministic"
+        );
+        assert_ne!(forward, reordered, "chain must depend on round order");
+    }
+}

--- a/crates/dp-zk/src/merkle.rs
+++ b/crates/dp-zk/src/merkle.rs
@@ -67,6 +67,15 @@ fn canonical_leaves(commitments: &[Fr]) -> Result<Vec<Fr>, ZkError> {
             commitments.len()
         )));
     }
+    // The padding leaf is `empty_leaf()` (zero), and membership is decided by
+    // field-element equality. A real commitment equal to the empty leaf would
+    // be indistinguishable from a padded slot, so reject it rather than rely on
+    // the "Poseidon commitments are ~never zero" assumption holding silently.
+    if commitments.iter().any(|c| *c == empty_leaf()) {
+        return Err(ZkError::Witness(
+            "admitted-set commitment collides with the empty (padding) leaf".to_string(),
+        ));
+    }
     let mut leaves = commitments.to_vec();
     leaves.sort_by_key(|a| a.into_bigint());
     leaves.resize(MERKLE_LEAVES, empty_leaf());
@@ -196,6 +205,13 @@ mod tests {
     fn non_member_yields_no_proof() {
         let set = leaves(&[1, 2, 3]);
         assert!(admitted_set_proof(&set, Fr::from(99u64)).unwrap().is_none());
+    }
+
+    #[test]
+    fn commitment_colliding_with_empty_leaf_is_rejected() {
+        let set = vec![Fr::from(1u64), empty_leaf(), Fr::from(3u64)];
+        assert!(admitted_set_root(&set).is_err());
+        assert!(admitted_set_proof(&set, Fr::from(1u64)).is_err());
     }
 
     #[test]

--- a/crates/dp-zk/src/params/mod.rs
+++ b/crates/dp-zk/src/params/mod.rs
@@ -30,9 +30,9 @@ pub struct ParamsMetadata {
 /// companion `<dir>/params_metadata.json` with a SHA-256 checksum and
 /// circuit version string.
 ///
-/// On a subsequent load the caller should verify `metadata.circuit_version`
-/// matches [`CIRCUIT_VERSION`] and re-compute the SHA-256 before trusting
-/// the bytes.
+/// On a subsequent load [`load_metadata`] verifies `circuit_version` matches
+/// [`CIRCUIT_VERSION`]; the caller should still re-compute the SHA-256 before
+/// trusting the bytes.
 pub fn save(
     params: &HyperNovaPublicParams,
     dir: &Path,
@@ -63,9 +63,23 @@ pub fn save(
 
 /// Load the [`ParamsMetadata`] from `<dir>/params_metadata.json` without
 /// deserializing the (potentially large) params binary.
+///
+/// Rejects params whose `circuit_version` does not match this crate's
+/// [`CIRCUIT_VERSION`], so a stale on-disk cache from an earlier circuit
+/// revision can never be silently trusted. The caller is still responsible
+/// for re-computing and checking the SHA-256 before trusting the bytes.
 pub fn load_metadata(dir: &Path) -> Result<ParamsMetadata, ZkError> {
     let raw = fs::read_to_string(dir.join(META_FILE))?;
-    serde_json::from_str(&raw).map_err(|e| ZkError::Serialize(e.to_string()))
+    let meta: ParamsMetadata =
+        serde_json::from_str(&raw).map_err(|e| ZkError::Serialize(e.to_string()))?;
+    if meta.circuit_version != CIRCUIT_VERSION {
+        return Err(ZkError::Setup(format!(
+            "params circuit version mismatch: expected {CIRCUIT_VERSION}, found {} \
+             (regenerate params for the current circuit)",
+            meta.circuit_version
+        )));
+    }
+    Ok(meta)
 }
 
 /// Read the raw prover-param bytes from `<dir>/public_params.bin`.

--- a/crates/dp-zk/src/step_circuit.rs
+++ b/crates/dp-zk/src/step_circuit.rs
@@ -3,6 +3,7 @@ use std::borrow::Borrow;
 use ark_bn254::Fr;
 use ark_crypto_primitives::sponge::constraints::CryptographicSpongeVar;
 use ark_crypto_primitives::sponge::poseidon::constraints::PoseidonSpongeVar;
+use ark_crypto_primitives::sponge::poseidon::PoseidonConfig;
 use ark_ff::{One, Zero};
 use ark_r1cs_std::alloc::{AllocVar, AllocationMode};
 use ark_r1cs_std::eq::EqGadget;
@@ -13,7 +14,8 @@ use ark_relations::gr1cs::{ConstraintSystemRef, Namespace, SynthesisError};
 use folding_schemes::{frontend::FCircuit, Error};
 
 use crate::encoding::SCALE_FACTOR_I128;
-use crate::pedersen::{bytes_to_scalar, poseidon_config};
+use crate::merkle::{admitted_set_proof, admitted_set_root, MerkleProof, MERKLE_DEPTH};
+use crate::pedersen::{bytes_to_scalar, commit_native, poseidon_config, OrderCommitmentInput};
 use crate::witness::BatchWitness;
 use crate::ZkError;
 
@@ -57,6 +59,12 @@ pub struct CircuitMatchNative {
     pub match_price: Fr,
     pub match_size: Fr,
     pub is_active: Fr,
+
+    /// Membership paths proving the `bid` / `ask` commitments are leaves of the
+    /// round's admitted-set Merkle root (#157). Default (all-zero) on inactive
+    /// padding rows — the in-circuit membership check is gated by `is_active`.
+    pub bid_path: MerkleProof,
+    pub ask_path: MerkleProof,
 }
 
 impl Default for CircuitMatchNative {
@@ -83,6 +91,8 @@ impl Default for CircuitMatchNative {
             match_price: zero,
             match_size: zero,
             is_active: zero,
+            bid_path: MerkleProof::default(),
+            ask_path: MerkleProof::default(),
         }
     }
 }
@@ -98,6 +108,11 @@ pub struct AuctionExternalInputs {
     /// match in [`Self::from_witness`]; the honest engine applies one volume-
     /// maximizing price to every match, so all rows already equal it.
     pub clearing_price: Fr,
+    /// Canonical Merkle root over the commitments of every order admitted to
+    /// this auction round (#157). Folded into `z[4]` so a watcher can recompute
+    /// it from the public `OrderPlaced` log and confirm the operator did not
+    /// match an order outside the publicly admitted set.
+    pub admitted_root: Fr,
     pub matches: Vec<CircuitMatchNative>,
 }
 
@@ -108,15 +123,18 @@ impl Default for AuctionExternalInputs {
             min_price: Fr::zero(),
             position_limit: Fr::zero(),
             clearing_price: Fr::zero(),
+            admitted_root: Fr::zero(),
             matches: Vec::new(),
         }
     }
 }
 
 impl AuctionExternalInputs {
-    /// Convert a [`BatchWitness`] + per-match prices/sizes into
-    /// [`AuctionExternalInputs`], padding inactive rows to `batch_size`.
-    pub fn from_witness(
+    /// Build the policy + match rows from a [`BatchWitness`], padding inactive
+    /// rows to `batch_size`. Leaves `admitted_root` and every per-row
+    /// membership path at their defaults; callers finish the value via
+    /// [`Self::attach_membership`].
+    fn build_rows(
         witness: &BatchWitness,
         match_prices: &[rust_decimal::Decimal],
         match_sizes: &[rust_decimal::Decimal],
@@ -201,6 +219,8 @@ impl AuctionExternalInputs {
                 match_price: decimal_to_scalar(match_prices[i])?,
                 match_size: decimal_to_scalar(match_sizes[i])?,
                 is_active: Fr::one(),
+                bid_path: MerkleProof::default(),
+                ask_path: MerkleProof::default(),
             });
         }
 
@@ -223,9 +243,105 @@ impl AuctionExternalInputs {
             min_price,
             position_limit,
             clearing_price,
+            admitted_root: Fr::zero(),
             matches,
         })
     }
+
+    /// Convert a [`BatchWitness`] + per-match prices/sizes into
+    /// [`AuctionExternalInputs`]. The admitted set defaults to *exactly the
+    /// matched legs*, so every settled order is trivially a member — useful in
+    /// tests and as a safe fallback. The engine instead calls
+    /// [`Self::from_witness_with_admitted`] with the full live order book (a
+    /// superset), which is what turns membership into a real
+    /// input-completeness constraint (#157).
+    pub fn from_witness(
+        witness: &BatchWitness,
+        match_prices: &[rust_decimal::Decimal],
+        match_sizes: &[rust_decimal::Decimal],
+        batch_size: usize,
+    ) -> Result<Self, ZkError> {
+        let mut ext = Self::build_rows(witness, match_prices, match_sizes, batch_size)?;
+        let admitted: Vec<Fr> = ext
+            .matches
+            .iter()
+            .filter(|m| m.is_active == Fr::one())
+            .flat_map(|m| [leaf_of(m, true), leaf_of(m, false)])
+            .collect();
+        ext.attach_membership(&admitted)?;
+        Ok(ext)
+    }
+
+    /// Like [`Self::from_witness`] but binds the round to an explicit admitted
+    /// set — the commitments of *every* order live in the book at tick time.
+    /// Membership then proves each settled leg was drawn from the publicly
+    /// admitted set, not injected off-log (#157). Errors if a matched leg's
+    /// commitment is absent from `admitted_commitments` (an operator bug — a
+    /// settled order that was never admitted) or if the set exceeds the tree
+    /// capacity.
+    pub fn from_witness_with_admitted(
+        witness: &BatchWitness,
+        match_prices: &[rust_decimal::Decimal],
+        match_sizes: &[rust_decimal::Decimal],
+        batch_size: usize,
+        admitted_commitments: &[Fr],
+    ) -> Result<Self, ZkError> {
+        let mut ext = Self::build_rows(witness, match_prices, match_sizes, batch_size)?;
+        ext.attach_membership(admitted_commitments)?;
+        Ok(ext)
+    }
+
+    /// Compute the admitted-set root and fill in each active row's membership
+    /// path against `admitted_commitments`.
+    fn attach_membership(&mut self, admitted_commitments: &[Fr]) -> Result<(), ZkError> {
+        let root = admitted_set_root(admitted_commitments)?;
+        for m in self.matches.iter_mut() {
+            if m.is_active != Fr::one() {
+                // Padding rows keep default (all-zero) paths; the in-circuit
+                // membership check is gated off by `is_active`.
+                continue;
+            }
+            let bid_leaf = leaf_of(m, true);
+            let ask_leaf = leaf_of(m, false);
+            let (_, bid_path) =
+                admitted_set_proof(admitted_commitments, bid_leaf)?.ok_or_else(|| {
+                    ZkError::Witness("matched bid leg absent from admitted set".into())
+                })?;
+            let (_, ask_path) =
+                admitted_set_proof(admitted_commitments, ask_leaf)?.ok_or_else(|| {
+                    ZkError::Witness("matched ask leg absent from admitted set".into())
+                })?;
+            m.bid_path = bid_path;
+            m.ask_path = ask_path;
+        }
+        self.admitted_root = root;
+        Ok(())
+    }
+}
+
+/// The Poseidon commitment of one leg of a match, computed from the row's
+/// scalar fields. Identical to the in-circuit `bid_commit` / `ask_commit`
+/// (and to the engine's persisted `OrderPlaced` commitment), so a matched
+/// leg's leaf lines up with its entry in the admitted set.
+fn leaf_of(m: &CircuitMatchNative, is_bid: bool) -> Fr {
+    let input = if is_bid {
+        OrderCommitmentInput {
+            trader_id: m.bid_trader,
+            side: m.bid_side,
+            limit_price: m.bid_limit_price,
+            size: m.bid_order_size,
+            salt: m.bid_salt,
+        }
+    } else {
+        OrderCommitmentInput {
+            trader_id: m.ask_trader,
+            side: m.ask_side,
+            limit_price: m.ask_limit_price,
+            size: m.ask_order_size,
+            salt: m.ask_salt,
+        }
+    };
+    commit_native(&input)
 }
 
 // ─── In-circuit (variable) data types ────────────────────────────────────────
@@ -254,6 +370,17 @@ pub struct CircuitMatchVar {
     pub match_price: FpVar<Fr>,
     pub match_size: FpVar<Fr>,
     pub is_active: FpVar<Fr>,
+    pub bid_path: MerklePathVar,
+    pub ask_path: MerklePathVar,
+}
+
+/// In-circuit version of [`MerkleProof`]: a fixed `MERKLE_DEPTH` siblings and
+/// position bits. Allocated at constant width so the constraint system shape
+/// never depends on the admitted set's size.
+#[derive(Clone, Debug)]
+pub struct MerklePathVar {
+    pub siblings: Vec<FpVar<Fr>>,
+    pub index_bits: Vec<Boolean<Fr>>,
 }
 
 /// In-circuit version of [`AuctionExternalInputs`].
@@ -263,7 +390,35 @@ pub struct AuctionExternalInputsVar {
     pub min_price: FpVar<Fr>,
     pub position_limit: FpVar<Fr>,
     pub clearing_price: FpVar<Fr>,
+    pub admitted_root: FpVar<Fr>,
     pub matches: Vec<CircuitMatchVar>,
+}
+
+/// Allocate a fixed-width membership path. Always exactly `MERKLE_DEPTH` rows
+/// so preprocessing (run on the empty default) and proving derive the same CCS.
+fn alloc_merkle_path(
+    cs: &ConstraintSystemRef<Fr>,
+    proof: &MerkleProof,
+    mode: AllocationMode,
+) -> Result<MerklePathVar, SynthesisError> {
+    let mut siblings = Vec::with_capacity(MERKLE_DEPTH);
+    let mut index_bits = Vec::with_capacity(MERKLE_DEPTH);
+    for d in 0..MERKLE_DEPTH {
+        siblings.push(FpVar::new_variable(
+            cs.clone(),
+            || Ok(proof.siblings[d]),
+            mode,
+        )?);
+        index_bits.push(Boolean::new_variable(
+            cs.clone(),
+            || Ok(proof.index_bits[d]),
+            mode,
+        )?);
+    }
+    Ok(MerklePathVar {
+        siblings,
+        index_bits,
+    })
 }
 
 impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
@@ -281,6 +436,7 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
         let min_price = FpVar::new_variable(cs.clone(), || Ok(native.min_price), mode)?;
         let position_limit = FpVar::new_variable(cs.clone(), || Ok(native.position_limit), mode)?;
         let clearing_price = FpVar::new_variable(cs.clone(), || Ok(native.clearing_price), mode)?;
+        let admitted_root = FpVar::new_variable(cs.clone(), || Ok(native.admitted_root), mode)?;
 
         // Always allocate a fixed `IVC_BATCH_SIZE` rows so the constraint system
         // is identical whether `native` is the empty `default()` (used by
@@ -317,6 +473,8 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
                 match_price: FpVar::new_variable(cs.clone(), || Ok(cm.match_price), mode)?,
                 match_size: FpVar::new_variable(cs.clone(), || Ok(cm.match_size), mode)?,
                 is_active: FpVar::new_variable(cs.clone(), || Ok(cm.is_active), mode)?,
+                bid_path: alloc_merkle_path(&cs, &cm.bid_path, mode)?,
+                ask_path: alloc_merkle_path(&cs, &cm.ask_path, mode)?,
             });
         }
 
@@ -325,6 +483,7 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
             min_price,
             position_limit,
             clearing_price,
+            admitted_root,
             matches,
         })
     }
@@ -334,8 +493,9 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
 
 /// IVC step circuit for HyperNova.
 ///
-/// IVC state: `z_i = [state_hash, round_nonce, policy_hash, settlement_acc]`
-/// (4 Fr elements).
+/// IVC state:
+/// `z_i = [state_hash, round_nonce, policy_hash, settlement_acc, admit_chain]`
+/// (5 Fr elements).
 ///
 /// Each step folds one auction batch, enforcing the constraint families, then
 /// updates the state:
@@ -345,7 +505,10 @@ impl AllocVar<AuctionExternalInputs, Fr> for AuctionExternalInputsVar {
 /// new_state_hash = poseidon(z_i[0], commitments_root, notionals_root, active_count)
 /// // settlement_acc folds each active row's tuple (bid_addr, ask_addr,
 /// // match_price, match_size) into a running Poseidon chain (#153)
-/// z_{i+1} = [new_state_hash, z_i[1] + 1, z_i[2], settlement_acc']
+/// // each active leg's commitment is proven a member of the round's
+/// // admitted-set Merkle root (#157); admit_chain folds that root in:
+/// //   admit_chain' = poseidon(z_i[4], admitted_root)
+/// z_{i+1} = [new_state_hash, z_i[1] + 1, z_i[2], settlement_acc', admit_chain']
 /// ```
 #[derive(Clone, Debug)]
 pub struct AuctionStepCircuit {
@@ -362,7 +525,7 @@ impl FCircuit<Fr> for AuctionStepCircuit {
     }
 
     fn state_len(&self) -> usize {
-        4 // [state_hash, round_nonce, policy_hash, settlement_acc]
+        5 // [state_hash, round_nonce, policy_hash, settlement_acc, admit_chain]
     }
 
     fn generate_step_constraints(
@@ -383,6 +546,11 @@ impl FCircuit<Fr> for AuctionStepCircuit {
         // means the contract folds only real matches, with no padding-length
         // coupling to the circuit's fixed `batch_size`.
         let mut settlement_acc = z_i[3].clone();
+        // Running chain over each round's admitted-set Merkle root (#157). The
+        // root is also the value each active leg's membership path must verify
+        // to, so folding it here binds the proof to the exact input set a
+        // watcher recomputes from the public OrderPlaced log.
+        let admit_chain_prev = z_i[4].clone();
 
         let cfg = poseidon_config();
         let one = FpVar::<Fr>::one();
@@ -507,6 +675,21 @@ impl FCircuit<Fr> for AuctionStepCircuit {
             )?;
             let ask_commit = ask_sponge.squeeze_field_elements(1)?[0].clone();
 
+            // ── Family 5b: input-completeness membership (#157) ──────────────
+            // Each active leg's commitment must be a leaf of the round's
+            // admitted-set Merkle root. Together with a watcher recomputing
+            // that root from the public OrderPlaced log (and `admit_chain`
+            // binding it into z_n), this proves every settled order was part of
+            // the publicly admitted set — the operator cannot match an off-log
+            // phantom order. Gated by `is_active`: padding rows carry a
+            // default all-zero path and impose no constraint on the root.
+            let bid_member_root = merkle_root_var(cs.clone(), &cfg, &bid_commit, &cm.bid_path)?;
+            ((&bid_member_root - &external_inputs.admitted_root) * &is_active)
+                .enforce_equal(&zero)?;
+            let ask_member_root = merkle_root_var(cs.clone(), &cfg, &ask_commit, &cm.ask_path)?;
+            ((&ask_member_root - &external_inputs.admitted_root) * &is_active)
+                .enforce_equal(&zero)?;
+
             // ── Family 6: notional = price * size ────────────────────────────
             let notional = &m_price * &m_size;
 
@@ -598,13 +781,42 @@ impl FCircuit<Fr> for AuctionStepCircuit {
 
         let new_round_nonce = &round_nonce + &one;
 
+        // ── Admitted-set chain (#157) ───────────────────────────────────────
+        // Fold this round's admitted-set root into the running chain. Mirrors
+        // the native `admitted_chain_step` (poseidon(prev, root)) so a watcher
+        // reproduces z_n[4] by folding each round's recomputed root in order.
+        let mut admit_sponge = PoseidonSpongeVar::<Fr>::new(cs.clone(), &cfg);
+        admit_sponge.absorb(&[admit_chain_prev, external_inputs.admitted_root.clone()].as_ref())?;
+        let new_admit_chain = admit_sponge.squeeze_field_elements(1)?[0].clone();
+
         Ok(vec![
             new_state_hash,
             new_round_nonce,
             policy_hash,
             settlement_acc,
+            new_admit_chain,
         ])
     }
+}
+
+/// Recompute a Merkle root from a leaf and its membership path — the in-circuit
+/// mirror of `merkle::root_from_proof`. `index_bit == 1` means the current node
+/// is the right child (sibling on the left), matching the native convention.
+fn merkle_root_var(
+    cs: ConstraintSystemRef<Fr>,
+    cfg: &PoseidonConfig<Fr>,
+    leaf: &FpVar<Fr>,
+    path: &MerklePathVar,
+) -> Result<FpVar<Fr>, SynthesisError> {
+    let mut cur = leaf.clone();
+    for (sib, bit) in path.siblings.iter().zip(path.index_bits.iter()) {
+        let left = FpVar::conditionally_select(bit, sib, &cur)?;
+        let right = FpVar::conditionally_select(bit, &cur, sib)?;
+        let mut s = PoseidonSpongeVar::<Fr>::new(cs.clone(), cfg);
+        s.absorb(&[left, right].as_ref())?;
+        cur = s.squeeze_field_elements(1)?[0].clone();
+    }
+    Ok(cur)
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -626,6 +838,7 @@ fn enforce_range_n(value: &FpVar<Fr>, n: usize) -> Result<(), SynthesisError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::merkle::admitted_chain_step;
     use crate::pedersen::derive_trader_id;
     use crate::witness::{BatchWitness, MatchWitness, OrderLegWitness, DEFAULT_POLICY};
     use ark_crypto_primitives::sponge::poseidon::PoseidonSponge;
@@ -710,8 +923,8 @@ mod tests {
         let mut s = PoseidonSponge::<Fr>::new(&cfg);
         s.absorb(&vec![ext.min_size, ext.min_price, ext.position_limit]);
         let policy_hash = s.squeeze_field_elements::<Fr>(1)[0];
-        // [state_hash, round_nonce, policy_hash, settlement_acc]
-        vec![Fr::zero(), Fr::zero(), policy_hash, Fr::zero()]
+        // [state_hash, round_nonce, policy_hash, settlement_acc, admit_chain]
+        vec![Fr::zero(), Fr::zero(), policy_hash, Fr::zero(), Fr::zero()]
     }
 
     /// Native mirror of the in-circuit settlement hash-chain (#153): folds
@@ -966,6 +1179,101 @@ mod tests {
         assert!(
             satisfied,
             "expected satisfied: two active matches at the same price"
+        );
+    }
+
+    // ── Input-completeness membership (#157) ─────────────────────────────────
+
+    #[test]
+    fn admit_chain_advances_with_round_root() {
+        let (w, prices, sizes) = sample_witness();
+        let ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 2).unwrap();
+        let root = ext.admitted_root;
+        let z_0 = initial_z(&ext);
+        let circuit = AuctionStepCircuit::new(2).unwrap();
+        let (satisfied, z_next) = run_step(&circuit, z_0.clone(), ext);
+        assert!(satisfied, "valid round with membership paths must satisfy");
+        assert_eq!(
+            z_next[4],
+            admitted_chain_step(z_0[4], root),
+            "z[4] must fold poseidon(prev, admitted_root) — the watcher recomputes this"
+        );
+        assert_ne!(
+            z_next[4], z_0[4],
+            "a real round must advance the admit chain"
+        );
+    }
+
+    /// The engine's real case: the admitted set is the full live book, a
+    /// superset of the matched legs. Membership still holds for every settled
+    /// leg.
+    #[test]
+    fn step_accepts_admitted_superset() {
+        let (w, prices, sizes) = sample_witness();
+        let base = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 2).unwrap();
+        let mut admitted: Vec<Fr> = base
+            .matches
+            .iter()
+            .filter(|m| m.is_active == Fr::one())
+            .flat_map(|m| [leaf_of(m, true), leaf_of(m, false)])
+            .collect();
+        // Unrelated commitments standing in for other admitted-but-unmatched
+        // orders that sit in the book this round.
+        admitted.extend([Fr::from(7u64), Fr::from(99u64), Fr::from(123_456u64)]);
+        let ext =
+            AuctionExternalInputs::from_witness_with_admitted(&w, &prices, &sizes, 2, &admitted)
+                .unwrap();
+        let z_0 = initial_z(&ext);
+        let circuit = AuctionStepCircuit::new(2).unwrap();
+        let (satisfied, _) = run_step(&circuit, z_0, ext);
+        assert!(
+            satisfied,
+            "matched legs must be members of the larger admitted set"
+        );
+    }
+
+    /// A settled order whose commitment was never admitted is rejected at
+    /// witness-build time — there is no membership path to give it.
+    #[test]
+    fn from_witness_with_admitted_rejects_unadmitted_match() {
+        let (w, prices, sizes) = sample_witness();
+        let admitted = vec![Fr::from(1u64), Fr::from(2u64)]; // omits the matched legs
+        let res =
+            AuctionExternalInputs::from_witness_with_admitted(&w, &prices, &sizes, 2, &admitted);
+        assert!(
+            res.is_err(),
+            "a settled order absent from the admitted set must be rejected"
+        );
+    }
+
+    /// The binding property: if the operator claims a different admitted root
+    /// than the one the membership paths actually prove (e.g. to hide a
+    /// censored input set), the in-circuit membership check fails.
+    #[test]
+    fn step_rejects_tampered_admitted_root() {
+        let (w, prices, sizes) = sample_witness();
+        let mut ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 2).unwrap();
+        ext.admitted_root += Fr::from(1u64);
+        let z_0 = initial_z(&ext);
+        let circuit = AuctionStepCircuit::new(2).unwrap();
+        let (satisfied, _) = run_step(&circuit, z_0, ext);
+        assert!(
+            !satisfied,
+            "membership must fail when the bound root is not the one the paths prove"
+        );
+    }
+
+    #[test]
+    fn step_rejects_tampered_membership_path() {
+        let (w, prices, sizes) = sample_witness();
+        let mut ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 2).unwrap();
+        ext.matches[0].bid_path.siblings[0] += Fr::from(1u64);
+        let z_0 = initial_z(&ext);
+        let circuit = AuctionStepCircuit::new(2).unwrap();
+        let (satisfied, _) = run_step(&circuit, z_0, ext);
+        assert!(
+            !satisfied,
+            "a corrupted membership path must not verify to the bound root"
         );
     }
 }

--- a/crates/dp-zk/tests/ivc.rs
+++ b/crates/dp-zk/tests/ivc.rs
@@ -84,15 +84,16 @@ fn sample_ext(batch_size: usize) -> AuctionExternalInputs {
         .expect("sample_ext: from_witness")
 }
 
-/// Compute `z_0 = [0, 0, policy_hash, 0]` where
-/// `policy_hash = poseidon(min_size, min_price, position_limit)` and the
-/// trailing slot is the empty settlement hash-chain accumulator.
-fn z_0_for(ext: &AuctionExternalInputs) -> [Fr; 4] {
+/// Compute `z_0 = [0, 0, policy_hash, 0, 0]` where
+/// `policy_hash = poseidon(min_size, min_price, position_limit)`; the two
+/// trailing slots are the empty settlement hash-chain (#153) and admitted-set
+/// chain (#157) accumulators.
+fn z_0_for(ext: &AuctionExternalInputs) -> [Fr; 5] {
     let cfg = poseidon_config();
     let mut s = PoseidonSponge::<Fr>::new(&cfg);
     s.absorb(&vec![ext.min_size, ext.min_price, ext.position_limit]);
     let policy_hash = s.squeeze_field_elements::<Fr>(1)[0];
-    [Fr::zero(), Fr::zero(), policy_hash, Fr::zero()]
+    [Fr::zero(), Fr::zero(), policy_hash, Fr::zero(), Fr::zero()]
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +149,13 @@ fn fold_single_step_verifies() {
         proof.z_n[3],
         Fr::zero(),
         "settlement_acc must change after folding an active match"
+    );
+    // admit_chain (#157) folds the round's admitted-set root, so it too leaves
+    // the zero seed after a real round.
+    assert_ne!(
+        proof.z_n[4],
+        Fr::zero(),
+        "admit_chain must change after folding a round with an admitted set"
     );
 }
 


### PR DESCRIPTION
Closes #157

The matching proof showed the published matches were valid and bound which orders got settled, but nothing tied those settled orders to the set actually admitted to a round. A semi-trusted operator could drop a victim's order or match one it never published (an off-log phantom) and the proof still verified. That's the fairness half of the trust model, and without it the "trustless clearing price" claim doesn't hold.

Each round now commits to its admitted set, the commitments of every order live in the book when the auction ran, as a canonical fixed-depth Poseidon Merkle root. The step circuit proves every settled leg's commitment is a member of that root and folds the root into a new IVC state slot `z[4]`, mirroring the settlement chain already in `z[3]`. The engine snapshots the admitted order ids under the state lock and resolves them to commitment leaves off the lock (the secrets lock can't be taken under the state lock; the order is secrets then state), then binds membership against the full book. The per-round root is published in the `BatchFolded` event so a watcher can recompute it from the public `OrderPlaced` log and check it against `z[4]`.

This gets you matched-subset-of-admitted (no phantom injection) plus input-set transparency. It does not force the operator to match every crossing order; full maximal matching is too costly in circuit, so omission still rests on operator honesty plus public-book observation. That boundary is written up in `CIRCUIT.md`. On-chain enforcement of `z[4]` rides along with the Phase 4 contract work (the stub decider verifier ignores public IO today), so what lands here is the in-circuit and watcher-side binding.

Verified: merkle and step-circuit unit tests including five new membership cases, the full engine suite (138), and the ignored IVC fold+verify tests through 60 rounds. Membership didn't move prove time, preprocessing dominates at ~13s for a single step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Merkle tree-based verification to ensure matched orders belong to the operator's explicitly admitted set, preventing unauthorized order matching.
  * Extended the proof format to track an admitted-set chain accumulator across auction rounds.

* **Documentation**
  * Updated circuit documentation to describe the new input-completeness verification mechanism and expanded proof state structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->