### PR TITLE
auction: Make fill allocation deterministic via (price, seq)

### DIFF
--- a/crates/dp-auction/src/lib.rs
+++ b/crates/dp-auction/src/lib.rs
@@ -22,6 +22,22 @@ pub struct Match {
     pub size: Decimal,
 }
 
+/// Run one batch auction over the orders for `pair` and return the matches,
+/// or `None` if the book does not cross.
+///
+/// Matching is **strict price-time priority** under the deterministic total
+/// order `(price, seq)`: best price first, ties broken by the monotonic
+/// placement `seq` (earliest placement wins). That ordering is established
+/// here, inside `run`, rather than relying on the caller passing pre-sorted
+/// slices — so the result is identical regardless of input order, and
+/// identical between live execution and event-log replay. `seq` is unique per
+/// order, making this a strict total order with no dependence on sort
+/// stability. See ADR 0005 for why price-time (not pro-rata) and why `seq`
+/// (not `submitted_at`).
+///
+/// Allocation is greedy under that order: the highest-priority order on each
+/// side is filled as far as the opposing liquidity allows before the next is
+/// considered. There is no pro-rata split.
 #[must_use]
 pub fn run(auction_id: Uuid, pair: &str, bids: &[Order], asks: &[Order]) -> Option<AuctionResult> {
     if bids.is_empty() || asks.is_empty() {
@@ -30,8 +46,11 @@ pub fn run(auction_id: Uuid, pair: &str, bids: &[Order], asks: &[Order]) -> Opti
 
     let mut bids = bids.to_vec();
     let mut asks = asks.to_vec();
-    bids.sort_by_key(|o| std::cmp::Reverse(o.price));
-    asks.sort_by_key(|o| o.price);
+    // Total order: best price first, then earliest placement (seq asc). `seq`
+    // is unique per order, so this fully determines priority without relying
+    // on the caller's input order or on sort stability.
+    bids.sort_by(|a, b| b.price.cmp(&a.price).then(a.seq.cmp(&b.seq)));
+    asks.sort_by(|a, b| a.price.cmp(&b.price).then(a.seq.cmp(&b.seq)));
 
     if bids[0].price < asks[0].price {
         return None;
@@ -100,6 +119,11 @@ fn cumulative_volume(orders: &[Order], pred: impl Fn(&Order) -> bool) -> Decimal
         .sum()
 }
 
+/// Greedy fill under strict price-time priority. `bids`/`asks` arrive already
+/// in `(price, seq)` order (established in [`run`]); each order is matched in
+/// that order against the opposing side, highest priority first, until its
+/// remaining size is exhausted. Self-trades (orders sharing a
+/// `commitment_key`) are skipped.
 fn match_orders(bids: &[Order], asks: &[Order], price: Decimal) -> Vec<Match> {
     let mut eligible_bids: Vec<Order> = bids
         .iter()
@@ -149,6 +173,23 @@ fn match_orders(bids: &[Order], asks: &[Order], price: Decimal) -> Vec<Match> {
         }
     }
 
+    // Conservation invariant: every match debits the bid and credits the ask
+    // by the same `fill_size` and prices at the clearing price, so volume is
+    // conserved leg-for-leg (Σ bid fills == Σ ask fills) and no fill happens
+    // off the clearing price. True by construction here; asserted in
+    // debug/test builds to catch any regression, with no release-build cost.
+    debug_assert!(
+        matches
+            .iter()
+            .all(|m| m.price == price && m.bid.size == m.ask.size),
+        "every fill must price at the clearing price with equal bid/ask legs"
+    );
+    debug_assert_eq!(
+        matches.iter().map(|m| m.bid.size).sum::<Decimal>(),
+        matches.iter().map(|m| m.ask.size).sum::<Decimal>(),
+        "sum of bid fills must equal sum of ask fills"
+    );
+
     matches
 }
 
@@ -171,6 +212,7 @@ mod tests {
             encrypted_payload: vec![],
             submitted_at: Utc::now(),
             expires_at: Utc::now() + chrono::Duration::minutes(10),
+            seq: 0,
         }
     }
 
