### PR TITLE
dp-api: Document XFF append requirement and decouple nonce TTL

### DIFF
--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -102,6 +102,15 @@ pub struct Config {
     /// proxies / load balancers. When the TCP peer matches one of these,
     /// rate limiting and the SIWE nonce cap key on the client IP from
     /// `X-Forwarded-For` / `X-Real-IP` instead of the proxy's address.
+    ///
+    /// Operator requirement: every proxy listed here MUST *append* the real
+    /// peer to `X-Forwarded-For` (e.g. nginx `$proxy_add_x_forwarded_for`)
+    /// and MUST NOT forward a client-supplied `X-Forwarded-For` verbatim.
+    /// The rightmost-untrusted client lookup is spoof-resistant only because
+    /// the hop the trusted proxy appends is the one entry the caller cannot
+    /// control; a pass-through proxy lets the caller forge their own
+    /// rate-limit / nonce key and evade or misattribute the per-IP budget.
+    ///
     /// Empty (the default) means the listener is directly exposed and
     /// forwarding headers are ignored — set this whenever a TLS-terminating
     /// proxy or LB sits in front, or per-IP limits collapse onto the proxy

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -303,7 +303,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let siwe_state = if cfg.siwe_enabled {
         let secret = cfg.session_secret().unwrap();
         let jwt_manager = Arc::new(dp_api::siwe::JwtManager::new(secret, cfg.session_ttl));
-        let nonce_store = Arc::new(dp_api::siwe::NonceStore::new(Duration::from_secs(300)));
+        let nonce_store = Arc::new(dp_api::siwe::NonceStore::new(dp_api::siwe::NONCE_TTL));
         nonce_store.start_cleanup(cancel.clone(), Duration::from_secs(60));
         let chain_id = if cfg.chain_id > 0 {
             Some(cfg.chain_id)

--- a/crates/dp-api/src/ratelimit.rs
+++ b/crates/dp-api/src/ratelimit.rs
@@ -189,10 +189,14 @@ impl TrustedProxies {
 /// a trusted proxy, walk its `X-Forwarded-For` chain right-to-left and
 /// return the rightmost address that is **not** itself a trusted hop —
 /// that is the real client as seen by the outermost proxy we trust, and
-/// the only entry an attacker upstream of our proxies cannot forge. Falls
-/// back to `X-Real-IP`, then the peer IP, when no usable forwarding header
-/// is present. Returns `None` only when there is no peer at all (e.g. unit
-/// tests using `oneshot` without `ConnectInfo`).
+/// the only entry an attacker upstream of our proxies cannot forge. This
+/// last guarantee holds only when each trusted proxy *appends* the real
+/// peer to the chain rather than forwarding a client-supplied
+/// `X-Forwarded-For` verbatim; see the `trusted_proxies` config doc for
+/// the operator requirement. Falls back to `X-Real-IP`, then the peer IP,
+/// when no usable forwarding header is present. Returns `None` only when
+/// there is no peer at all (e.g. unit tests using `oneshot` without
+/// `ConnectInfo`).
 pub fn resolve_client_ip(
     trusted: &TrustedProxies,
     headers: &HeaderMap,

--- a/crates/dp-api/src/siwe.rs
+++ b/crates/dp-api/src/siwe.rs
@@ -168,22 +168,30 @@ pub enum SiweError {
     Verification(String),
 }
 
+/// Server-side single-use nonce lifetime — the authoritative freshness
+/// bound for a SIWE login. The leeway and expiry-window bounds below are
+/// sized relative to this, so it is the single knob to turn; the binary
+/// builds its [`NonceStore`] from this exact value (no separate literal).
+pub const NONCE_TTL: Duration = Duration::from_secs(NONCE_TTL_SECS);
+const NONCE_TTL_SECS: u64 = 300;
+
 /// Clock-skew tolerance when validating the client-supplied `Issued At`.
-/// The authoritative freshness bound is the server nonce TTL (see
-/// [`NonceStore`]); this check only rejects a grossly future `issued_at`,
-/// so generous leeway avoids false rejections from honest client clock
-/// drift (issue #160). Staleness is already covered by the nonce TTL, so
-/// there is deliberately no lower bound here.
+/// The authoritative freshness bound is the server nonce TTL ([`NONCE_TTL`]);
+/// this check only rejects a grossly future `issued_at`, so generous leeway
+/// avoids false rejections from honest client clock drift (issue #160).
+/// Staleness is already covered by the nonce TTL, so there is deliberately
+/// no lower bound here.
 const ISSUED_AT_LEEWAY: time::Duration = time::Duration::seconds(120);
 
 /// Upper bound on how far a SIWE message's `Expiration Time` may sit past
 /// server time. SIWE makes expiry optional; issue #160 requires it and
 /// bounds it so a captured message cannot stay valid indefinitely —
-/// defense-in-depth around the single-use nonce. Sized at ~2x the nonce
-/// TTL (300 s) to absorb honest client clock skew and the client's own
-/// expiry slack without false-rejecting real logins; the nonce remains
-/// the authoritative single-use freshness bound.
-const MAX_EXPIRY_WINDOW: time::Duration = time::Duration::seconds(600);
+/// defense-in-depth around the single-use nonce. Derived as 2x [`NONCE_TTL`]
+/// to absorb honest client clock skew and the client's own expiry slack
+/// without false-rejecting real logins; deriving it (rather than restating
+/// 600 s) keeps it from silently drifting if the nonce TTL changes. The
+/// nonce remains the authoritative single-use freshness bound.
+const MAX_EXPIRY_WINDOW: time::Duration = time::Duration::seconds(2 * NONCE_TTL_SECS as i64);
 
 pub fn verify_siwe_message(
     message_str: &str,

--- a/crates/dp-api/tests/ratelimit.rs
+++ b/crates/dp-api/tests/ratelimit.rs
@@ -211,10 +211,12 @@ fn xff_uses_rightmost_untrusted_hop() {
 
 #[test]
 fn xff_spoof_does_not_extend_the_chain() {
-    // Attacker sends "1.1.1.1, 2.2.2.2" hoping to be keyed as 1.1.1.1.
-    // Neither forged hop is trusted, so the rightmost untrusted entry
-    // (2.2.2.2, what our proxy actually saw as the client) is used — the
-    // attacker cannot pick which bucket they land in beyond their own hop.
+    // Attacker prepends a forged hop ("1.1.1.1, 2.2.2.2") hoping to be keyed
+    // as 1.1.1.1. The rightmost *untrusted* entry (2.2.2.2) wins, so padding
+    // the chain with forged hops on the left cannot move the caller into a
+    // different bucket. (Whether 2.2.2.2 itself is forgeable depends on the
+    // proxy appending the real peer rather than passing this header through
+    // — that invariant is locked by `xff_proxy_appended_client_defeats_spoof`.)
     let trusted = TrustedProxies::parse("10.0.0.0/8").unwrap();
     let h = xff("1.1.1.1, 2.2.2.2");
     assert_eq!(ip_client_key(&trusted, &h, peer([10, 0, 0, 1])), "2.2.2.2");

--- a/crates/dp-api/tests/ratelimit.rs
+++ b/crates/dp-api/tests/ratelimit.rs
@@ -223,6 +223,22 @@ fn xff_spoof_does_not_extend_the_chain() {
 }
 
 #[test]
+fn xff_proxy_appended_client_defeats_spoof() {
+    // The invariant operators actually rely on: a correctly configured proxy
+    // appends the real peer as the rightmost hop, so any client-supplied
+    // forged prefix is ignored. Two different spoofed prefixes carrying the
+    // same appended client must collapse onto the same bucket — the caller
+    // cannot escape their real-IP budget by rotating the forged prefix.
+    let trusted = TrustedProxies::parse("10.0.0.0/8").unwrap();
+    let appended = "203.0.113.7"; // the hop our trusted proxy adds
+
+    let a = xff(&format!("9.9.9.9, {appended}"));
+    let b = xff(&format!("8.8.8.8, 7.7.7.7, {appended}"));
+    assert_eq!(ip_client_key(&trusted, &a, peer([10, 0, 0, 1])), appended);
+    assert_eq!(ip_client_key(&trusted, &b, peer([10, 0, 0, 1])), appended);
+}
+
+#[test]
 fn x_real_ip_fallback_when_no_xff() {
     let trusted = TrustedProxies::parse("10.0.0.0/8").unwrap();
     let mut h = HeaderMap::new();


### PR DESCRIPTION
Review follow-ups to the rate-limit and SIWE hardening that merged in #187 through #190.

The rightmost-untrusted client lookup only resists spoofing if every trusted proxy appends the real peer to X-Forwarded-For. A proxy left in pass-through mode forwards a caller-supplied header verbatim, which hands the caller their own rate-limit and nonce-cap key. Nothing in the code said so, so it's now stated on the trusted_proxies config and the resolve_client_ip doc. The old spoof test also claimed the rightmost hop was what the proxy saw, which wasn't true for the header it built, so there's a new test that constructs the proxy-appended case and pins the real invariant: two different forged prefixes carrying the same appended client hash to one bucket.

Separately, the nonce TTL was a bare 300s literal in the binary while MAX_EXPIRY_WINDOW only mentioned the 2x relationship in a comment, so editing one would quietly desync the other. It's a single NONCE_TTL constant now, the NonceStore is built from it, and the expiry window derives from it. Same 300s and 600s, no behaviour change.