### PR TITLE
contracts: Harden deposit() with token allowlist and balance-delta accounting

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -67,6 +67,22 @@ contract DeployScript is Script {
         console.log("DarkPool:", address(pool));
         console.log("OperatorPubkey bytes:", operatorPubkey.length);
 
+        // Allowlist the tradeable tokens so the pool accepts deposits out of
+        // the box. deposit() rejects any token not on the allowlist, so a
+        // pool deployed without this can never take a deposit. Pass a
+        // comma-free single address per env var; both are optional so local
+        // smoke deploys can skip them and allowlist later via setTokenAllowed.
+        if (vm.envExists("BASE_TOKEN")) {
+            address baseToken = vm.envAddress("BASE_TOKEN");
+            pool.setTokenAllowed(baseToken, true);
+            console.log("Allowlisted base token:", baseToken);
+        }
+        if (vm.envExists("QUOTE_TOKEN")) {
+            address quoteToken = vm.envAddress("QUOTE_TOKEN");
+            pool.setTokenAllowed(quoteToken, true);
+            console.log("Allowlisted quote token:", quoteToken);
+        }
+
         require(
             block.chainid != 1,
             "stub IVC verifier cannot be deployed on mainnet; use a real Decider verifier"

--- a/contracts/src/DarkPool.sol
+++ b/contracts/src/DarkPool.sol
@@ -23,6 +23,14 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
     mapping(bytes32 => bool) public settled;
     mapping(address => mapping(address => uint256)) public balances;
 
+    /// @notice Tokens approved for deposit. Only vetted, standard ERC20s
+    ///         (no fee-on-transfer, no rebasing) should ever be allowlisted.
+    ///         `deposit` rejects any token not present here, and even for
+    ///         allowlisted tokens it credits the measured balance delta —
+    ///         not the requested `amount` — so a token that transfers less
+    ///         than requested can never overstate internal `balances`.
+    mapping(address => bool) public allowedTokens;
+
     IDeciderVerifier public ivcVerifier;
     mapping(bytes32 => bool) public sessionSubmitted;
     mapping(bytes32 => bytes32) public auctionToSession;
@@ -81,11 +89,37 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         emit OperatorPubkeyUpdated(bytes(""), operatorPubkey_, uint64(block.timestamp));
     }
 
-    function deposit(address token, uint256 amount) external whenNotPaused {
+    /// @notice Deposit `amount` of an allowlisted ERC20 into escrow.
+    /// @dev Credits the *measured* balance delta rather than the requested
+    ///      `amount`. For a fee-on-transfer or rebasing token the contract
+    ///      would receive less than `amount`; crediting the request would
+    ///      overstate `balances` and let later withdrawals/settlements drain
+    ///      other users' funds (insolvency). Measuring the delta around the
+    ///      transfer makes internal accounting track real holdings exactly.
+    ///      The allowlist is the primary defense (only vetted standard ERC20s
+    ///      are accepted); the delta check is defense-in-depth. `nonReentrant`
+    ///      guards the pre/post balanceOf reads against a malicious token that
+    ///      re-enters mid-transfer.
+    function deposit(address token, uint256 amount) external nonReentrant whenNotPaused {
         require(amount > 0, "zero amount");
+        require(allowedTokens[token], "token not allowed");
+        uint256 balanceBefore = IERC20(token).balanceOf(address(this));
         IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
-        balances[msg.sender][token] += amount;
-        emit Deposit(msg.sender, token, amount);
+        uint256 received = IERC20(token).balanceOf(address(this)) - balanceBefore;
+        require(received > 0, "no tokens received");
+        balances[msg.sender][token] += received;
+        emit Deposit(msg.sender, token, received);
+    }
+
+    /// @notice Add or remove a token from the deposit allowlist.
+    /// @dev Owner-only. Allowlist only tokens that have been vetted as
+    ///      standard, non-fee-on-transfer, non-rebasing ERC20s. Removing a
+    ///      token blocks new deposits but does not touch existing balances —
+    ///      traders can still withdraw what they already hold.
+    function setTokenAllowed(address token, bool allowed) external onlyOwner {
+        require(token != address(0), "zero token");
+        allowedTokens[token] = allowed;
+        emit TokenAllowed(token, allowed);
     }
 
     function withdraw(address token, uint256 amount) external nonReentrant whenNotPaused {

--- a/contracts/src/interfaces/IDarkPool.sol
+++ b/contracts/src/interfaces/IDarkPool.sol
@@ -24,7 +24,11 @@ interface IDarkPool {
     ///         accepted by the off-chain decrypter until in-flight
     ///         orders drain.
     event OperatorPubkeyUpdated(bytes oldPubkey, bytes newPubkey, uint64 effectiveAt);
+    /// @notice Emitted when the owner adds or removes a token from the
+    ///         deposit allowlist. `allowed` is the new state.
+    event TokenAllowed(address indexed token, bool allowed);
     function deposit(address token, uint256 amount) external;
+    function setTokenAllowed(address token, bool allowed) external;
     function withdraw(address token, uint256 amount) external;
     function submitBatch(
         bytes32 batchId,

--- a/contracts/test/DarkPool.t.sol
+++ b/contracts/test/DarkPool.t.sol
@@ -8,6 +8,8 @@ import {IVerifier} from "../src/interfaces/IVerifier.sol";
 import {HyperNovaDeciderVerifier} from "../src/HyperNovaDeciderVerifier.sol";
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 import {MockERC20} from "./mocks/MockERC20.sol";
+import {FeeOnTransferERC20} from "./mocks/FeeOnTransferERC20.sol";
+import {NoopTransferERC20} from "./mocks/NoopTransferERC20.sol";
 
 contract MockVerifier is IVerifier {
     bool public shouldReturn;
@@ -58,6 +60,11 @@ contract DarkPoolTest is Test {
 
         baseToken = new MockERC20("Base", "BASE", 18);
         quoteToken = new MockERC20("Quote", "QUOTE", 18);
+
+        // Allowlist the single MVP pair so deposits are accepted. Tokens
+        // not on the allowlist are rejected by deposit().
+        pool.setTokenAllowed(address(baseToken), true);
+        pool.setTokenAllowed(address(quoteToken), true);
     }
 
     // --- Deposit ---
@@ -93,7 +100,135 @@ contract DarkPoolTest is Test {
         vm.stopPrank();
     }
 
-    // --- Withdraw ---
+    // --- Deposit allowlist (#164) ---
+
+    function test_deposit_notAllowedToken_reverts() public {
+        MockERC20 rogue = new MockERC20("Rogue", "RGE", 18);
+        uint256 amount = 100e18;
+        rogue.mint(trader1, amount);
+
+        vm.startPrank(trader1);
+        rogue.approve(address(pool), amount);
+        vm.expectRevert("token not allowed");
+        pool.deposit(address(rogue), amount);
+        vm.stopPrank();
+    }
+
+    function test_setTokenAllowed_addsAndEmits() public {
+        MockERC20 token = new MockERC20("New", "NEW", 18);
+        assertFalse(pool.allowedTokens(address(token)));
+
+        vm.expectEmit(true, false, false, true);
+        emit IDarkPool.TokenAllowed(address(token), true);
+        pool.setTokenAllowed(address(token), true);
+
+        assertTrue(pool.allowedTokens(address(token)));
+    }
+
+    function test_setTokenAllowed_removesAndEmits() public {
+        assertTrue(pool.allowedTokens(address(quoteToken)));
+
+        vm.expectEmit(true, false, false, true);
+        emit IDarkPool.TokenAllowed(address(quoteToken), false);
+        pool.setTokenAllowed(address(quoteToken), false);
+
+        assertFalse(pool.allowedTokens(address(quoteToken)));
+    }
+
+    function test_setTokenAllowed_notOwner_reverts() public {
+        vm.prank(address(0xdead));
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0xdead)));
+        pool.setTokenAllowed(address(quoteToken), false);
+    }
+
+    function test_setTokenAllowed_zeroToken_reverts() public {
+        vm.expectRevert("zero token");
+        pool.setTokenAllowed(address(0), true);
+    }
+
+    function test_deposit_afterDelisting_reverts() public {
+        pool.setTokenAllowed(address(quoteToken), false);
+
+        uint256 amount = 100e18;
+        quoteToken.mint(trader1, amount);
+        vm.startPrank(trader1);
+        quoteToken.approve(address(pool), amount);
+        vm.expectRevert("token not allowed");
+        pool.deposit(address(quoteToken), amount);
+        vm.stopPrank();
+    }
+
+    function test_withdraw_afterDelisting_succeeds() public {
+        // Delisting a token must not strand funds already deposited.
+        uint256 amount = 100e18;
+        _deposit(trader1, address(quoteToken), amount);
+
+        pool.setTokenAllowed(address(quoteToken), false);
+
+        vm.prank(trader1);
+        pool.withdraw(address(quoteToken), amount);
+
+        assertEq(pool.balances(trader1, address(quoteToken)), 0);
+        assertEq(quoteToken.balanceOf(trader1), amount);
+    }
+
+    // --- Deposit balance-delta accounting (fee-on-transfer) (#164) ---
+
+    function test_deposit_feeOnTransfer_creditsActualReceived() public {
+        // 100 bps (1%) fee-on-transfer token. A deposit of 100e18 transfers
+        // only 99e18 to the pool; balances must reflect the received 99e18,
+        // not the requested 100e18, or internal accounting goes insolvent.
+        FeeOnTransferERC20 fee = new FeeOnTransferERC20("Fee", "FEE", 100);
+        pool.setTokenAllowed(address(fee), true);
+
+        uint256 amount = 100e18;
+        uint256 expectedReceived = amount - (amount * 100 / 10_000); // 99e18
+        fee.mint(trader1, amount);
+
+        vm.startPrank(trader1);
+        fee.approve(address(pool), amount);
+        pool.deposit(address(fee), amount);
+        vm.stopPrank();
+
+        assertEq(pool.balances(trader1, address(fee)), expectedReceived);
+        assertEq(fee.balanceOf(address(pool)), expectedReceived);
+        // Internal accounting never exceeds real holdings.
+        assertEq(pool.balances(trader1, address(fee)), fee.balanceOf(address(pool)));
+    }
+
+    function test_deposit_feeOnTransfer_emitsReceivedAmount() public {
+        FeeOnTransferERC20 fee = new FeeOnTransferERC20("Fee", "FEE", 100);
+        pool.setTokenAllowed(address(fee), true);
+
+        uint256 amount = 100e18;
+        uint256 expectedReceived = 99e18;
+        fee.mint(trader1, amount);
+
+        vm.startPrank(trader1);
+        fee.approve(address(pool), amount);
+        vm.expectEmit(true, true, false, true);
+        emit IDarkPool.Deposit(trader1, address(fee), expectedReceived);
+        pool.deposit(address(fee), amount);
+        vm.stopPrank();
+    }
+
+    function test_deposit_noTokensReceived_reverts() public {
+        // A token whose transferFrom reports success but moves nothing yields
+        // a zero balance delta. deposit() must revert rather than credit a
+        // phantom balance.
+        NoopTransferERC20 noop = new NoopTransferERC20();
+        pool.setTokenAllowed(address(noop), true);
+
+        uint256 amount = 100e18;
+        noop.mint(trader1, amount);
+        vm.startPrank(trader1);
+        noop.approve(address(pool), amount);
+        vm.expectRevert("no tokens received");
+        pool.deposit(address(noop), amount);
+        vm.stopPrank();
+
+        assertEq(pool.balances(trader1, address(noop)), 0);
+    }
 
     function test_withdraw() public {
         uint256 amount = 100e18;

--- a/contracts/test/mocks/FeeOnTransferERC20.sol
+++ b/contracts/test/mocks/FeeOnTransferERC20.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/// @notice ERC20 that burns a fixed bps fee on every transfer, so the
+///         recipient receives less than the requested amount. Used to
+///         verify DarkPool.deposit credits the measured balance delta
+///         rather than the requested amount.
+contract FeeOnTransferERC20 is ERC20 {
+    uint256 public immutable feeBps;
+    uint256 private constant BPS_DENOMINATOR = 10_000;
+
+    constructor(string memory name_, string memory symbol_, uint256 feeBps_) ERC20(name_, symbol_) {
+        require(feeBps_ < BPS_DENOMINATOR, "fee too high");
+        feeBps = feeBps_;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    /// @dev Deducts `feeBps` of every transfer by burning it, so the
+    ///      recipient is credited `amount - fee`. Overrides the internal
+    ///      `_update` hook used by both transfer and transferFrom.
+    function _update(address from, address to, uint256 value) internal override {
+        // Mint/burn (from or to == address(0)) pass through untouched.
+        if (from == address(0) || to == address(0)) {
+            super._update(from, to, value);
+            return;
+        }
+        uint256 fee = value * feeBps / BPS_DENOMINATOR;
+        if (fee > 0) {
+            super._update(from, address(0), fee); // burn the fee
+        }
+        super._update(from, to, value - fee);
+    }
+}

--- a/contracts/test/mocks/NoopTransferERC20.sol
+++ b/contracts/test/mocks/NoopTransferERC20.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @notice Malicious ERC20 whose transferFrom returns true but moves no
+///         tokens. Used to verify DarkPool.deposit rejects a deposit that
+///         credits nothing ("no tokens received") rather than emitting a
+///         phantom balance. Mirrors a 100% fee-on-transfer / broken token.
+contract NoopTransferERC20 is IERC20 {
+    string public name = "Noop";
+    string public symbol = "NOOP";
+    uint8 public decimals = 18;
+
+    mapping(address => uint256) private _balances;
+    mapping(address => mapping(address => uint256)) private _allowances;
+    uint256 private _totalSupply;
+
+    function mint(address to, uint256 amount) external {
+        _balances[to] += amount;
+        _totalSupply += amount;
+    }
+
+    function totalSupply() external view returns (uint256) {
+        return _totalSupply;
+    }
+
+    function balanceOf(address account) external view returns (uint256) {
+        return _balances[account];
+    }
+
+    function allowance(address owner, address spender) external view returns (uint256) {
+        return _allowances[owner][spender];
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        _allowances[msg.sender][spender] = amount;
+        emit Approval(msg.sender, spender, amount);
+        return true;
+    }
+
+    function transfer(address, uint256) external pure returns (bool) {
+        // Moves nothing, reports success.
+        return true;
+    }
+
+    /// @dev Reports success but transfers zero tokens — the pool's measured
+    ///      balance delta is therefore 0.
+    function transferFrom(address, address, uint256) external pure returns (bool) {
+        return true;
+    }
+}

--- a/crates/dp-settlement/abi/DarkPool.json
+++ b/crates/dp-settlement/abi/DarkPool.json
@@ -68,6 +68,25 @@
   },
   {
     "type": "function",
+    "name": "allowedTokens",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "auctionToSession",
     "inputs": [
       {
@@ -403,6 +422,24 @@
         "name": "positionLimit_",
         "type": "uint256",
         "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setTokenAllowed",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "allowed",
+        "type": "bool",
+        "internalType": "bool"
       }
     ],
     "outputs": [],
@@ -847,6 +884,25 @@
         "type": "bytes32",
         "indexed": false,
         "internalType": "bytes32"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TokenAllowed",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "allowed",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
       }
     ],
     "anonymous": false

--- a/crates/dp-settlement/tests/anvil_e2e.rs
+++ b/crates/dp-settlement/tests/anvil_e2e.rs
@@ -220,6 +220,9 @@ async fn settles_batch_end_to_end() {
     await_tx!(quote.approve(pool_addr, notional));
 
     let pool = DarkPool::new(pool_addr, &http_provider);
+    // deposit() rejects tokens not on the allowlist; allowlist the pair first.
+    await_tx!(pool.setTokenAllowed(base_addr, true));
+    await_tx!(pool.setTokenAllowed(quote_addr, true));
     await_tx!(pool.deposit(base_addr, size));
     await_tx!(pool.deposit(quote_addr, notional));
     await_tx!(pool.addOperator(signer_addr));


### PR DESCRIPTION
Closes #164

`deposit()` accepted any ERC20 and credited the requested `amount` instead of what the contract actually received. A fee-on-transfer or rebasing token would transfer less than `amount`, but `balances` would reflect the full request — overstating real holdings. Later withdrawals or settlements could then drain other users' funds. There was also no allowlist, so any token could be deposited.

Two layered defenses now:

**Token allowlist** — owner-managed `allowedTokens` mapping. `deposit()` reverts with `"token not allowed"` for anything not on it. `setTokenAllowed(token, bool)` is `onlyOwner`, rejects the zero address, emits `TokenAllowed`. Removing a token blocks new deposits but doesn't strand existing balances — traders can still withdraw. Good enough for the single-pair ETH/USDC MVP, and scales to multi-pair by just allowlisting more tokens.

**Balance-delta accounting** — measures `balanceOf(this)` before and after `safeTransferFrom`, credits the actual delta. Reverts `"no tokens received"` on a zero delta. Even if a misbehaving token slips through the allowlist, internal accounting tracks real holdings exactly. `deposit()` is now `nonReentrant` to protect the pre/post reads.

Deploy script optionally allowlists `BASE_TOKEN`/`QUOTE_TOKEN` env vars so a freshly deployed pool can take deposits without a follow-up tx.

New test mocks: `FeeOnTransferERC20` (burns a bps fee on transfer) and `NoopTransferERC20` (reports success, moves nothing). Test cases cover allowlist add/remove/auth/zero-address, deposit-of-unlisted revert, deposit-after-delist revert, withdraw-after-delist succeeds, fee-on-transfer crediting the actual received amount (with `balances == pool.balanceOf` invariant), event carrying the received amount, and zero-delta revert. Existing deposit tests updated to allowlist the pair in `setUp`. Full suite: 106 passed, 0 failed.