@@ -258,5 +300,112 @@ mod tests {
         let result = run(test_auction_id(), "TEST/USD", &bids, &asks).expect("expected result");
         assert_eq!(result.clearing_price, Decimal::from(100));
         assert_eq!(result.matched_volume, Decimal::from(20));
+    }
+
+    /// Issue #161: every auction must conserve volume leg-for-leg and price
+    /// every fill at the single clearing price.
+    #[test]
+    fn fills_conserve_volume_and_clear_at_one_price() {
+        let bids = vec![
+            new_order(Side::Buy, 1810, 5),
+            new_order(Side::Buy, 1800, 10),
+        ];
+        let asks = vec![
+            new_order(Side::Sell, 1790, 8),
+            new_order(Side::Sell, 1795, 4),
+        ];
+
+        let result = run(test_auction_id(), "TEST/USD", &bids, &asks).expect("expected result");
+
+        let bid_total: Decimal = result.matches.iter().map(|m| m.bid.size).sum();
+        let ask_total: Decimal = result.matches.iter().map(|m| m.ask.size).sum();
+
+        assert_eq!(bid_total, ask_total, "Σ bid fills must equal Σ ask fills");
+        assert_eq!(
+            bid_total, result.matched_volume,
+            "matched_volume must equal the conserved fill total"
+        );
+        assert!(
+            result
+                .matches
+                .iter()
+                .all(|m| m.price == result.clearing_price),
+            "every fill must price at the clearing price"
+        );
+    }
+
+    /// Issue #161: among same-price orders the lower `seq` (earlier placement)
+    /// fills first; the marginal order takes the remainder. This is the
+    /// documented price-time priority rule.
+    #[test]
+    fn strict_price_time_priority_breaks_ties_by_seq() {
+        let mut bid = new_order(Side::Buy, 1790, 8);
+        bid.seq = 1;
+        let mut ask_early = new_order(Side::Sell, 1790, 6);
+        ask_early.seq = 2;
+        let mut ask_late = new_order(Side::Sell, 1790, 6);
+        ask_late.seq = 3;
+
+        let result = run(
+            test_auction_id(),
+            "TEST/USD",
+            &[bid],
+            &[ask_early.clone(), ask_late.clone()],
+        )
+        .expect("expected result");
+
+        let early_fill: Decimal = result
+            .matches
+            .iter()
+            .filter(|m| m.ask.order_id == ask_early.id)
+            .map(|m| m.ask.size)
+            .sum();
+        let late_fill: Decimal = result
+            .matches
+            .iter()
+            .filter(|m| m.ask.order_id == ask_late.id)
+            .map(|m| m.ask.size)
+            .sum();
+
+        assert_eq!(
+            early_fill,
+            Decimal::from(6),
+            "earlier seq fills fully first"
+        );
+        assert_eq!(late_fill, Decimal::from(2), "later seq takes the remainder");
+    }
+
+    /// Issue #161: the result is a function of `(price, seq)` alone — feeding
+    /// the same orders in a different input order must produce an identical
+    /// matching. Guards against the old reliance on caller sort-stability.
+    #[test]
+    fn result_independent_of_input_order() {
+        let mut b1 = new_order(Side::Buy, 1800, 5);
+        b1.seq = 10;
+        let mut b2 = new_order(Side::Buy, 1800, 5);
+        b2.seq = 11;
+        let mut a1 = new_order(Side::Sell, 1790, 5);
+        a1.seq = 12;
+        let mut a2 = new_order(Side::Sell, 1790, 5);
+        a2.seq = 13;
+
+        let forward = run(
+            test_auction_id(),
+            "TEST/USD",
+            &[b1.clone(), b2.clone()],
+            &[a1.clone(), a2.clone()],
+        )
+        .expect("expected result");
+        let reversed = run(
+            test_auction_id(),
+            "TEST/USD",
+            &[b2.clone(), b1.clone()],
+            &[a2.clone(), a1.clone()],
+        )
+        .expect("expected result");
+
+        assert_eq!(forward.matches, reversed.matches);
+        assert_eq!(forward.clearing_price, reversed.clearing_price);
+        assert_eq!(forward.matched_volume, reversed.matched_volume);
     }
 }

--- a/crates/dp-book/src/book.rs
+++ b/crates/dp-book/src/book.rs
@@ -105,33 +105,33 @@ impl OrderBook {
         };
     }
 
