### PR TITLE
contracts: Transfer DarkPool ownership to governance at deploy

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -46,6 +46,20 @@ contract DeployScript is Script {
         );
         address governor = vm.envOr("VERIFIER_GOVERNOR", deployer);
 
+        // DARKPOOL_OWNER: address that controls operator management,
+        // policy, fee recipient, operator-pubkey rotation, the IVC
+        // verifier pointer, and pause on the contract that escrows every
+        // trader's funds. In production this must be a TimelockController
+        // (or a multisig fronting one); the default falls back to the
+        // deployer for local and CI deploys. On mainnet we refuse the
+        // silent fallback — leaving full protocol control on a single
+        // deploying EOA is the centralisation risk flagged in #166.
+        require(
+            block.chainid != 1 || vm.envExists("DARKPOOL_OWNER"),
+            "DARKPOOL_OWNER must be set on mainnet"
+        );
+        address darkPoolOwner = vm.envOr("DARKPOOL_OWNER", deployer);
+
         (
             uint256[2] memory alpha1,
             uint256[2][2] memory beta2,
@@ -98,6 +112,17 @@ contract DeployScript is Script {
         if (governor != deployer) {
             proxy.transferOwnership(governor);
             console.log("VerifierProxy ownership transferred to governor:", governor);
+        }
+
+        // Hand the pool to its production owner last, after every
+        // deployer-as-owner setup call above (setTokenAllowed,
+        // setIvcVerifier). DarkPool is Ownable2Step, so this only queues
+        // the transfer — darkPoolOwner must call acceptOwnership() to take
+        // control, which keeps a fat-fingered address from bricking
+        // governance.
+        if (darkPoolOwner != deployer) {
+            pool.transferOwnership(darkPoolOwner);
+            console.log("DarkPool ownership transfer initiated (awaiting acceptOwnership):", darkPoolOwner);
         }
 
         _writeDeployment(

--- a/contracts/test/Deploy.t.sol
+++ b/contracts/test/Deploy.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {stdJson} from "forge-std/StdJson.sol";
+import {DeployScript} from "../script/Deploy.s.sol";
+import {DarkPool} from "../src/DarkPool.sol";
+
+contract DeployTest is Test {
+    using stdJson for string;
+
+    // Non-mainnet id so the deploy writes to a throwaway deployments file
+    // we clean up, instead of clobbering the committed 31337.json.
+    uint256 constant CHAIN_ID = 424242;
+    uint256 constant DEPLOYER_KEY = 0xA11CE;
+
+    address deployer = vm.addr(DEPLOYER_KEY);
+    address governor = address(0x60E2);
+    address darkPoolOwner = address(0xDA12);
+
+    function setUp() public {
+        vm.setEnv("FEE_RECIPIENT", vm.toString(address(0xFEE)));
+        vm.setEnv("PRIVATE_KEY", vm.toString(DEPLOYER_KEY));
+        vm.setEnv("VK_JSON_PATH", "test/fixtures/vk.json");
+        vm.setEnv(
+            "OPERATOR_PUBKEY_HEX",
+            "0x0279BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798"
+        );
+    }
+
+    // The deploy must not leave DarkPool — which escrows every trader's
+    // funds — owned by the deploying EOA. On mainnet it refuses the silent
+    // fallback; given a DARKPOOL_OWNER it hands the pool over (Ownable2Step,
+    // so ownership is pending until the timelock/multisig accepts).
+    function test_darkPoolOwnershipHandoff() public {
+        // Mainnet without DARKPOOL_OWNER is refused. VERIFIER_GOVERNOR is set
+        // so we get past its (earlier) guard and reach the new requirement.
+        vm.setEnv("VERIFIER_GOVERNOR", vm.toString(governor));
+        vm.chainId(1);
+        DeployScript mainnetDeploy = new DeployScript();
+        vm.expectRevert(bytes("DARKPOOL_OWNER must be set on mainnet"));
+        mainnetDeploy.run();
+
+        // With an owner set, deploy on a non-mainnet chain and confirm the
+        // pool is handed to it rather than retained by the deployer.
+        vm.setEnv("DARKPOOL_OWNER", vm.toString(darkPoolOwner));
+        vm.chainId(CHAIN_ID);
+        DeployScript deploy = new DeployScript();
+        deploy.run();
+
+        DarkPool pool = DarkPool(_deployedPool());
+        assertEq(pool.pendingOwner(), darkPoolOwner, "owner transfer not queued");
+        assertEq(pool.owner(), deployer, "owner should change only on acceptOwnership");
+
+        vm.removeFile(_deploymentPath());
+    }
+
+    function _deployedPool() internal view returns (address) {
+        string memory json = vm.readFile(_deploymentPath());
+        return json.readAddress(".darkPool");
+    }
+
+    function _deploymentPath() internal view returns (string memory) {
+        return string.concat("./deployments/", vm.toString(block.chainid), ".json");
+    }
+}


### PR DESCRIPTION
Closes #166

The deploy script handed VerifierProxy governance to a timelock on mainnet but left DarkPool owned by the deploying EOA, even though that owner controls operator management, the policy, the operator pubkey, the IVC verifier pointer, and pause on the contract holding every trader's escrow. One compromised key would own the protocol, with no timelock and no announcement.

Mirror the VERIFIER_GOVERNOR pattern: require a DARKPOOL_OWNER on mainnet, refuse the silent EOA fallback, and transfer ownership to it after the deployer-owner setup calls (setTokenAllowed, setIvcVerifier). DarkPool is Ownable2Step, so the handoff stays pending until the timelock or multisig accepts, which keeps a wrong address from bricking governance. The stub IVC verifier still blocks a real mainnet run, so this wires the intended production governance for when that stub is replaced.

The test runs the script on a throwaway chain and checks the pool lands on DARKPOOL_OWNER as pendingOwner while the deployer stays owner until acceptance, plus that mainnet refuses a missing DARKPOOL_OWNER.