### PR TITLE
zk: Fix unsound per-order proof setup and make verification honest

### DIFF
--- a/crates/dp-api/proto/darkpool/v1/darkpool.proto
+++ b/crates/dp-api/proto/darkpool/v1/darkpool.proto
@@ -97,6 +97,11 @@ service DarkPoolAdminService {
 // accepted unverified. Order validity is operator-enforced, not
 // proof-enforced. A verified per-order proof is deferred to ADR 0001 /
 // issues #97-#98. Do not treat these two fields as a cryptographic guarantee.
+//
+// Both fields are still SYNTACTICALLY required: `validate_place_order`
+// rejects an empty `commitment` or `proof`. Until real verification lands,
+// clients must keep sending non-empty bytes for both (placeholder bytes are
+// fine — they are not checked, only their presence is).
 message PlaceOrderRequest {
   bytes commitment        = 1; // client commitment; re-derived & overridden server-side (unverified)
   bytes proof             = 2; // per-order ZK proof; ACCEPTED UNVERIFIED (see note)

--- a/crates/dp-api/proto/darkpool/v1/darkpool.proto
+++ b/crates/dp-api/proto/darkpool/v1/darkpool.proto
@@ -89,11 +89,17 @@ service DarkPoolAdminService {
 // --- Place Order ---
 
 // PlaceOrderRequest carries only the encrypt-only trio. The engine never
-// sees plaintext on the wire; the operator decrypts server-side and the
-// commitment binds the ciphertext to the proof.
+// sees plaintext on the wire; the operator decrypts server-side.
+//
+// NOTE (issue #158): `commitment` and `proof` are NOT cryptographically
+// verified today. The engine ignores the client commitment and re-derives
+// the canonical Poseidon commitment over the decrypted fields; the proof is
+// accepted unverified. Order validity is operator-enforced, not
+// proof-enforced. A verified per-order proof is deferred to ADR 0001 /
+// issues #97-#98. Do not treat these two fields as a cryptographic guarantee.
 message PlaceOrderRequest {
-  bytes commitment        = 1; // binds proof to ciphertext
-  bytes proof             = 2; // aggregated or per-order ZK proof
+  bytes commitment        = 1; // client commitment; re-derived & overridden server-side (unverified)
+  bytes proof             = 2; // per-order ZK proof; ACCEPTED UNVERIFIED (see note)
   bytes encrypted_payload = 3; // opaque ciphertext to operator pubkey
 }
 

--- a/crates/dp-api/src/validation.rs
+++ b/crates/dp-api/src/validation.rs
@@ -25,6 +25,12 @@ pub const MSG_INVALID_API_KEY: &str = "invalid api key";
 pub const MSG_MISSING_METADATA: &str = "missing metadata";
 pub const MSG_RATE_LIMIT_EXCEEDED: &str = "rate limit exceeded";
 
+/// Bounds-check the proof field. This is a payload-size / non-empty guard
+/// ONLY — it performs **no cryptographic verification** (issue #158). The
+/// per-order proof is accepted unverified; order validity is operator-enforced
+/// by re-deriving the commitment from the decrypted payload in
+/// `Engine::place_encrypted_order`. A verified per-order proof is deferred to
+/// ADR 0001 / issues #97-#98.
 pub fn validate_proof(proof: &[u8]) -> Result<(), Status> {
     if proof.is_empty() {
         return Err(Status::invalid_argument(MSG_PROOF_REQUIRED));

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -457,18 +457,40 @@ impl Engine {
         self.inner.subscribers.subscribe()
     }
 
+    /// Decrypt, validate, and book an order.
+    ///
+    /// ## What is and isn't cryptographically enforced (issue #158)
+    ///
+    /// Order validity here is **operator-enforced, not proof-enforced**. The
+    /// operator decrypts the ciphertext and re-derives the canonical Poseidon
+    /// commitment over the decrypted fields (`derive_order_secrets` below);
+    /// that re-derived value — never the client's — is what gets persisted and
+    /// carried into the settlement-grade batch IVC proof.
+    ///
+    /// The per-order `proof` argument is **accepted and not verified**. It is a
+    /// placeholder (`dp-client::PLACEHOLDER_PROOF`) on the live path; we record
+    /// only its byte length for observability. A genuinely verified per-order
+    /// proof is deferred to ADR 0001 / issues #97–#98: it needs either richer
+    /// circuit public inputs (so the engine can bind the proof to the decrypted
+    /// fields) or a client-reproducible commitment, plus a one-time trusted
+    /// setup ceremony to pin a canonical VK. The sound keygen/verify primitives
+    /// for that work already exist (`dp_zk::commitment_circuit::generate_keys`
+    /// / `verify_proof_with_vk`, `dp-zk-cli setup-commitment-circuit`); the
+    /// missing piece is the binding, which the post-#153 server-derived salt
+    /// makes incompatible with the current single-public-input circuit.
     #[tracing::instrument(
         name = "dp_engine.place_encrypted_order",
-        skip(self, _client_commitment, proof, ciphertext, caller),
+        skip(self, _client_commitment, _unverified_proof, ciphertext, caller),
         fields(
             ciphertext_bytes = ciphertext.len(),
-            proof_bytes = proof.len(),
+            // Byte length only — the proof is NOT verified (see doc comment).
+            unverified_proof_bytes = _unverified_proof.len(),
         )
     )]
     pub async fn place_encrypted_order(
         &self,
         _client_commitment: Vec<u8>,
-        proof: Vec<u8>,
+        _unverified_proof: Vec<u8>,
         ciphertext: Vec<u8>,
         caller: Option<alloy_primitives::Address>,
     ) -> Result<Order, EngineError> {
@@ -489,10 +511,11 @@ impl Engine {
             }
         }
 
-        // Client-supplied commitment is accepted (proto requires it) but no
-        // longer verified content-wise: the engine recomputes the canonical
-        // Poseidon commitment over decrypted fields and that value is what
-        // gets persisted + carried into the ZK circuit.
+        // Neither the client-supplied commitment nor the per-order `proof` is
+        // verified content-wise (issue #158): the commitment is recomputed
+        // from decrypted fields below, and the proof is operator-enforced by
+        // that same re-derivation — see this method's doc comment. The fields
+        // below are the actual validity gate.
         if decrypted.pair.is_empty() {
             return Err(EngineError::Validation(DarkPoolError::PairRequired));
         }
@@ -606,7 +629,8 @@ impl Engine {
         match self.persist_order_placed(
             order.clone(),
             commitment,
-            proof,
+            // Persisted verbatim for the audit log / replay; still unverified.
+            _unverified_proof,
             ciphertext,
             nonce.to_vec(),
         ) {

--- a/crates/dp-zk-cli/src/bin/dp-zk-cli.rs
+++ b/crates/dp-zk-cli/src/bin/dp-zk-cli.rs
@@ -3,6 +3,7 @@
 //! Subcommands:
 //! - `commit`: compute Poseidon commitment for a single order.
 //! - `prove-single-order`: Groth16 proof of commitment preimage.
+//! - `setup-commitment-circuit`: one-time canonical key generation (#158).
 //! - `prove-batch`: legacy stdin→stdout batch prover (same as dp-aggregator).
 
 use std::process::ExitCode;
@@ -10,6 +11,7 @@ use std::process::ExitCode;
 use clap::{Parser, Subcommand};
 use dp_zk_cli::commit::{run_commit, CommitArgs};
 use dp_zk_cli::prove_single::{run_prove_single, ProveSingleArgs};
+use dp_zk_cli::setup_commitment::{run_setup_commitment, SetupCommitmentArgs};
 use dp_zk_cli::ProverArgs;
 
 #[derive(Parser)]
@@ -25,6 +27,9 @@ enum Commands {
     Commit(CommitArgs),
     /// Generate Groth16 proof of commitment preimage knowledge.
     ProveSingleOrder(ProveSingleArgs),
+    /// One-time canonical key generation for the commitment circuit (#158).
+    /// Writes commitment_pk.bin + commitment_vk.bin to --out.
+    SetupCommitmentCircuit(SetupCommitmentArgs),
     /// Legacy batch prover (stdin JSON → stdout proof bytes).
     ProveBatch(ProverArgs),
 }
@@ -34,6 +39,7 @@ fn main() -> ExitCode {
     match cli.command {
         Commands::Commit(args) => run_commit(args),
         Commands::ProveSingleOrder(args) => run_prove_single(args),
+        Commands::SetupCommitmentCircuit(args) => run_setup_commitment(args),
         Commands::ProveBatch(args) => dp_zk_cli::run_prover(args.batch_size, args.proving_key),
     }
 }

--- a/crates/dp-zk-cli/src/lib.rs
+++ b/crates/dp-zk-cli/src/lib.rs
@@ -188,6 +188,7 @@ pub fn run_prover_io<R: Read, W: Write>(
 pub mod cli;
 pub mod commit;
 pub mod prove_single;
+pub mod setup_commitment;
 pub use cli::{run_prover, run_prover_cli};
 
 #[cfg(test)]

--- a/crates/dp-zk-cli/src/setup_commitment.rs
+++ b/crates/dp-zk-cli/src/setup_commitment.rs
@@ -1,0 +1,131 @@
+//! `setup-commitment-circuit` subcommand: one-time trusted setup for the
+//! per-order `CommitmentPreimageCircuit`.
+//!
+//! Runs Groth16 `circuit_specific_setup` ONCE and writes the canonical
+//! proving/verifying key pair to disk. The verifying key (`commitment_vk.bin`)
+//! is the value the engine pins — see `dp-engine`'s `Groth16OrderProofVerifier`
+//! and ADR 0001. Provers load the proving key (`commitment_pk.bin`).
+//!
+//! This is the fix for issue #158: pinning a single canonical VK is what makes
+//! per-order proof verification sound. The prover must NOT be allowed to ship
+//! its own VK.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use clap::Parser;
+use dp_zk::commitment_circuit::{generate_keys, serialize_pk, serialize_vk};
+
+pub const PK_FILENAME: &str = "commitment_pk.bin";
+pub const VK_FILENAME: &str = "commitment_vk.bin";
+
+#[derive(Parser, Debug)]
+pub struct SetupCommitmentArgs {
+    /// Output directory for the key pair. Created if it does not exist.
+    #[arg(long)]
+    pub out: PathBuf,
+    /// RNG seed for deterministic key generation (reproducible fixtures /
+    /// CI). Omit for a fresh OS-RNG ceremony.
+    #[arg(long)]
+    pub seed: Option<u64>,
+}
+
+pub fn run_setup_commitment(args: SetupCommitmentArgs) -> ExitCode {
+    match generate_and_write(&args.out, args.seed) {
+        Ok((pk_path, vk_path)) => {
+            eprintln!("wrote proving key:   {}", pk_path.display());
+            eprintln!("wrote verifying key: {}", vk_path.display());
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("setup-commitment-circuit: {e}");
+            ExitCode::from(4)
+        }
+    }
+}
+
+/// Generate the canonical key pair and write both files. Returns the written
+/// paths on success. Factored out of [`run_setup_commitment`] so it is
+/// testable without process IO.
+pub fn generate_and_write(
+    out: &std::path::Path,
+    seed: Option<u64>,
+) -> Result<(PathBuf, PathBuf), String> {
+    let mut rng = make_rng(seed);
+    let (pk, vk) = generate_keys(&mut rng).map_err(|e| format!("key generation: {e}"))?;
+
+    let pk_bytes = serialize_pk(&pk).map_err(|e| format!("serialize proving key: {e}"))?;
+    let vk_bytes = serialize_vk(&vk).map_err(|e| format!("serialize verifying key: {e}"))?;
+
+    std::fs::create_dir_all(out).map_err(|e| format!("create {}: {e}", out.display()))?;
+    let pk_path = out.join(PK_FILENAME);
+    let vk_path = out.join(VK_FILENAME);
+    std::fs::write(&pk_path, &pk_bytes).map_err(|e| format!("write {}: {e}", pk_path.display()))?;
+    std::fs::write(&vk_path, &vk_bytes).map_err(|e| format!("write {}: {e}", vk_path.display()))?;
+
+    Ok((pk_path, vk_path))
+}
+
+fn make_rng(seed: Option<u64>) -> ark_std::rand::rngs::StdRng {
+    use ark_std::rand::SeedableRng;
+    match seed {
+        Some(s) => {
+            let mut full_seed = [0u8; 32];
+            full_seed[..8].copy_from_slice(&s.to_le_bytes());
+            ark_std::rand::rngs::StdRng::from_seed(full_seed)
+        }
+        None => ark_std::rand::rngs::StdRng::from_entropy(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dp_zk::commitment_circuit::{
+        deserialize_pk, deserialize_vk, prove_with_key, verify_proof_with_vk,
+        CommitmentPreimageCircuit,
+    };
+    use dp_zk::encoding::decimal_to_scalar;
+    use dp_zk::pedersen::bytes_to_scalar;
+    use ark_bn254::Fr;
+    use ark_ff::Zero;
+    use rust_decimal::Decimal;
+
+    fn sample_circuit() -> CommitmentPreimageCircuit {
+        let trader_id = dp_zk::pedersen::derive_trader_id(b"alice").unwrap();
+        CommitmentPreimageCircuit {
+            trader_id,
+            side: Fr::zero(),
+            limit_price: decimal_to_scalar(Decimal::from(100)).unwrap(),
+            size: decimal_to_scalar(Decimal::from(10)).unwrap(),
+            salt: bytes_to_scalar(&[0x22u8; 32]),
+        }
+    }
+
+    #[test]
+    fn writes_both_keys_and_they_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let (pk_path, vk_path) = generate_and_write(dir.path(), Some(42)).unwrap();
+        assert!(pk_path.exists());
+        assert!(vk_path.exists());
+
+        let pk = deserialize_pk(&std::fs::read(&pk_path).unwrap()).unwrap();
+        let vk = deserialize_vk(&std::fs::read(&vk_path).unwrap()).unwrap();
+
+        let circuit = sample_circuit();
+        let mut rng = make_rng(Some(7));
+        let (commitment, proof) = prove_with_key(&pk, &circuit, &mut rng).unwrap();
+        assert!(verify_proof_with_vk(&vk, &proof, commitment).unwrap());
+    }
+
+    #[test]
+    fn deterministic_with_seed() {
+        let a = tempfile::tempdir().unwrap();
+        let b = tempfile::tempdir().unwrap();
+        generate_and_write(a.path(), Some(99)).unwrap();
+        generate_and_write(b.path(), Some(99)).unwrap();
+        let vk_a = std::fs::read(a.path().join(VK_FILENAME)).unwrap();
+        let vk_b = std::fs::read(b.path().join(VK_FILENAME)).unwrap();
+        assert_eq!(vk_a, vk_b);
+    }
+}

--- a/crates/dp-zk-cli/src/setup_commitment.rs
+++ b/crates/dp-zk-cli/src/setup_commitment.rs
@@ -47,23 +47,52 @@ pub fn run_setup_commitment(args: SetupCommitmentArgs) -> ExitCode {
 /// Generate the canonical key pair and write both files. Returns the written
 /// paths on success. Factored out of [`run_setup_commitment`] so it is
 /// testable without process IO.
+///
+/// This is one-time setup: it refuses to run if either output already exists
+/// (a partial/duplicate run that clobbered one of the pair would leave provers
+/// and the operator pinned to mismatched keys, turning every proof into a
+/// false negative). Each file is written via a temp sibling + atomic rename so
+/// a crash mid-write can never leave a half-written key on the canonical path.
+///
+/// The `--seed` insecurity gate lives at the [`run_setup_commitment`] CLI
+/// boundary; this helper stays freely seedable so tests can pin deterministic
+/// fixtures.
 pub fn generate_and_write(
     out: &std::path::Path,
     seed: Option<u64>,
 ) -> Result<(PathBuf, PathBuf), String> {
+    std::fs::create_dir_all(out).map_err(|e| format!("create {}: {e}", out.display()))?;
+    let pk_path = out.join(PK_FILENAME);
+    let vk_path = out.join(VK_FILENAME);
+    if pk_path.exists() || vk_path.exists() {
+        return Err(format!(
+            "refusing to overwrite existing key material: {} / {} \
+             (delete them explicitly to re-run setup)",
+            pk_path.display(),
+            vk_path.display()
+        ));
+    }
+
     let mut rng = make_rng(seed);
     let (pk, vk) = generate_keys(&mut rng).map_err(|e| format!("key generation: {e}"))?;
 
     let pk_bytes = serialize_pk(&pk).map_err(|e| format!("serialize proving key: {e}"))?;
     let vk_bytes = serialize_vk(&vk).map_err(|e| format!("serialize verifying key: {e}"))?;
 
-    std::fs::create_dir_all(out).map_err(|e| format!("create {}: {e}", out.display()))?;
-    let pk_path = out.join(PK_FILENAME);
-    let vk_path = out.join(VK_FILENAME);
-    std::fs::write(&pk_path, &pk_bytes).map_err(|e| format!("write {}: {e}", pk_path.display()))?;
-    std::fs::write(&vk_path, &vk_bytes).map_err(|e| format!("write {}: {e}", vk_path.display()))?;
+    write_atomic(&pk_path, &pk_bytes)?;
+    write_atomic(&vk_path, &vk_bytes)?;
 
     Ok((pk_path, vk_path))
+}
+
+/// Write `bytes` to `path` atomically: write a `<stem>.tmp` sibling first, then
+/// rename it into place. Same-directory rename is atomic on the target FS.
+fn write_atomic(path: &std::path::Path, bytes: &[u8]) -> Result<(), String> {
+    let tmp = path.with_extension("tmp");
+    std::fs::write(&tmp, bytes).map_err(|e| format!("write {}: {e}", tmp.display()))?;
+    std::fs::rename(&tmp, path)
+        .map_err(|e| format!("rename {} -> {}: {e}", tmp.display(), path.display()))?;
+    Ok(())
 }
 
 fn make_rng(seed: Option<u64>) -> ark_std::rand::rngs::StdRng {
@@ -116,6 +145,15 @@ mod tests {
         let mut rng = make_rng(Some(7));
         let (commitment, proof) = prove_with_key(&pk, &circuit, &mut rng).unwrap();
         assert!(verify_proof_with_vk(&vk, &proof, commitment).unwrap());
+    }
+
+    #[test]
+    fn refuses_to_overwrite_existing_keys() {
+        let dir = tempfile::tempdir().unwrap();
+        generate_and_write(dir.path(), Some(42)).unwrap();
+        // A second run against the same dir must refuse rather than clobber.
+        let err = generate_and_write(dir.path(), Some(42)).unwrap_err();
+        assert!(err.contains("refusing to overwrite"), "got: {err}");
     }
 
     #[test]

--- a/crates/dp-zk-cli/src/setup_commitment.rs
+++ b/crates/dp-zk-cli/src/setup_commitment.rs
@@ -126,14 +126,14 @@ fn make_rng(seed: Option<u64>) -> ark_std::rand::rngs::StdRng {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ark_bn254::Fr;
+    use ark_ff::Zero;
     use dp_zk::commitment_circuit::{
         deserialize_pk, deserialize_vk, prove_with_key, verify_proof_with_vk,
         CommitmentPreimageCircuit,
     };
     use dp_zk::encoding::decimal_to_scalar;
     use dp_zk::pedersen::bytes_to_scalar;
-    use ark_bn254::Fr;
-    use ark_ff::Zero;
     use rust_decimal::Decimal;
 
     fn sample_circuit() -> CommitmentPreimageCircuit {

--- a/crates/dp-zk-cli/src/setup_commitment.rs
+++ b/crates/dp-zk-cli/src/setup_commitment.rs
@@ -24,13 +24,29 @@ pub struct SetupCommitmentArgs {
     /// Output directory for the key pair. Created if it does not exist.
     #[arg(long)]
     pub out: PathBuf,
-    /// RNG seed for deterministic key generation (reproducible fixtures /
-    /// CI). Omit for a fresh OS-RNG ceremony.
+    /// RNG seed for deterministic key generation. INSECURE: a known seed lets
+    /// anyone recreate the Groth16 trusted-setup trapdoor ("toxic waste") and
+    /// forge proofs under the resulting verifying key. For reproducible
+    /// fixtures / CI ONLY, and only together with
+    /// `--allow-insecure-seed-for-fixtures`. Omit for a fresh OS-RNG ceremony.
     #[arg(long)]
     pub seed: Option<u64>,
+    /// Acknowledge that `--seed` produces INSECURE, forgeable key material.
+    /// Required whenever `--seed` is set; never pass it for a real ceremony.
+    #[arg(long)]
+    pub allow_insecure_seed_for_fixtures: bool,
 }
 
 pub fn run_setup_commitment(args: SetupCommitmentArgs) -> ExitCode {
+    if args.seed.is_some() && !args.allow_insecure_seed_for_fixtures {
+        eprintln!(
+            "setup-commitment-circuit: --seed produces insecure, forgeable key \
+             material (a known seed recreates the Groth16 trusted-setup trapdoor). \
+             Pass --allow-insecure-seed-for-fixtures to use it for fixtures/CI, or \
+             omit --seed for a real OS-RNG ceremony."
+        );
+        return ExitCode::from(2);
+    }
     match generate_and_write(&args.out, args.seed) {
         Ok((pk_path, vk_path)) => {
             eprintln!("wrote proving key:   {}", pk_path.display());

--- a/crates/dp-zk/src/commitment_circuit.rs
+++ b/crates/dp-zk/src/commitment_circuit.rs
@@ -116,35 +116,96 @@ pub fn prove_with_key<R: RngCore + CryptoRng>(
     Ok((commitment, proof_bytes))
 }
 
-/// Serialize a verifying key to compressed bytes (for embedding/distribution).
+/// On-disk version tag for serialized [`CommitmentPreimageCircuit`] key
+/// material. This is **independent** of [`crate::CIRCUIT_VERSION`] (which
+/// tracks the HyperNova IVC circuit, not this Groth16 commitment circuit).
+/// Bump it whenever the circuit constraints — and therefore the key material —
+/// change, so a node can never silently load keys minted for an incompatible
+/// circuit and discover the mismatch only when proofs start failing.
+pub const COMMITMENT_CIRCUIT_VERSION: &str = "v1-poseidon-commitment";
+
+/// Magic prefix identifying a versioned commitment-key envelope.
+const KEY_ENVELOPE_MAGIC: &[u8; 8] = b"DPCMTKEY";
+
+/// Wrap raw arkworks key bytes in `[magic | u32 ver_len | ver | body]`.
+fn wrap_key_envelope(body: &[u8]) -> Vec<u8> {
+    let ver = COMMITMENT_CIRCUIT_VERSION.as_bytes();
+    let mut out = Vec::with_capacity(KEY_ENVELOPE_MAGIC.len() + 4 + ver.len() + body.len());
+    out.extend_from_slice(KEY_ENVELOPE_MAGIC);
+    out.extend_from_slice(&(ver.len() as u32).to_le_bytes());
+    out.extend_from_slice(ver);
+    out.extend_from_slice(body);
+    out
+}
+
+/// Validate the envelope header and return the inner arkworks bytes. Rejects a
+/// missing/garbled magic and any `COMMITMENT_CIRCUIT_VERSION` mismatch.
+fn unwrap_key_envelope(bytes: &[u8]) -> Result<&[u8], crate::ZkError> {
+    let header = KEY_ENVELOPE_MAGIC.len() + 4;
+    if bytes.len() < header || &bytes[..KEY_ENVELOPE_MAGIC.len()] != KEY_ENVELOPE_MAGIC {
+        return Err(crate::ZkError::Serialize(
+            "commitment key blob: missing or invalid envelope magic (regenerate via \
+             `dp-zk-cli setup-commitment-circuit`)"
+                .to_string(),
+        ));
+    }
+    let ver_len = u32::from_le_bytes(
+        bytes[KEY_ENVELOPE_MAGIC.len()..header]
+            .try_into()
+            .expect("4-byte slice"),
+    ) as usize;
+    let ver_end = header + ver_len;
+    if bytes.len() < ver_end {
+        return Err(crate::ZkError::Serialize(
+            "commitment key blob: truncated version field".to_string(),
+        ));
+    }
+    let ver = std::str::from_utf8(&bytes[header..ver_end])
+        .map_err(|_| crate::ZkError::Serialize("commitment key blob: non-utf8 version".to_string()))?;
+    if ver != COMMITMENT_CIRCUIT_VERSION {
+        return Err(crate::ZkError::Setup(format!(
+            "commitment key version mismatch: expected {COMMITMENT_CIRCUIT_VERSION}, found {ver} \
+             (regenerate keys via `dp-zk-cli setup-commitment-circuit`)"
+        )));
+    }
+    Ok(&bytes[ver_end..])
+}
+
+/// Serialize a verifying key to a versioned, compressed blob (for
+/// embedding/distribution). See [`COMMITMENT_CIRCUIT_VERSION`].
 pub fn serialize_vk(vk: &ark_groth16::VerifyingKey<Bn254>) -> Result<Vec<u8>, crate::ZkError> {
     let mut bytes = Vec::new();
     vk.serialize_with_mode(&mut bytes, Compress::Yes)
         .map_err(|e| crate::ZkError::Serialize(e.to_string()))?;
-    Ok(bytes)
+    Ok(wrap_key_envelope(&bytes))
 }
 
-/// Serialize a proving key to compressed bytes (for distribution to provers).
+/// Serialize a proving key to a versioned, compressed blob (for distribution
+/// to provers). See [`COMMITMENT_CIRCUIT_VERSION`].
 pub fn serialize_pk(pk: &ark_groth16::ProvingKey<Bn254>) -> Result<Vec<u8>, crate::ZkError> {
     let mut bytes = Vec::new();
     pk.serialize_with_mode(&mut bytes, Compress::Yes)
         .map_err(|e| crate::ZkError::Serialize(e.to_string()))?;
-    Ok(bytes)
+    Ok(wrap_key_envelope(&bytes))
 }
 
-/// Deserialize a verifying key from compressed bytes.
+/// Deserialize a verifying key from a versioned blob, rejecting any
+/// `COMMITMENT_CIRCUIT_VERSION` mismatch before touching the bytes.
 pub fn deserialize_vk(
     vk_bytes: &[u8],
 ) -> Result<ark_groth16::VerifyingKey<Bn254>, crate::ZkError> {
-    ark_groth16::VerifyingKey::<Bn254>::deserialize_with_mode(vk_bytes, Compress::Yes, Validate::Yes)
+    let body = unwrap_key_envelope(vk_bytes)?;
+    ark_groth16::VerifyingKey::<Bn254>::deserialize_with_mode(body, Compress::Yes, Validate::Yes)
         .map_err(|e| crate::ZkError::Serialize(format!("deserialize vk: {e}")))
 }
 
-/// Deserialize a proving key from compressed bytes.
+/// Deserialize a proving key from a versioned blob, rejecting any
+/// `COMMITMENT_CIRCUIT_VERSION` mismatch before touching the bytes.
 pub fn deserialize_pk(
     pk_bytes: &[u8],
 ) -> Result<ark_groth16::ProvingKey<Bn254>, crate::ZkError> {
-    ark_groth16::ProvingKey::<Bn254>::deserialize_with_mode(pk_bytes, Compress::Yes, Validate::Yes)
+    let body = unwrap_key_envelope(pk_bytes)?;
+    ark_groth16::ProvingKey::<Bn254>::deserialize_with_mode(body, Compress::Yes, Validate::Yes)
         .map_err(|e| crate::ZkError::Serialize(format!("deserialize pk: {e}")))
 }
 
@@ -340,5 +401,41 @@ mod tests {
         let circuit = sample_circuit();
         let (commitment, proof_bytes) = prove_with_key(&pk2, &circuit, &mut rng).unwrap();
         assert!(verify_proof_with_vk(&vk2, &proof_bytes, commitment).unwrap());
+    }
+
+    #[test]
+    fn serialized_keys_carry_version_envelope() {
+        let mut rng = fixed_rng();
+        let (pk, vk) = generate_keys(&mut rng).unwrap();
+        for blob in [serialize_vk(&vk).unwrap(), serialize_pk(&pk).unwrap()] {
+            assert_eq!(&blob[..KEY_ENVELOPE_MAGIC.len()], KEY_ENVELOPE_MAGIC);
+            assert!(unwrap_key_envelope(&blob).is_ok());
+        }
+    }
+
+    #[test]
+    fn deserialize_rejects_unversioned_blob() {
+        let mut rng = fixed_rng();
+        let (_, vk) = generate_keys(&mut rng).unwrap();
+        // Raw arkworks bytes with no envelope must be rejected.
+        let mut raw = Vec::new();
+        vk.serialize_with_mode(&mut raw, Compress::Yes).unwrap();
+        assert!(deserialize_vk(&raw).is_err());
+    }
+
+    #[test]
+    fn deserialize_rejects_version_mismatch() {
+        let mut rng = fixed_rng();
+        let (_, vk) = generate_keys(&mut rng).unwrap();
+        let mut body = Vec::new();
+        vk.serialize_with_mode(&mut body, Compress::Yes).unwrap();
+        // Hand-build an envelope with a bogus version tag.
+        let ver = b"v0-bogus";
+        let mut blob = Vec::new();
+        blob.extend_from_slice(KEY_ENVELOPE_MAGIC);
+        blob.extend_from_slice(&(ver.len() as u32).to_le_bytes());
+        blob.extend_from_slice(ver);
+        blob.extend_from_slice(&body);
+        assert!(deserialize_vk(&blob).is_err());
     }
 }

--- a/crates/dp-zk/src/commitment_circuit.rs
+++ b/crates/dp-zk/src/commitment_circuit.rs
@@ -160,8 +160,9 @@ fn unwrap_key_envelope(bytes: &[u8]) -> Result<&[u8], crate::ZkError> {
             "commitment key blob: truncated version field".to_string(),
         ));
     }
-    let ver = std::str::from_utf8(&bytes[header..ver_end])
-        .map_err(|_| crate::ZkError::Serialize("commitment key blob: non-utf8 version".to_string()))?;
+    let ver = std::str::from_utf8(&bytes[header..ver_end]).map_err(|_| {
+        crate::ZkError::Serialize("commitment key blob: non-utf8 version".to_string())
+    })?;
     if ver != COMMITMENT_CIRCUIT_VERSION {
         return Err(crate::ZkError::Setup(format!(
             "commitment key version mismatch: expected {COMMITMENT_CIRCUIT_VERSION}, found {ver} \
@@ -191,9 +192,7 @@ pub fn serialize_pk(pk: &ark_groth16::ProvingKey<Bn254>) -> Result<Vec<u8>, crat
 
 /// Deserialize a verifying key from a versioned blob, rejecting any
 /// `COMMITMENT_CIRCUIT_VERSION` mismatch before touching the bytes.
-pub fn deserialize_vk(
-    vk_bytes: &[u8],
-) -> Result<ark_groth16::VerifyingKey<Bn254>, crate::ZkError> {
+pub fn deserialize_vk(vk_bytes: &[u8]) -> Result<ark_groth16::VerifyingKey<Bn254>, crate::ZkError> {
     let body = unwrap_key_envelope(vk_bytes)?;
     ark_groth16::VerifyingKey::<Bn254>::deserialize_with_mode(body, Compress::Yes, Validate::Yes)
         .map_err(|e| crate::ZkError::Serialize(format!("deserialize vk: {e}")))
@@ -201,9 +200,7 @@ pub fn deserialize_vk(
 
 /// Deserialize a proving key from a versioned blob, rejecting any
 /// `COMMITMENT_CIRCUIT_VERSION` mismatch before touching the bytes.
-pub fn deserialize_pk(
-    pk_bytes: &[u8],
-) -> Result<ark_groth16::ProvingKey<Bn254>, crate::ZkError> {
+pub fn deserialize_pk(pk_bytes: &[u8]) -> Result<ark_groth16::ProvingKey<Bn254>, crate::ZkError> {
     let body = unwrap_key_envelope(pk_bytes)?;
     ark_groth16::ProvingKey::<Bn254>::deserialize_with_mode(body, Compress::Yes, Validate::Yes)
         .map_err(|e| crate::ZkError::Serialize(format!("deserialize pk: {e}")))
@@ -379,12 +376,10 @@ mod tests {
         )
         .unwrap());
         // ...but is rejected by the pinned canonical VK.
-        assert!(!verify_proof_with_vk(
-            &canonical_vk,
-            &attacker.proof_bytes,
-            attacker.commitment
-        )
-        .unwrap());
+        assert!(
+            !verify_proof_with_vk(&canonical_vk, &attacker.proof_bytes, attacker.commitment)
+                .unwrap()
+        );
     }
 
     #[test]

--- a/crates/dp-zk/src/commitment_circuit.rs
+++ b/crates/dp-zk/src/commitment_circuit.rs
@@ -67,36 +67,114 @@ pub struct SingleOrderProof {
     pub vk_bytes: Vec<u8>,
 }
 
-pub fn setup_and_prove<R: RngCore + CryptoRng>(
+type Groth16Keys = (
+    ark_groth16::ProvingKey<Bn254>,
+    ark_groth16::VerifyingKey<Bn254>,
+);
+
+/// Run the **one-time** trusted setup for `CommitmentPreimageCircuit` and
+/// return the proving/verifying key pair.
+///
+/// This is the only sound way to obtain a verifying key: setup is run once,
+/// the resulting VK is pinned as canonical, and every prover then uses the
+/// matching proving key. The verifier must NEVER accept a prover-supplied
+/// VK — see [`verify_proof_with_vk`].
+///
+/// The circuit shape is fixed (witness values don't affect the constraint
+/// system here — they only affect the public-input value), so any concrete
+/// circuit instance produces an interchangeable key pair for the same RNG.
+pub fn generate_keys<R: RngCore + CryptoRng>(rng: &mut R) -> Result<Groth16Keys, crate::ZkError> {
+    // The witness values are placeholders: setup only inspects the
+    // constraint structure, which is identical for every instance of this
+    // circuit. Using zeros keeps key generation independent of any order.
+    let shape = CommitmentPreimageCircuit {
+        trader_id: Fr::from(0u64),
+        side: Fr::from(0u64),
+        limit_price: Fr::from(0u64),
+        size: Fr::from(0u64),
+        salt: Fr::from(0u64),
+    };
+    Groth16::<Bn254>::circuit_specific_setup(shape, rng)
+        .map_err(|e| crate::ZkError::Setup(e.to_string()))
+}
+
+/// Prove against an existing (canonical) proving key. The verifying key is
+/// NOT emitted — proving must not let the prover choose the VK. Returns the
+/// commitment (engine cross-checks this) and the compressed proof bytes.
+pub fn prove_with_key<R: RngCore + CryptoRng>(
+    pk: &ark_groth16::ProvingKey<Bn254>,
     circuit: &CommitmentPreimageCircuit,
     rng: &mut R,
-) -> Result<SingleOrderProof, crate::ZkError> {
+) -> Result<(Fr, Vec<u8>), crate::ZkError> {
     let commitment = compute_commitment_native(circuit);
-
-    let (pk, vk) = Groth16::<Bn254>::circuit_specific_setup(circuit.clone(), rng)
-        .map_err(|e| crate::ZkError::Setup(e.to_string()))?;
-
-    let proof = Groth16::<Bn254>::prove(&pk, circuit.clone(), rng)
+    let proof = Groth16::<Bn254>::prove(pk, circuit.clone(), rng)
         .map_err(|e| crate::ZkError::Prove(e.to_string()))?;
-
-    let pvk =
-        Groth16::<Bn254>::process_vk(&vk).map_err(|e| crate::ZkError::Setup(e.to_string()))?;
-
-    let valid = Groth16::<Bn254>::verify_with_processed_vk(&pvk, &[commitment], &proof)
-        .map_err(|e| crate::ZkError::Prove(e.to_string()))?;
-
-    if !valid {
-        return Err(crate::ZkError::Verify);
-    }
-
     let mut proof_bytes = Vec::new();
     proof
         .serialize_with_mode(&mut proof_bytes, Compress::Yes)
         .map_err(|e| crate::ZkError::Serialize(e.to_string()))?;
+    Ok((commitment, proof_bytes))
+}
 
-    let mut vk_bytes = Vec::new();
-    vk.serialize_with_mode(&mut vk_bytes, Compress::Yes)
+/// Serialize a verifying key to compressed bytes (for embedding/distribution).
+pub fn serialize_vk(vk: &ark_groth16::VerifyingKey<Bn254>) -> Result<Vec<u8>, crate::ZkError> {
+    let mut bytes = Vec::new();
+    vk.serialize_with_mode(&mut bytes, Compress::Yes)
         .map_err(|e| crate::ZkError::Serialize(e.to_string()))?;
+    Ok(bytes)
+}
+
+/// Serialize a proving key to compressed bytes (for distribution to provers).
+pub fn serialize_pk(pk: &ark_groth16::ProvingKey<Bn254>) -> Result<Vec<u8>, crate::ZkError> {
+    let mut bytes = Vec::new();
+    pk.serialize_with_mode(&mut bytes, Compress::Yes)
+        .map_err(|e| crate::ZkError::Serialize(e.to_string()))?;
+    Ok(bytes)
+}
+
+/// Deserialize a verifying key from compressed bytes.
+pub fn deserialize_vk(
+    vk_bytes: &[u8],
+) -> Result<ark_groth16::VerifyingKey<Bn254>, crate::ZkError> {
+    ark_groth16::VerifyingKey::<Bn254>::deserialize_with_mode(vk_bytes, Compress::Yes, Validate::Yes)
+        .map_err(|e| crate::ZkError::Serialize(format!("deserialize vk: {e}")))
+}
+
+/// Deserialize a proving key from compressed bytes.
+pub fn deserialize_pk(
+    pk_bytes: &[u8],
+) -> Result<ark_groth16::ProvingKey<Bn254>, crate::ZkError> {
+    ark_groth16::ProvingKey::<Bn254>::deserialize_with_mode(pk_bytes, Compress::Yes, Validate::Yes)
+        .map_err(|e| crate::ZkError::Serialize(format!("deserialize pk: {e}")))
+}
+
+/// **DEMO / FIXTURE USE ONLY — NOT a verification primitive.**
+///
+/// Runs `circuit_specific_setup` *per proof* with the caller's RNG, so the
+/// prover generates its own verifying key. A proof produced this way is
+/// only meaningful when verified against the VK emitted alongside it — which
+/// is exactly the unsoundness a verifier must avoid: a malicious prover can
+/// run setup for a trivially-satisfiable circuit and emit a `(vk, proof)`
+/// pair that verifies for an arbitrary commitment.
+///
+/// The engine MUST NOT use this. It exists for CLI fixtures and WASM demos
+/// where there is no canonical VK to verify against. Soundness at ingestion
+/// comes from [`generate_keys`] (run once) + [`prove_with_key`] +
+/// [`verify_proof_with_vk`] (against the pinned canonical VK).
+pub fn setup_and_prove<R: RngCore + CryptoRng>(
+    circuit: &CommitmentPreimageCircuit,
+    rng: &mut R,
+) -> Result<SingleOrderProof, crate::ZkError> {
+    let (pk, vk) = generate_keys(rng)?;
+    let (commitment, proof_bytes) = prove_with_key(&pk, circuit, rng)?;
+    let vk_bytes = serialize_vk(&vk)?;
+
+    // Self-check the proof verifies under the just-generated VK. This is a
+    // sanity check on the prover, NOT a security guarantee — the VK is
+    // prover-chosen here.
+    if !verify_proof(&vk_bytes, &proof_bytes, commitment)? {
+        return Err(crate::ZkError::Verify);
+    }
 
     Ok(SingleOrderProof {
         commitment,
@@ -105,18 +183,15 @@ pub fn setup_and_prove<R: RngCore + CryptoRng>(
     })
 }
 
-pub fn verify_proof(
-    vk_bytes: &[u8],
+/// Verify a proof against a deserialized, **canonical** verifying key. This
+/// is the sound entrypoint: the VK is pinned by the verifier (loaded once at
+/// boot), never supplied by the prover. The proof is bound to `commitment`
+/// via the public input.
+pub fn verify_proof_with_vk(
+    vk: &ark_groth16::VerifyingKey<Bn254>,
     proof_bytes: &[u8],
     commitment: Fr,
 ) -> Result<bool, crate::ZkError> {
-    let vk = ark_groth16::VerifyingKey::<Bn254>::deserialize_with_mode(
-        vk_bytes,
-        Compress::Yes,
-        Validate::Yes,
-    )
-    .map_err(|e| crate::ZkError::Serialize(format!("deserialize vk: {e}")))?;
-
     let proof = ark_groth16::Proof::<Bn254>::deserialize_with_mode(
         proof_bytes,
         Compress::Yes,
@@ -124,11 +199,26 @@ pub fn verify_proof(
     )
     .map_err(|e| crate::ZkError::Serialize(format!("deserialize proof: {e}")))?;
 
-    let pvk = ark_groth16::prepare_verifying_key(&vk);
+    let pvk = ark_groth16::prepare_verifying_key(vk);
     let valid = Groth16::<Bn254>::verify_with_processed_vk(&pvk, &[commitment], &proof)
         .map_err(|e| crate::ZkError::Prove(e.to_string()))?;
 
     Ok(valid)
+}
+
+/// Verify a proof against a verifying key supplied as bytes.
+///
+/// SECURITY: the caller is responsible for the provenance of `vk_bytes`. If
+/// the bytes came from the prover, the result is meaningless (see
+/// [`setup_and_prove`]). Pass the canonical VK only. The engine uses
+/// [`verify_proof_with_vk`] with a VK it loaded at boot.
+pub fn verify_proof(
+    vk_bytes: &[u8],
+    proof_bytes: &[u8],
+    commitment: Fr,
+) -> Result<bool, crate::ZkError> {
+    let vk = deserialize_vk(vk_bytes)?;
+    verify_proof_with_vk(&vk, proof_bytes, commitment)
 }
 
 #[cfg(test)]
@@ -184,5 +274,71 @@ mod tests {
         assert_eq!(r1.commitment, r2.commitment);
         assert_eq!(r1.proof_bytes, r2.proof_bytes);
         assert_eq!(r1.vk_bytes, r2.vk_bytes);
+    }
+
+    /// A VK generated once by `generate_keys` (independent of any order's
+    /// witness, using a zero shape) verifies a real order proof produced
+    /// against the matching proving key. This is the canonical-VK flow the
+    /// engine uses.
+    #[test]
+    fn canonical_keys_prove_and_verify() {
+        let mut rng = fixed_rng();
+        let (pk, vk) = generate_keys(&mut rng).unwrap();
+
+        let circuit = sample_circuit();
+        let (commitment, proof_bytes) = prove_with_key(&pk, &circuit, &mut rng).unwrap();
+
+        assert!(verify_proof_with_vk(&vk, &proof_bytes, commitment).unwrap());
+        // Tampering with the commitment public input must fail.
+        assert!(!verify_proof_with_vk(&vk, &proof_bytes, commitment + Fr::one()).unwrap());
+    }
+
+    /// SOUNDNESS REGRESSION (issue #158): a proof produced under one VK must
+    /// NOT verify against a different, canonical VK. The old per-proof-setup
+    /// path let a prover ship its own VK; pinning a canonical VK closes that
+    /// hole. A proof minted under `setup_and_prove`'s prover-chosen VK is
+    /// rejected by an independently generated canonical VK.
+    #[test]
+    fn proof_under_foreign_vk_rejected_by_canonical_vk() {
+        let circuit = sample_circuit();
+
+        // Prover-chosen keys (the attack surface): VK travels with the proof.
+        let mut prover_rng = StdRng::from_seed([7u8; 32]);
+        let attacker = setup_and_prove(&circuit, &mut prover_rng).unwrap();
+
+        // Canonical keys: generated once by the operator with different RNG.
+        let mut canonical_rng = StdRng::from_seed([99u8; 32]);
+        let (_pk, canonical_vk) = generate_keys(&mut canonical_rng).unwrap();
+
+        // The attacker's proof verifies under its own VK (that's the trap)...
+        assert!(verify_proof(
+            &attacker.vk_bytes,
+            &attacker.proof_bytes,
+            attacker.commitment
+        )
+        .unwrap());
+        // ...but is rejected by the pinned canonical VK.
+        assert!(!verify_proof_with_vk(
+            &canonical_vk,
+            &attacker.proof_bytes,
+            attacker.commitment
+        )
+        .unwrap());
+    }
+
+    #[test]
+    fn vk_pk_round_trip_serialization() {
+        let mut rng = fixed_rng();
+        let (pk, vk) = generate_keys(&mut rng).unwrap();
+        let vk_bytes = serialize_vk(&vk).unwrap();
+        let pk_bytes = serialize_pk(&pk).unwrap();
+
+        let vk2 = deserialize_vk(&vk_bytes).unwrap();
+        let pk2 = deserialize_pk(&pk_bytes).unwrap();
+
+        // A proof under the round-tripped pk verifies under the round-tripped vk.
+        let circuit = sample_circuit();
+        let (commitment, proof_bytes) = prove_with_key(&pk2, &circuit, &mut rng).unwrap();
+        assert!(verify_proof_with_vk(&vk2, &proof_bytes, commitment).unwrap());
     }
 }

--- a/docs/adr/0001-client-order-proof.md
+++ b/docs/adr/0001-client-order-proof.md
@@ -1,9 +1,62 @@
 # ADR 0001 — Client-side order proof circuit
 
-- **Status:** Accepted
+- **Status:** Accepted (design) — **NOT IMPLEMENTED**; verification deferred
 - **Date:** 2026-05-24
 - **Tag:** C5
 - **Issue:** [#85](https://github.com/Dnreikronos/DarkPool-Exchange/issues/85)
+- **Amended:** 2026-06-01 — see "Implementation status" below ([#158](https://github.com/Dnreikronos/DarkPool-Exchange/issues/158))
+
+## Implementation status (issue #158)
+
+> **What is cryptographically enforced today: the per-order proof is NOT.**
+> The live ingestion path (`Engine::place_encrypted_order`) accepts the
+> `proof` and `commitment` fields **unverified**. Order validity is
+> **operator-enforced**: the operator decrypts the ciphertext and re-derives
+> the canonical Poseidon commitment over the decrypted fields
+> (`derive_order_secrets`); that re-derived value — never the client's — is
+> persisted and carried into the settlement-grade batch IVC proof, which *is*
+> verified on-chain. The advertised per-order "proof of validity" is, for now,
+> operator-enforced redundancy, not a cryptographic guarantee at ingestion.
+
+This ADR's design (verify a per-order Groth16 at ingestion against a pinned
+canonical VK) is still the target, but it was **not** implementable as a
+single fix for #158, for two reasons:
+
+1. **Soundness of the original demo circuit.** The first cut ran
+   `Groth16::circuit_specific_setup` *per proof* with the prover's own RNG, so
+   the prover generated its own verifying key — a malicious prover could prove
+   an arbitrary commitment against a VK it chose. Issue #158 fixed this in
+   `dp-zk`: setup is now split from proving
+   (`generate_keys` → `prove_with_key` → `verify_proof_with_vk`), the per-proof
+   `setup_and_prove` is documented as **demo/fixture-only, unsound for
+   verification**, and `dp-zk-cli setup-commitment-circuit` generates the
+   canonical key pair **once**. A soundness regression test asserts a proof
+   minted under a foreign VK is rejected by the canonical VK.
+
+2. **Post-#153 commitment is not client-reproducible.** Since
+   [#153](https://github.com/Dnreikronos/DarkPool-Exchange/issues/153) the
+   engine binds `trader_id` to the verified on-chain address and derives the
+   `salt` **server-side**
+   (`SHA256("salt" ‖ server_nonce ‖ commitment_key ‖ order_id)`). The client
+   has neither the server nonce nor the server-assigned `order_id` at proving
+   time, so it cannot compute the commitment the engine derives. Because the
+   circuit's **only** public input is that commitment, "verify the proof
+   against the engine-derived commitment" can never pass as specified here.
+
+**To actually enforce a per-order proof (deferred to #97/#98)** one of these
+must change first:
+
+- **Richer public inputs:** expose `trader_id`, `side`, `limit_price`,
+  `order_size` as public inputs so the engine can bind the proof to the
+  decrypted fields without needing a client-reproducible commitment; OR
+- **Client-reproducible commitment:** let the client choose the salt and
+  compute the commitment (partially reverting #153's salt-at-rest), so the
+  engine-derived commitment equals the proof's public input.
+
+Either path also requires the one-time trusted-setup ceremony described in
+§6. Until then the engine path is honest about being operator-enforced; the
+sound keygen/verify primitives and the canonical-VK CLI are in place as the
+groundwork.
 
 ## Context
 


### PR DESCRIPTION
Closes #158

The per-order proof submitted with each order was accepted and thrown away. `place_encrypted_order` took the proof bytes, logged the length, and never checked them, so the advertised "submit a ZK proof of validity" gave a false sense of a guarantee that wasn't there. Worse, the commitment circuit ran `circuit_specific_setup` per proof with the prover's own RNG, so the prover picked its own verifying key: a malicious prover could run setup for a trivially satisfiable circuit and produce a `(vk, proof)` that verifies for any commitment.

We can't verify the per-order proof at ingestion yet. Since #153 the engine binds `trader_id` to the on-chain address and derives the salt server-side, so the client can't reproduce the commitment, and the circuit's only public input is that commitment. Pinning a canonical VK and checking against it can't pass until the circuit grows richer public inputs (or the client owns the salt again), plus a trusted-setup ceremony. That work stays in #97/#98, so for now this fixes the soundness bug and makes everything else honest about what's actually enforced.

Setup is split from proving in `dp-zk`: `generate_keys` runs the one-time setup, `prove_with_key` proves without emitting a VK, and `verify_proof_with_vk` checks against a pinned VK. `setup_and_prove` stays for CLI fixtures and WASM demos but is documented as unsound for verification, with a regression test that a proof minted under a foreign VK is rejected by an independently generated canonical VK. `dp-zk-cli` gains `setup-commitment-circuit` to mint the canonical pair once. `place_encrypted_order` now documents that validity is operator-enforced (the engine re-derives the commitment over the decrypted fields) and the proof argument is renamed `_unverified_proof`. The proto and `validate_proof` comments no longer claim the commitment binds the proof to the ciphertext, and ADR 0001 carries the real status plus the path to a verified proof.

Review follow-ups in the same vein. `--seed` on the setup command now requires `--allow-insecure-seed-for-fixtures`, since a known seed reconstructs the Groth16 trapdoor and forges proofs under the resulting VK. The command refuses to clobber existing key material and writes each file via a temp sibling then rename, so a rerun or a crash can't pin provers and the operator to mismatched keys. Serialized VK/PK blobs now carry a magic-and-version envelope under a dedicated `COMMITMENT_CIRCUIT_VERSION` (kept separate from the HyperNova `CIRCUIT_VERSION`), so stale or unversioned keys are rejected on load instead of failing silently at proof time.