-    /// Sorted bids for a single pair (price desc, then submission time asc).
+    /// Sorted bids for a single pair (price desc, then placement `seq` asc).
+    ///
+    /// The tiebreak is the monotonic placement `seq`, not `submitted_at`:
+    /// `seq` is unique and identical live and on replay, so the priority order
+    /// is deterministic (see ADR 0005). `dp_auction::run` re-establishes this
+    /// same `(price, seq)` order internally, so it does not depend on this
+    /// method's ordering — but keeping them aligned avoids surprising
+    /// observers of the book.
     pub fn bids(&self, pair: &str) -> Vec<Order> {
         let inner = self.inner.read();
         let Some(book) = inner.books.get(pair) else {
             return Vec::new();
         };
         let mut out: Vec<Order> = book.bids.values().cloned().collect();
-        out.sort_by(|a, b| {
-            b.price
-                .cmp(&a.price)
-                .then(a.submitted_at.cmp(&b.submitted_at))
-        });
+        out.sort_by(|a, b| b.price.cmp(&a.price).then(a.seq.cmp(&b.seq)));
         out
     }
 
-    /// Sorted asks for a single pair (price asc, then submission time asc).
+    /// Sorted asks for a single pair (price asc, then placement `seq` asc).
+    /// Same priority key as [`Self::bids`]; see its docs.
     pub fn asks(&self, pair: &str) -> Vec<Order> {
         let inner = self.inner.read();
         let Some(book) = inner.books.get(pair) else {
             return Vec::new();
         };
         let mut out: Vec<Order> = book.asks.values().cloned().collect();
-        out.sort_by(|a, b| {
-            a.price
-                .cmp(&b.price)
-                .then(a.submitted_at.cmp(&b.submitted_at))
-        });
+        out.sort_by(|a, b| a.price.cmp(&b.price).then(a.seq.cmp(&b.seq)));
         out
     }
 
@@ -325,6 +325,7 @@ mod tests {
             encrypted_payload: vec![],
             submitted_at: Utc::now(),
             expires_at: DateTime::default(),
+            seq: 0,
         }
     }
 
@@ -437,42 +438,42 @@ mod tests {
     }
 
     #[test]
