### PR TITLE
dp-api: Refuse off-loopback plaintext binds by default

### DIFF
--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -695,7 +695,9 @@ mod tests {
         // 0.0.0.0 (the default) is unspecified, not loopback — externally
         // reachable, so plaintext there must be refused at boot.
         let cfg = cfg_with_bind("0.0.0.0:9090", "0.0.0.0:8080", false);
-        let err = cfg.validate_plaintext_bind(&TlsMode::Plaintext).unwrap_err();
+        let err = cfg
+            .validate_plaintext_bind(&TlsMode::Plaintext)
+            .unwrap_err();
         assert!(err.contains("0.0.0.0:9090"), "msg: {err}");
         assert!(err.contains("0.0.0.0:8080"), "msg: {err}");
         assert!(err.contains("--insecure"), "msg: {err}");
@@ -712,9 +714,14 @@ mod tests {
     fn plaintext_bind_flags_only_the_exposed_listener() {
         // gRPC on loopback, REST on every interface → only REST is flagged.
         let cfg = cfg_with_bind("127.0.0.1:9090", "0.0.0.0:8080", false);
-        let err = cfg.validate_plaintext_bind(&TlsMode::Plaintext).unwrap_err();
+        let err = cfg
+            .validate_plaintext_bind(&TlsMode::Plaintext)
+            .unwrap_err();
         assert!(err.contains("0.0.0.0:8080"), "msg: {err}");
-        assert!(!err.contains("9090"), "loopback listener must not be flagged: {err}");
+        assert!(
+            !err.contains("9090"),
+            "loopback listener must not be flagged: {err}"
+        );
     }
 
     #[test]

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -35,6 +35,20 @@ pub struct Config {
     #[arg(long, env = "DARKPOOL_TLS_CLIENT_CA", default_value = "")]
     pub tls_client_ca: String,
 
+    /// Permit binding plaintext (no TLS) on a non-loopback address.
+    /// Without it, a plaintext bind to anything other than a loopback
+    /// interface is a hard boot failure: the API key, the SIWE bearer
+    /// token, and order ciphertext/metadata would otherwise travel in
+    /// the clear to any on-path observer, defeating the SIWE replay
+    /// mitigations that assume TLS. Loopback-only plaintext (local dev)
+    /// never needs this flag. Set it only for trusted-network
+    /// development or when a TLS-terminating reverse proxy / load
+    /// balancer fronts the service (in which case also set
+    /// --trusted-proxies). Never point a plaintext listener directly at
+    /// an untrusted network. See [`Config::validate_plaintext_bind`].
+    #[arg(long, env = "DARKPOOL_INSECURE", default_value = "false")]
+    pub insecure: bool,
+
     #[arg(long, env = "DARKPOOL_AUCTION_INTERVAL", default_value = "5s", value_parser = parse_duration)]
     pub auction_interval: Duration,
 
@@ -327,6 +341,41 @@ impl Config {
         Ok(())
     }
 
+    /// Fail-closed guard against serving plaintext on an
+    /// externally-reachable interface. With no TLS material configured
+    /// the server defaults to binding `0.0.0.0` (every interface) in the
+    /// clear — exposing the API key, the SIWE bearer token, and order
+    /// ciphertext/metadata to any on-path observer. Refuse to boot in
+    /// that posture unless every plaintext listener is loopback-only, or
+    /// the operator explicitly accepts the risk with `--insecure`
+    /// (e.g. a TLS-terminating proxy fronts the service). TLS / mTLS
+    /// modes encrypt the wire and are always allowed.
+    ///
+    /// Takes the already-resolved [`TlsMode`] so the boot path validates
+    /// the same posture it is about to bind, rather than re-deriving it.
+    pub fn validate_plaintext_bind(&self, tls_mode: &TlsMode) -> Result<(), String> {
+        if !matches!(tls_mode, TlsMode::Plaintext) || self.insecure {
+            return Ok(());
+        }
+        let exposed: Vec<String> = [self.grpc_addr, self.http_addr]
+            .iter()
+            .filter(|addr| !addr.ip().is_loopback())
+            .map(|addr| addr.to_string())
+            .collect();
+        if exposed.is_empty() {
+            return Ok(());
+        }
+        Err(format!(
+            "plaintext transport on non-loopback bind(s) {} — the API key, SIWE \
+             bearer token, and order ciphertext/metadata would travel in the clear. \
+             Configure TLS with --tls-cert/--tls-key (see \
+             docs/operations/tls-setup.md), bind loopback only, or pass --insecure / \
+             DARKPOOL_INSECURE=true to override (e.g. when a TLS-terminating proxy \
+             fronts the service).",
+            exposed.join(", "),
+        ))
+    }
+
     pub fn tls_cert_path(&self) -> Option<&str> {
         opt(&self.tls_cert)
     }
@@ -376,8 +425,10 @@ impl Config {
 /// of what the operator can ask for via [`Config::tls_mode`]:
 ///
 /// - `Plaintext` — no TLS material configured; both listeners bind
-///   plaintext. Acceptable for local dev only; main.rs logs a loud
-///   warning at boot.
+///   plaintext. Loopback-only is acceptable for local dev (main.rs logs
+///   a loud warning); a non-loopback plaintext bind is a hard boot
+///   failure unless `--insecure` is set. See
+///   [`Config::validate_plaintext_bind`].
 /// - `Tls` — server-auth TLS, no client cert required.
 /// - `Mtls` — mutual TLS, clients must present a cert signed by
 ///   `client_ca`.
@@ -610,5 +661,81 @@ mod tests {
         let cfg = cfg_with_admin("op-secret-1", true);
         assert!(cfg.validate_admin_auth().is_ok());
         assert_eq!(cfg.operator_api_keys(), vec!["op-secret-1"]);
+    }
+
+    fn cfg_with_bind(grpc: &str, http: &str, insecure: bool) -> Config {
+        let mut args = vec![
+            "darkpool-server".to_string(),
+            "--grpc-addr".into(),
+            grpc.into(),
+            "--http-addr".into(),
+            http.into(),
+        ];
+        if insecure {
+            args.push("--insecure".into());
+        }
+        Config::parse_from(args)
+    }
+
+    #[test]
+    fn plaintext_bind_loopback_only_is_ok() {
+        // Local dev on loopback needs no opt-in.
+        let cfg = cfg_with_bind("127.0.0.1:9090", "127.0.0.1:8080", false);
+        assert!(cfg.validate_plaintext_bind(&TlsMode::Plaintext).is_ok());
+    }
+
+    #[test]
+    fn plaintext_bind_ipv6_loopback_is_ok() {
+        let cfg = cfg_with_bind("[::1]:9090", "[::1]:8080", false);
+        assert!(cfg.validate_plaintext_bind(&TlsMode::Plaintext).is_ok());
+    }
+
+    #[test]
+    fn plaintext_bind_non_loopback_fails_without_insecure() {
+        // 0.0.0.0 (the default) is unspecified, not loopback — externally
+        // reachable, so plaintext there must be refused at boot.
+        let cfg = cfg_with_bind("0.0.0.0:9090", "0.0.0.0:8080", false);
+        let err = cfg.validate_plaintext_bind(&TlsMode::Plaintext).unwrap_err();
+        assert!(err.contains("0.0.0.0:9090"), "msg: {err}");
+        assert!(err.contains("0.0.0.0:8080"), "msg: {err}");
+        assert!(err.contains("--insecure"), "msg: {err}");
+    }
+
+    #[test]
+    fn plaintext_bind_non_loopback_ok_with_insecure() {
+        let cfg = cfg_with_bind("0.0.0.0:9090", "0.0.0.0:8080", true);
+        assert!(cfg.insecure);
+        assert!(cfg.validate_plaintext_bind(&TlsMode::Plaintext).is_ok());
+    }
+
+    #[test]
+    fn plaintext_bind_flags_only_the_exposed_listener() {
+        // gRPC on loopback, REST on every interface → only REST is flagged.
+        let cfg = cfg_with_bind("127.0.0.1:9090", "0.0.0.0:8080", false);
+        let err = cfg.validate_plaintext_bind(&TlsMode::Plaintext).unwrap_err();
+        assert!(err.contains("0.0.0.0:8080"), "msg: {err}");
+        assert!(!err.contains("9090"), "loopback listener must not be flagged: {err}");
+    }
+
+    #[test]
+    fn tls_bind_non_loopback_ok_without_insecure() {
+        // TLS encrypts the wire — a non-loopback bind needs no override.
+        let cfg = cfg_with_bind("0.0.0.0:9090", "0.0.0.0:8080", false);
+        let mode = TlsMode::Tls {
+            cert: "/srv/cert.pem".into(),
+            key: "/srv/key.pem".into(),
+        };
+        assert!(cfg.validate_plaintext_bind(&mode).is_ok());
+    }
+
+    #[test]
+    fn mtls_bind_non_loopback_ok_without_insecure() {
+        let cfg = cfg_with_bind("0.0.0.0:9090", "0.0.0.0:8080", false);
+        let mode = TlsMode::Mtls {
+            cert: "/srv/cert.pem".into(),
+            key: "/srv/key.pem".into(),
+            client_ca: "/srv/ca.pem".into(),
+        };
+        assert!(cfg.validate_plaintext_bind(&mode).is_ok());
     }
 }

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -54,6 +54,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let tls_mode = cfg
         .tls_mode()
         .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
+    // Fail closed before binding: plaintext on a non-loopback interface
+    // leaks credentials and order metadata on the wire. Loopback-only
+    // plaintext (local dev) and an explicit --insecure override are the
+    // only ways past this check.
+    cfg.validate_plaintext_bind(&tls_mode)
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> { e.into() })?;
     if matches!(tls_mode, TlsMode::Plaintext) {
         warn!(
             grpc = %cfg.grpc_addr,

--- a/docs/operations/tls-setup.md
+++ b/docs/operations/tls-setup.md
@@ -20,12 +20,22 @@ opt-in via a separate client-CA bundle.
 | `--tls-cert` / `DARKPOOL_TLS_CERT` | PEM cert (or chain). When set together with `--tls-key`, TLS is enabled on both listeners. |
 | `--tls-key`  / `DARKPOOL_TLS_KEY`  | PEM private key matching `--tls-cert`. |
 | `--tls-client-ca` / `DARKPOOL_TLS_CLIENT_CA` | PEM CA bundle that signs *client* certificates. Presence enables mTLS — clients without a cert chained to this bundle are rejected at the handshake. |
+| `--insecure` / `DARKPOOL_INSECURE` | Opt in to plaintext on a **non-loopback** bind. Required only when no TLS material is configured and at least one listener binds something other than a loopback address (e.g. the default `0.0.0.0`). Loopback-only plaintext never needs it. |
 
 Validation rules (enforced at boot — invalid combinations exit
 non-zero):
 
 - Both `--tls-cert` and `--tls-key` empty → **plaintext mode**, with a
   loud `warn!` so it is impossible to ship to prod silently.
+- Plaintext mode on a **non-loopback** bind (the default `--grpc-addr` /
+  `--http-addr` are `0.0.0.0`, which is externally reachable) → **fatal
+  error** unless `--insecure` / `DARKPOOL_INSECURE=true` is set.
+  Off-loopback plaintext leaks the API key, the SIWE bearer token, and
+  order ciphertext/metadata to any on-path observer, and undermines the
+  SIWE replay mitigations that assume TLS. Either configure TLS, bind
+  loopback only, or accept the risk explicitly with `--insecure` (the
+  usual case being a TLS-terminating reverse proxy / load balancer in
+  front — also set `--trusted-proxies` then).
 - Exactly one of `--tls-cert` / `--tls-key` set → fatal error.
 - `--tls-client-ca` set without `--tls-cert`/`--tls-key` → fatal
   error (otherwise mTLS would silently degrade to "no TLS at all").


### PR DESCRIPTION
Closes #169

With no TLS cert/key configured the server fell back to plaintext and still bound the default `0.0.0.0` listeners, warning but serving anyway. That puts the API key, the SIWE bearer token, and order ciphertext/metadata on the wire in the clear for any on-path observer, and quietly undercuts the SIWE replay mitigations that assume TLS.

Boot now validates the resolved TLS posture against the bind addresses. Loopback-only plaintext stays fine for local dev, but a plaintext listener on any non-loopback address is a hard boot failure unless the operator opts in with `--insecure` / `DARKPOOL_INSECURE` (the usual case being a TLS-terminating proxy out front, where you'd also set `--trusted-proxies`). TLS and mTLS are unaffected.

Note this flips the default dev ergonomics: `cargo run -p dp-api` with no TLS now refuses to start, since the defaults bind `0.0.0.0`. Bind loopback or pass `--insecure`. The TLS runbook documents both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--insecure` CLI flag / `DARKPOOL_INSECURE` env to allow plaintext on non-loopback interfaces. Loopback-only plaintext remains allowed. Boot-time fail-closed validation now prevents non-loopback plaintext unless opted in.

* **Documentation**
  * Expanded TLS/mTLS operations docs with clarified plaintext validation, non-loopback requirements, and recommended proxy setups.

* **Tests**
  * Added coverage for plaintext binding validation across loopback, non-loopback, and TLS modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->