-    fn bids_sorted_price_desc_time_asc() {
+    fn bids_sorted_price_desc_seq_asc() {
         let book = OrderBook::new();
         let mut o1 = make_order(Side::Buy, 100, 1);
-        o1.submitted_at = Utc::now() - Duration::seconds(10);
+        o1.seq = 1;
         let mut o2 = make_order(Side::Buy, 200, 1);
-        o2.submitted_at = Utc::now();
+        o2.seq = 7;
         let mut o3 = make_order(Side::Buy, 200, 1);
-        o3.submitted_at = Utc::now() - Duration::seconds(5);
+        o3.seq = 3;
 
         book.insert_order(o1.clone());
         book.insert_order(o2.clone());
         book.insert_order(o3.clone());
 
         let bids = book.bids("BTC-USD");
-        assert_eq!(bids[0].id, o3.id); // price 200, earlier
-        assert_eq!(bids[1].id, o2.id); // price 200, later
+        assert_eq!(bids[0].id, o3.id); // price 200, lower seq
+        assert_eq!(bids[1].id, o2.id); // price 200, higher seq
         assert_eq!(bids[2].id, o1.id); // price 100
     }
 
     #[test]
-    fn asks_sorted_price_asc_time_asc() {
+    fn asks_sorted_price_asc_seq_asc() {
         let book = OrderBook::new();
         let mut o1 = make_order(Side::Sell, 300, 1);
-        o1.submitted_at = Utc::now();
+        o1.seq = 9;
         let mut o2 = make_order(Side::Sell, 100, 1);
-        o2.submitted_at = Utc::now() - Duration::seconds(5);
+        o2.seq = 2;
         let mut o3 = make_order(Side::Sell, 100, 1);
-        o3.submitted_at = Utc::now();
+        o3.seq = 5;
 
         book.insert_order(o1.clone());
         book.insert_order(o2.clone());
         book.insert_order(o3.clone());
 
         let asks = book.asks("BTC-USD");
-        assert_eq!(asks[0].id, o2.id); // price 100, earlier
-        assert_eq!(asks[1].id, o3.id); // price 100, later
+        assert_eq!(asks[0].id, o2.id); // price 100, lower seq
+        assert_eq!(asks[1].id, o3.id); // price 100, higher seq
         assert_eq!(asks[2].id, o1.id); // price 300
     }
 

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -557,7 +557,7 @@ impl Engine {
         let expires_at = now
             + chrono::Duration::from_std(ttl).unwrap_or_else(|_| chrono::Duration::seconds(600));
 
-        let order = Order {
+        let mut order = Order {
             id: Uuid::new_v4(),
             trader: decrypted.trader,
             pair: pair_key,
@@ -569,8 +569,8 @@ impl Engine {
             encrypted_payload: ciphertext.clone(),
             submitted_at: now,
             expires_at,
-            // Adopted from the OrderPlaced event's store-assigned seq in
-            // `persist_order_placed`, once the append fixes it.
+            // Placeholder; the real seq is the store-assigned OrderPlaced seq,
+            // stamped onto both the book copy and this returned order below.
             seq: 0,
         };
 
@@ -592,7 +592,15 @@ impl Engine {
         let commitment = secrets.commitment.to_vec();
         self.inner.secrets.lock().insert(order.id, secrets);
 
-        self.persist_order_placed(order.clone(), commitment, proof, ciphertext, nonce.to_vec())?;
+        // Stamp the returned order with the same seq the book copy got, so a
+        // caller inspecting the result sees the real priority key, not 0.
+        order.seq = self.persist_order_placed(
+            order.clone(),
+            commitment,
+            proof,
+            ciphertext,
+            nonce.to_vec(),
+        )?;
         Ok(order)
     }
 
@@ -687,7 +695,7 @@ impl Engine {
         proof: Vec<u8>,
         ciphertext: Vec<u8>,
         salt_nonce: Vec<u8>,
-    ) -> Result<(), EngineError> {
+    ) -> Result<u64, EngineError> {
         let mut events = [Event {
             seq: 0,
             event_type: EventType::OrderPlaced,
@@ -708,6 +716,7 @@ impl Engine {
         // adopt it as the order's price-time priority key so the live book and
         // a replayed book agree on matching order (issue #161, ADR 0005).
         order.seq = evt.seq;
+        let assigned_seq = order.seq;
         state.book.apply(evt);
         let side_label = match order.side {
             Side::Buy => "buy",
@@ -715,7 +724,7 @@ impl Engine {
         };
         state.book.insert_order(order);
         metrics::counter!(M_ORDERS_PLACED, "side" => side_label).increment(1);
-        Ok(())
+        Ok(assigned_seq)
     }
 
     pub fn cancel_order(&self, order_id: Uuid, reason: Option<String>) -> Result<(), EngineError> {

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -569,6 +569,9 @@ impl Engine {
             encrypted_payload: ciphertext.clone(),
             submitted_at: now,
             expires_at,
+            // Adopted from the OrderPlaced event's store-assigned seq in
+            // `persist_order_placed`, once the append fixes it.
+            seq: 0,
         };
 
         // Capture ZK witness secrets in-memory only. Salt is derived
@@ -679,7 +682,7 @@ impl Engine {
 
     fn persist_order_placed(
         &self,
-        order: Order,
+        mut order: Order,
         commitment: Vec<u8>,
         proof: Vec<u8>,
         ciphertext: Vec<u8>,
@@ -701,6 +704,10 @@ impl Engine {
         let state = self.inner.state.lock();
         self.inner.store.append(&mut events)?;
         let evt = &events[0];
+        // The store stamped the monotonic seq onto the event during append;
+        // adopt it as the order's price-time priority key so the live book and
+        // a replayed book agree on matching order (issue #161, ADR 0005).
+        order.seq = evt.seq;
         state.book.apply(evt);
         let side_label = match order.side {
             Side::Buy => "buy",

--- a/crates/dp-engine/src/recover.rs
+++ b/crates/dp-engine/src/recover.rs
@@ -431,6 +431,11 @@ impl Engine {
                     encrypted_payload: ciphertext.clone(),
                     submitted_at: ev.timestamp,
                     expires_at,
+                    // Priority key is the event's own seq — the same value the
+                    // live path stamped at placement (issue #161, ADR 0005), so
+                    // replay reconstructs the identical matching order even
+                    // though `submitted_at` here is the (DB-write) event time.
+                    seq: ev.seq,
                 };
                 placed_orders.insert(order.id, order.clone());
                 let mut state = self.inner.state.lock();
@@ -740,6 +745,7 @@ mod tests {
             encrypted_payload: Vec::new(),
             submitted_at: Utc::now(),
             expires_at: Utc::now() + chrono::Duration::seconds(600),
+            seq: 0,
         }
     }
 

--- a/crates/dp-engine/src/tick.rs
+++ b/crates/dp-engine/src/tick.rs
@@ -445,6 +445,7 @@ mod tests {
             encrypted_payload: Vec::new(),
             submitted_at: Utc::now(),
             expires_at: Utc::now() + chrono::Duration::seconds(60),
+            seq: 0,
         }
     }
 

--- a/crates/dp-types/src/order.rs
+++ b/crates/dp-types/src/order.rs
@@ -24,6 +24,19 @@ pub struct Order {
     pub encrypted_payload: Vec<u8>,
     pub submitted_at: DateTime<Utc>,
     pub expires_at: DateTime<Utc>,
+    /// Monotonic placement sequence — the event-store `seq` assigned to this
+    /// order's `OrderPlaced` event. Strictly increasing across every order and
+    /// identical on live placement and on event-log replay, so it is the
+    /// canonical price-time priority key for matching (see ADR 0005).
+    ///
+    /// `submitted_at` is a wall-clock instant for display and TTL only; it must
+    /// never drive matching priority because it is non-monotonic at
+    /// sub-millisecond granularity and is reconstructed from the (possibly
+    /// DB-write) event timestamp on recovery. `#[serde(default)]` keeps older
+    /// snapshots that predate this field deserialisable (they replay to the
+    /// correct `seq` from their `OrderPlaced` events).
+    #[serde(default)]
+    pub seq: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -53,6 +66,7 @@ mod tests {
             encrypted_payload: vec![],
             submitted_at: DateTime::default(),
             expires_at: DateTime::default(),
+            seq: 0,
         };
         let json = serde_json::to_value(&order).unwrap();
         assert!(json.get("ID").is_some(), "expected ID field");
@@ -76,6 +90,7 @@ mod tests {
             "expected SubmittedAt field"
         );
         assert!(json.get("ExpiresAt").is_some(), "expected ExpiresAt field");
+        assert!(json.get("Seq").is_some(), "expected Seq field");
     }
 
     #[test]

--- a/crates/dp-types/src/order.rs
+++ b/crates/dp-types/src/order.rs
@@ -32,9 +32,14 @@ pub struct Order {
     /// `submitted_at` is a wall-clock instant for display and TTL only; it must
     /// never drive matching priority because it is non-monotonic at
     /// sub-millisecond granularity and is reconstructed from the (possibly
-    /// DB-write) event timestamp on recovery. `#[serde(default)]` keeps older
-    /// snapshots that predate this field deserialisable (they replay to the
-    /// correct `seq` from their `OrderPlaced` events).
+    /// DB-write) event timestamp on recovery.
+    ///
+    /// `#[serde(default)]` only matters for self-describing formats (JSON): a
+    /// missing field decodes to `0`. The book snapshot is bincode (positional,
+    /// not self-describing), so a pre-`seq` snapshot does NOT gain the field
+    /// here — it fails to decode and the recover path treats it as corrupt,
+    /// falling back to a full event replay that restores the real `seq` from
+    /// each `OrderPlaced` event. See ADR 0005 for the snapshot/replay caveat.
     #[serde(default)]
     pub seq: u64,
 }

--- a/docs/adr/0005-matching-priority.md
+++ b/docs/adr/0005-matching-priority.md
@@ -1,0 +1,118 @@
+# ADR 0005 — Matching priority and fill allocation
+
+- **Status:** Accepted
+- **Date:** 2026-06-01
+- **Issue:** [#161](https://github.com/Dnreikronos/DarkPool-Exchange/issues/161)
+
+## Context
+
+Each auction round clears at a single uniform price. Once that price is
+fixed, the engine must decide **which** of the eligible orders get filled,
+and in what order, when one side is oversubscribed at the clearing price.
+Before this ADR that decision was implicit and unsafe:
+
+1. `dp_auction::run` sorted `bids` by `Reverse(price)` and `asks` by
+   `price` **only** — no tiebreak. It leaned on the caller passing
+   pre-sorted slices and on `sort_by_key` being stable. The order book
+   supplied a `submitted_at` tiebreak, but that is `Utc::now()` captured at
+   placement with no sequence fallback, so two orders in the same
+   millisecond had an ambiguous order.
+2. On recovery, `submitted_at` is reconstructed from the event timestamp
+   (`recover.rs`), which for the Postgres store is the **DB write time**,
+   not the original placement instant. Replayed priority could therefore
+   differ from live priority — the same event log could clear to a
+   different matching than was settled.
+3. `match_orders` is greedy: the first eligible order on each side consumes
+   the opposing side in sort order until exhausted. With a non-deterministic
+   sort that meant a marginal sub-millisecond timing difference could decide
+   who captured all the liquidity, with no documented rule.
+
+There was also no explicit check that volume is conserved leg-for-leg
+(`Σ bid fills == Σ ask fills`) or that every fill prices at the clearing
+price. Both held implicitly but were never asserted.
+
+## Decision
+
+### 1. Priority rule: strict price-time
+
+Within a round, orders are matched by **strict price-time priority**:
+
+- better price first (higher bid / lower ask), then
+- earlier placement first.
+
+We do **not** use pro-rata allocation. The highest-priority order on each
+side is filled as far as the opposing liquidity allows before the next is
+considered. The marginal order at the clearing price may be partially
+filled; lower-priority orders behind it get nothing that round.
+
+Rationale: price-time is the well-understood default for a continuous book,
+keeps the matcher simple and exact (no fractional pro-rata remainder to
+round, which matters because sizes are `Decimal` and on-chain settlement is
+integer base units — see [ADR 0002](0002-decimals.md)), and preserves the
+existing semantics rather than changing market behaviour while fixing a
+correctness bug. Pro-rata remains a possible future change; it would need
+its own ADR and a defined remainder-allocation rule.
+
+### 2. Priority key: a monotonic `seq`, not `submitted_at`
+
+The total order is `(price, seq)`, where `seq` is the **event-store
+sequence number** stamped on the order's `OrderPlaced` event when it is
+appended. `dp_types::Order` carries this as a new `seq: u64` field.
+
+`seq` is the right key because it is:
+
+- **unique** — strictly increasing across every order, so `(price, seq)` is
+  a strict total order with no ambiguity even at sub-millisecond placement;
+- **replay-stable** — on recovery the order is rebuilt from its
+  `OrderPlaced` event and takes that event's own `seq`, the identical value
+  the live path stamped. Live and replayed books therefore agree on
+  matching order regardless of when the DB happened to write the row.
+
+`submitted_at` is retained as a wall-clock instant for display and TTL only.
+It must never drive matching priority.
+
+### 3. Ordering is established inside `run`
+
+`dp_auction::run` now sorts its inputs by `(price, seq)` itself, instead of
+trusting the caller. The matching result is a pure function of the order set
+and is independent of the slice order handed in. `OrderBook::bids` / `asks`
+apply the same `(price, seq)` tiebreak so that observers of the book see the
+same priority the matcher uses, but the matcher no longer depends on that.
+
+### 4. Conservation is asserted
+
+`match_orders` debit-and-credits each match by an identical `fill_size` at
+the clearing price, so `Σ bid fills == Σ ask fills` and every fill prices at
+the clearing price by construction. These invariants are now `debug_assert`-ed
+in the matcher (no release-build cost) and covered by unit tests in
+`dp-auction`.
+
+## Consequences
+
+- The same event log always replays to the matching that was settled.
+  Recovery is deterministic with respect to fill allocation.
+- Priority is unambiguous at any placement granularity; there is no
+  sub-millisecond race for liquidity.
+- Adding a field to `Order` changes its serialized shape. `seq` is
+  `#[serde(default)]`, so snapshots written before this change still
+  deserialize (with `seq = 0`); on the next full replay each order recovers
+  its real `seq` from its `OrderPlaced` event. `seq` is **not** part of the
+  ZK commitment (the commitment is derived from id / key / side / price /
+  size), so proofs are unaffected.
+- The marginal-time advantage at the clearing price is now deliberate and
+  documented (price-time), not an accident of timestamp resolution. If the
+  protocol later wants to remove it, pro-rata is the lever — a separate ADR.
+
+## Alternatives considered
+
+- **Keep `submitted_at` but add a sequence fallback to it.** Still leaves a
+  wall-clock value in the priority key and a second source of truth; `seq`
+  alone is simpler and already monotonic.
+- **Pro-rata allocation at the clearing price.** Fairer for size and more in
+  the spirit of a batch auction (no within-batch time advantage), but a
+  larger change: it needs a defined, deterministic rule for the indivisible
+  `Decimal` remainder, and it changes market behaviour. Deferred; would get
+  its own ADR.
+- **Sort only in the caller (the book) and keep `run` trusting it.** This is
+  the status quo that broke. Establishing the order inside `run` makes the
+  matcher correct in isolation and testable without a book.

--- a/docs/adr/0005-matching-priority.md
+++ b/docs/adr/0005-matching-priority.md
@@ -93,12 +93,19 @@ in the matcher (no release-build cost) and covered by unit tests in
   Recovery is deterministic with respect to fill allocation.
 - Priority is unambiguous at any placement granularity; there is no
   sub-millisecond race for liquidity.
-- Adding a field to `Order` changes its serialized shape. `seq` is
-  `#[serde(default)]`, so snapshots written before this change still
-  deserialize (with `seq = 0`); on the next full replay each order recovers
-  its real `seq` from its `OrderPlaced` event. `seq` is **not** part of the
-  ZK commitment (the commitment is derived from id / key / side / price /
-  size), so proofs are unaffected.
+- Adding a field to `Order` changes its serialized shape. The book snapshot
+  is bincode (positional, not self-describing), so `#[serde(default)]` does
+  **not** make a pre-`seq` snapshot decode; it only covers self-describing
+  formats such as JSON. A stale snapshot fails to decode, the recover path
+  treats that envelope as corrupt and tries older envelopes, and ultimately
+  falls back to a full event replay, which reconstructs each order's real
+  `seq` from its `OrderPlaced` event. The one gap: if events were compacted
+  past the snapshot point (`compact_before`), full replay can no longer
+  rebuild the book and recovery fails. This is pre-prod with no snapshots in
+  existence yet, but the wire-shape change is real and snapshot compatibility
+  rests on the replay fallback, not on `serde(default)`. `seq` is **not**
+  part of the ZK commitment (derived from id / key / side / price / size), so
+  proofs are unaffected.
 - The marginal-time advantage at the clearing price is now deliberate and
   documented (price-time), not an accident of timestamp resolution. If the
   protocol later wants to remove it, pro-rata is the lever — a separate ADR.


### PR DESCRIPTION
Closes #161

Fill allocation wasn't deterministic. `dp_auction::run` sorted only by price and trusted the caller to pass stable-sorted slices. The book broke ties on `submitted_at`, which is `Utc::now()` at placement with no sequence fallback, and on recovery that gets rebuilt from the event (DB-write) timestamp. So two orders placed in the same millisecond had no defined priority, and the same event log could replay to a different matching than the one that settled.

Orders now carry `seq`, the event-store sequence number of their `OrderPlaced` event. It's unique, and it's the same value live and on replay, so `(price, seq)` is a stable total order. `run` sorts by that key itself now instead of leaning on the caller. The book tiebreaks on the same key. The live path stamps `seq` from the store append; recovery reuses the replayed event's own `seq`.

The rule is strict price-time, written up in ADR 0005 with the reasoning for `seq` over `submitted_at` and for leaving pro-rata out. `match_orders` debug-asserts the invariants that were already true by construction: every fill is at the clearing price, and bid and ask fill totals match. New dp-auction tests cover volume conservation, the seq tiebreak between same-price orders, and that the matching doesn't change when you reorder the inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented strict price-time priority ordering for auction matching, ensuring deterministic results regardless of input order.

* **Bug Fixes**
  * Improved order matching consistency between live and replayed states with monotonic sequence-based prioritization.

* **Documentation**
  * Added architecture decision record documenting matching priority semantics and fill-allocation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
