### PR TITLE
contracts: Lock matched funds in reserve escrow before settlement

### DIFF
--- a/contracts/src/DarkPool.sol
+++ b/contracts/src/DarkPool.sol
@@ -277,13 +277,43 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         uint256 fee = notional * PROTOCOL_FEE_BPS / BPS_DENOMINATOR;
         uint256 askReceives = notional - fee;
 
-        reserved[m.bidTrader][m.quoteToken] -= notional;
+        _consumeReserved(m.bidTrader, m.quoteToken, notional);
         balances[m.bidTrader][m.baseToken] += m.size;
 
-        reserved[m.askTrader][m.baseToken] -= m.size;
+        _consumeReserved(m.askTrader, m.baseToken, m.size);
         balances[m.askTrader][m.quoteToken] += askReceives;
 
         balances[feeRecipient][m.quoteToken] += fee;
+    }
+
+    /// @dev Spend `amount` of a trader's reserved collateral at settlement.
+    ///      A matched trade takes priority over a pending unbond, so
+    ///      free-reserved funds are consumed first and `pendingUnreserve` only
+    ///      shrinks when the match must reach into funds the trader had asked to
+    ///      unlock. Retiring the pending request (and clearing
+    ///      `unreserveReadyAt` once it hits zero) is what stops a stale unbond
+    ///      timer from later releasing freshly reserved collateral with no
+    ///      cooldown: otherwise settlement would zero `reserved` while leaving a
+    ///      matured timer, and the trader's next `reserve` would be instantly
+    ///      releasable — reopening the #165 withdraw-before-settlement vector.
+    ///      The `reserved -= amount` keeps its checked-math underflow, which is
+    ///      the intended fail-safe that reverts the whole batch when a trader
+    ///      lacks sufficient reserved funds.
+    function _consumeReserved(address trader, address token, uint256 amount) internal {
+        uint256 r = reserved[trader][token];
+        reserved[trader][token] = r - amount;
+
+        uint256 p = pendingUnreserve[trader][token];
+        if (p != 0) {
+            uint256 freeReserved = r > p ? r - p : 0;
+            if (amount > freeReserved) {
+                uint256 newPending = p - (amount - freeReserved);
+                pendingUnreserve[trader][token] = newPending;
+                if (newPending == 0) {
+                    unreserveReadyAt[trader][token] = 0;
+                }
+            }
+        }
     }
 
     function addOperator(address op) external onlyOwner {

--- a/contracts/src/DarkPool.sol
+++ b/contracts/src/DarkPool.sol
@@ -31,6 +31,32 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
     ///         than requested can never overstate internal `balances`.
     mapping(address => bool) public allowedTokens;
 
+    /// @notice Funds locked for trading. Settlement (`_settleMatch`) debits
+    ///         *only* this bucket, never free `balances`. A trader must
+    ///         `reserve` before their orders are eligible to be matched.
+    ///         Reserved funds are not directly withdrawable; releasing them is
+    ///         gated by `UNRESERVE_DELAY`. This is the on-chain escrow that
+    ///         "cannot drop before settlement" (#165): a matched trader cannot
+    ///         pull committed funds out within the cooldown window, so a single
+    ///         underfunded trader can no longer revert the whole batch by
+    ///         front-running settlement with a withdrawal.
+    mapping(address => mapping(address => uint256)) public reserved;
+
+    /// @notice Amount of `reserved` a trader has asked to unlock, and the
+    ///         timestamp at which it becomes releasable. Pending funds REMAIN
+    ///         in `reserved` (settlement can still claim them) until
+    ///         `releaseUnreserve` moves them back to free `balances` — so a
+    ///         pending request never lets a matched trader escape settlement.
+    mapping(address => mapping(address => uint256)) public pendingUnreserve;
+    mapping(address => mapping(address => uint256)) public unreserveReadyAt;
+
+    /// @notice Cooldown between requesting an unreserve and releasing it. MUST
+    ///         exceed the maximum matching→settlement latency so funds matched
+    ///         in an auction are still present when that auction settles.
+    ///         Auctions tick every ~5s and in-browser ZK proving adds seconds;
+    ///         one hour is a generous safety margin.
+    uint256 public constant UNRESERVE_DELAY = 1 hours;
+
     IDeciderVerifier public ivcVerifier;
     mapping(bytes32 => bool) public sessionSubmitted;
     mapping(bytes32 => bytes32) public auctionToSession;
@@ -130,6 +156,60 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         emit Withdrawal(msg.sender, token, amount);
     }
 
+    /// @notice Lock free balance for trading. Only reserved funds are eligible
+    ///         for matching and settlement (see `reserved`). Moves `amount`
+    ///         from withdrawable `balances` into the settlement-locked
+    ///         `reserved` bucket. No external calls, so no reentrancy surface.
+    function reserve(address token, uint256 amount) external whenNotPaused {
+        require(amount > 0, "zero amount");
+        require(balances[msg.sender][token] >= amount, "insufficient balance");
+        balances[msg.sender][token] -= amount;
+        reserved[msg.sender][token] += amount;
+        emit Reserved(msg.sender, token, amount);
+    }
+
+    /// @notice Begin unlocking reserved funds. The funds STAY in `reserved`
+    ///         (and remain claimable by settlement) until `releaseUnreserve`
+    ///         is called after `UNRESERVE_DELAY`. That delay is what closes the
+    ///         #165 griefing vector: a matched trader cannot pull committed
+    ///         funds within the window between matching and settlement.
+    /// @dev A second request before the first matures extends the deadline for
+    ///      the whole pending bucket — deliberately conservative (it can only
+    ///      lock funds longer, never release them early).
+    function requestUnreserve(address token, uint256 amount) external whenNotPaused {
+        require(amount > 0, "zero amount");
+        uint256 r = reserved[msg.sender][token];
+        uint256 p = pendingUnreserve[msg.sender][token];
+        uint256 available = r > p ? r - p : 0;
+        require(amount <= available, "exceeds reserved");
+        pendingUnreserve[msg.sender][token] = p + amount;
+        uint256 readyAt = block.timestamp + UNRESERVE_DELAY;
+        unreserveReadyAt[msg.sender][token] = readyAt;
+        emit UnreserveRequested(msg.sender, token, amount, readyAt);
+    }
+
+    /// @notice Move matured unreserve funds from `reserved` back to
+    ///         withdrawable `balances`. Releases the lesser of the pending
+    ///         amount and what remains reserved: settlement may have
+    ///         legitimately consumed some pending funds (a matched trade wins
+    ///         over a pending unbond), so clamping to `reserved` avoids
+    ///         underflow and clears the stale request either way.
+    function releaseUnreserve(address token) external whenNotPaused {
+        uint256 pending = pendingUnreserve[msg.sender][token];
+        require(pending > 0, "nothing pending");
+        // UNRESERVE_DELAY is hour-scale, so the few seconds of timestamp drift a
+        // validator could introduce is immaterial to the settlement safety margin.
+        // forge-lint: disable-next-line(block-timestamp)
+        require(block.timestamp >= unreserveReadyAt[msg.sender][token], "unreserve not ready");
+        uint256 r = reserved[msg.sender][token];
+        uint256 amount = pending <= r ? pending : r;
+        reserved[msg.sender][token] = r - amount;
+        balances[msg.sender][token] += amount;
+        pendingUnreserve[msg.sender][token] = 0;
+        unreserveReadyAt[msg.sender][token] = 0;
+        emit Unreserved(msg.sender, token, amount);
+    }
+
     function submitBatch(
         bytes32 batchId,
         bytes32 auctionId,
@@ -179,15 +259,28 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         c[1] = uint256(bytes32(proof[224:256]));
     }
 
+    /// @dev Debits the settlement-locked `reserved` escrow — never free
+    ///      `balances` — for what each side owes; credits proceeds to free
+    ///      `balances`. If a trader lacks sufficient *reserved* funds the
+    ///      subtraction underflows and the whole batch reverts. That atomic
+    ///      revert is the intended fail-safe (#165): settling a financially
+    ///      inconsistent subset, or letting the operator "skip" the offending
+    ///      match, would break batch-proof atomicity (publicInputs[0] attests
+    ///      matches.length) and hand the operator a censorship/selection lever.
+    ///      The reserve + cooldown mechanism makes this revert unreachable for
+    ///      honest flow, because matched funds cannot be withdrawn before
+    ///      settlement. (Operator-side: matching MUST gate on on-chain
+    ///      `reserved` so a valid batch never references unreserved funds —
+    ///      see the BalanceOracle follow-up, which overlaps #153.)
     function _settleMatch(Match calldata m) internal {
         uint256 notional = m.price * m.size / 1e18;
         uint256 fee = notional * PROTOCOL_FEE_BPS / BPS_DENOMINATOR;
         uint256 askReceives = notional - fee;
 
-        balances[m.bidTrader][m.quoteToken] -= notional;
+        reserved[m.bidTrader][m.quoteToken] -= notional;
         balances[m.bidTrader][m.baseToken] += m.size;
 
-        balances[m.askTrader][m.baseToken] -= m.size;
+        reserved[m.askTrader][m.baseToken] -= m.size;
         balances[m.askTrader][m.quoteToken] += askReceives;
 
         balances[feeRecipient][m.quoteToken] += fee;

--- a/contracts/src/interfaces/IDarkPool.sol
+++ b/contracts/src/interfaces/IDarkPool.sol
@@ -27,9 +27,20 @@ interface IDarkPool {
     /// @notice Emitted when the owner adds or removes a token from the
     ///         deposit allowlist. `allowed` is the new state.
     event TokenAllowed(address indexed token, bool allowed);
+    /// @notice Free balance locked into the settlement escrow (`reserved`).
+    event Reserved(address indexed trader, address indexed token, uint256 amount);
+    /// @notice An unlock of reserved funds was requested. `readyAt` is the
+    ///         timestamp after which `releaseUnreserve` will succeed; until
+    ///         then the funds stay in escrow and remain claimable by settlement.
+    event UnreserveRequested(address indexed trader, address indexed token, uint256 amount, uint256 readyAt);
+    /// @notice Matured reserved funds were moved back to free balance.
+    event Unreserved(address indexed trader, address indexed token, uint256 amount);
     function deposit(address token, uint256 amount) external;
     function setTokenAllowed(address token, bool allowed) external;
     function withdraw(address token, uint256 amount) external;
+    function reserve(address token, uint256 amount) external;
+    function requestUnreserve(address token, uint256 amount) external;
+    function releaseUnreserve(address token) external;
     function submitBatch(
         bytes32 batchId,
         bytes32 auctionId,

--- a/contracts/test/DarkPool.t.sol
+++ b/contracts/test/DarkPool.t.sol
@@ -340,8 +340,8 @@ contract DarkPoolTest is Test {
         uint256 notional = price * size / 1e18;
         uint256 fee = notional * 5 / 10_000;
 
-        _deposit(trader1, address(quoteToken), notional);
-        _deposit(trader2, address(baseToken), size);
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
 
         uint256[6] memory inputs;
         inputs[0] = 1;
@@ -390,8 +390,8 @@ contract DarkPoolTest is Test {
         uint256 notional = price * size / 1e18;
         uint256 expectedFee = notional * 5 / 10_000;
 
-        _deposit(trader1, address(quoteToken), notional);
-        _deposit(trader2, address(baseToken), size);
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
 
         uint256[6] memory inputs;
         inputs[0] = 1;
@@ -748,12 +748,12 @@ contract DarkPoolTest is Test {
         uint64 nSteps = 60;
         bytes32 policyHash = bytes32(uint256(123));
 
-        // Fund traders so _settleMatch doesn't underflow
+        // Fund + reserve traders so _settleMatch debits locked escrow
         uint256 price = 100e8;
         uint256 size = 10e8;
         uint256 notional = price * size / 1e18;
-        _deposit(trader1, address(quoteToken), notional);
-        _deposit(trader2, address(baseToken), size);
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
 
         // Build matches + the operator's pre-commitment hash
         bytes32 auctionId = bytes32(uint256(2));
@@ -822,6 +822,247 @@ contract DarkPoolTest is Test {
         pool.settleAuction(sessionId, auctionId, substituted);
     }
 
+    // --- Escrow reserve / unbonding (#165) ---
+
+    function test_reserve_movesFreeToReserved() public {
+        _deposit(trader1, address(quoteToken), 100e18);
+
+        vm.prank(trader1);
+        pool.reserve(address(quoteToken), 40e18);
+
+        assertEq(pool.balances(trader1, address(quoteToken)), 60e18);
+        assertEq(pool.reserved(trader1, address(quoteToken)), 40e18);
+    }
+
+    function test_reserve_emitsEvent() public {
+        uint256 amount = 100e18;
+        _deposit(trader1, address(quoteToken), amount);
+
+        vm.prank(trader1);
+        vm.expectEmit(true, true, false, true);
+        emit IDarkPool.Reserved(trader1, address(quoteToken), amount);
+        pool.reserve(address(quoteToken), amount);
+    }
+
+    function test_reserve_insufficientFree_reverts() public {
+        _deposit(trader1, address(quoteToken), 10e18);
+
+        vm.prank(trader1);
+        vm.expectRevert("insufficient balance");
+        pool.reserve(address(quoteToken), 11e18);
+    }
+
+    function test_reserve_zero_reverts() public {
+        vm.prank(trader1);
+        vm.expectRevert("zero amount");
+        pool.reserve(address(quoteToken), 0);
+    }
+
+    function test_reserve_whenPaused_reverts() public {
+        pool.pause();
+        vm.prank(trader1);
+        vm.expectRevert(abi.encodeWithSignature("EnforcedPause()"));
+        pool.reserve(address(quoteToken), 1);
+    }
+
+    function test_withdraw_cannotTouchReservedFunds() public {
+        uint256 amount = 100e18;
+        _deposit(trader1, address(quoteToken), amount);
+        _reserve(trader1, address(quoteToken), amount); // all reserved, free == 0
+
+        vm.prank(trader1);
+        vm.expectRevert("insufficient balance");
+        pool.withdraw(address(quoteToken), 1);
+    }
+
+    function test_requestUnreserve_exceedingReserved_reverts() public {
+        _deposit(trader1, address(quoteToken), 100e18);
+        _reserve(trader1, address(quoteToken), 40e18);
+
+        vm.prank(trader1);
+        vm.expectRevert("exceeds reserved");
+        pool.requestUnreserve(address(quoteToken), 41e18);
+    }
+
+    function test_releaseUnreserve_nothingPending_reverts() public {
+        vm.prank(trader1);
+        vm.expectRevert("nothing pending");
+        pool.releaseUnreserve(address(quoteToken));
+    }
+
+    function test_releaseUnreserve_beforeDelay_reverts() public {
+        _deposit(trader1, address(quoteToken), 100e18);
+        _reserve(trader1, address(quoteToken), 100e18);
+
+        vm.startPrank(trader1);
+        pool.requestUnreserve(address(quoteToken), 100e18);
+        vm.expectRevert("unreserve not ready");
+        pool.releaseUnreserve(address(quoteToken));
+        vm.stopPrank();
+    }
+
+    function test_requestThenReleaseUnreserve_afterDelay_returnsToFree() public {
+        _deposit(trader1, address(quoteToken), 100e18);
+        _reserve(trader1, address(quoteToken), 100e18);
+
+        vm.prank(trader1);
+        pool.requestUnreserve(address(quoteToken), 100e18);
+
+        vm.warp(block.timestamp + pool.UNRESERVE_DELAY());
+
+        vm.prank(trader1);
+        pool.releaseUnreserve(address(quoteToken));
+
+        assertEq(pool.reserved(trader1, address(quoteToken)), 0);
+        assertEq(pool.balances(trader1, address(quoteToken)), 100e18);
+        assertEq(pool.pendingUnreserve(trader1, address(quoteToken)), 0);
+
+        // Released funds are withdrawable again.
+        vm.prank(trader1);
+        pool.withdraw(address(quoteToken), 100e18);
+        assertEq(quoteToken.balanceOf(trader1), 100e18);
+    }
+
+    /// The core #165 regression: a matched trader who tries to pull committed
+    /// funds out before settlement is blocked by the cooldown — the funds stay
+    /// in `reserved` and settlement still succeeds. One trader can no longer
+    /// revert the whole batch by front-running settlement with a withdrawal.
+    function test_matchedFundsRemainClaimableDuringUnbond() public {
+        bytes32 batchId = bytes32(uint256(7));
+        uint256 price = 100e18;
+        uint256 size = 10e18;
+        uint256 notional = price * size / 1e18;
+        uint256 fee = notional * 5 / 10_000;
+
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
+
+        // Both traders immediately try to unbond their committed funds.
+        vm.prank(trader1);
+        pool.requestUnreserve(address(quoteToken), notional);
+        vm.prank(trader2);
+        pool.requestUnreserve(address(baseToken), size);
+
+        IDarkPool.Match[] memory matches = new IDarkPool.Match[](1);
+        matches[0] = IDarkPool.Match({
+            bidOrderId: bytes32(uint256(1)),
+            askOrderId: bytes32(uint256(2)),
+            bidTrader: trader1,
+            askTrader: trader2,
+            baseToken: address(baseToken),
+            quoteToken: address(quoteToken),
+            price: price,
+            size: size
+        });
+
+        uint256[6] memory inputs;
+        inputs[0] = 1;
+
+        // Settlement succeeds despite the pending unbonds.
+        vm.prank(operator);
+        pool.submitBatch(batchId, bytes32(0), new bytes(256), inputs, matches);
+
+        assertTrue(pool.settled(batchId));
+        assertEq(pool.reserved(trader1, address(quoteToken)), 0);
+        assertEq(pool.balances(trader1, address(baseToken)), size);
+        assertEq(pool.reserved(trader2, address(baseToken)), 0);
+        assertEq(pool.balances(trader2, address(quoteToken)), notional - fee);
+
+        // After the delay the unbond releases only what's left (nothing): the
+        // trade legitimately consumed the reserved funds, no underflow.
+        vm.warp(block.timestamp + pool.UNRESERVE_DELAY());
+        vm.prank(trader1);
+        pool.releaseUnreserve(address(quoteToken));
+        assertEq(pool.reserved(trader1, address(quoteToken)), 0);
+        assertEq(pool.balances(trader1, address(quoteToken)), 0);
+        assertEq(pool.pendingUnreserve(trader1, address(quoteToken)), 0);
+    }
+
+    function test_submitBatch_revertsWhenFundsNotReserved() public {
+        // Funds sit in free balance but were never reserved → settlement
+        // debits the empty reserved escrow and reverts. Locking is enforced:
+        // free balance alone cannot settle.
+        uint256 price = 100e18;
+        uint256 size = 10e18;
+        uint256 notional = price * size / 1e18;
+
+        _deposit(trader1, address(quoteToken), notional); // NOT reserved
+        _deposit(trader2, address(baseToken), size); // NOT reserved
+
+        IDarkPool.Match[] memory matches = new IDarkPool.Match[](1);
+        matches[0] = IDarkPool.Match({
+            bidOrderId: bytes32(uint256(1)),
+            askOrderId: bytes32(uint256(2)),
+            bidTrader: trader1,
+            askTrader: trader2,
+            baseToken: address(baseToken),
+            quoteToken: address(quoteToken),
+            price: price,
+            size: size
+        });
+
+        uint256[6] memory inputs;
+        inputs[0] = 1;
+
+        vm.prank(operator);
+        vm.expectRevert(); // arithmetic underflow on reserved escrow
+        pool.submitBatch(bytes32(uint256(8)), bytes32(0), new bytes(256), inputs, matches);
+    }
+
+    /// The issue's exact scenario: one underfunded trader in a multi-match
+    /// batch. The whole batch reverts atomically; the valid first match must
+    /// NOT be partially settled (we reject the "skip the bad match" fix).
+    function test_submitBatch_oneUnderfundedRevertsEntireBatch() public {
+        address trader3 = address(0x30);
+        address trader4 = address(0x40);
+
+        uint256 price = 100e18;
+        uint256 size = 10e18;
+        uint256 notional = price * size / 1e18;
+
+        // Match 0: both sides fully reserved (would settle on its own).
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
+        // Match 1: ask side reserved, bid side (trader3) never reserved quote.
+        _depositAndReserve(trader4, address(baseToken), size);
+
+        IDarkPool.Match[] memory matches = new IDarkPool.Match[](2);
+        matches[0] = IDarkPool.Match({
+            bidOrderId: bytes32(uint256(1)),
+            askOrderId: bytes32(uint256(2)),
+            bidTrader: trader1,
+            askTrader: trader2,
+            baseToken: address(baseToken),
+            quoteToken: address(quoteToken),
+            price: price,
+            size: size
+        });
+        matches[1] = IDarkPool.Match({
+            bidOrderId: bytes32(uint256(3)),
+            askOrderId: bytes32(uint256(4)),
+            bidTrader: trader3, // underfunded: never reserved quote
+            askTrader: trader4,
+            baseToken: address(baseToken),
+            quoteToken: address(quoteToken),
+            price: price,
+            size: size
+        });
+
+        uint256[6] memory inputs;
+        inputs[0] = 2;
+
+        bytes32 batchId = bytes32(uint256(9));
+        vm.prank(operator);
+        vm.expectRevert();
+        pool.submitBatch(batchId, bytes32(0), new bytes(256), inputs, matches);
+
+        // Atomicity: the valid first match did NOT partially settle.
+        assertFalse(pool.settled(batchId));
+        assertEq(pool.reserved(trader1, address(quoteToken)), notional);
+        assertEq(pool.balances(trader1, address(baseToken)), 0);
+        assertEq(pool.reserved(trader2, address(baseToken)), size);
+    }
+
     // --- Helpers ---
 
     function _deposit(address trader, address token, uint256 amount) internal {
@@ -830,6 +1071,18 @@ contract DarkPoolTest is Test {
         MockERC20(token).approve(address(pool), amount);
         pool.deposit(token, amount);
         vm.stopPrank();
+    }
+
+    function _reserve(address trader, address token, uint256 amount) internal {
+        vm.prank(trader);
+        pool.reserve(token, amount);
+    }
+
+    /// Settlement debits the locked `reserved` escrow, so any trader appearing
+    /// in a settled match must have reserved the funds they owe first.
+    function _depositAndReserve(address trader, address token, uint256 amount) internal {
+        _deposit(trader, token, amount);
+        _reserve(trader, token, amount);
     }
 
     function _zeroInputs() internal pure returns (uint256[6] memory inputs) {
@@ -868,8 +1121,8 @@ contract DarkPoolTest is Test {
 
     function _setupBatchBalances() internal {
         uint256 notional = 100e18 * 10e18 / 1e18;
-        _deposit(trader1, address(quoteToken), notional);
-        _deposit(trader2, address(baseToken), 10e18);
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), 10e18);
     }
 
     function _fundAndSubmitBatch(bytes32 batchId) internal {

--- a/contracts/test/DarkPool.t.sol
+++ b/contracts/test/DarkPool.t.sol
@@ -968,14 +968,17 @@ contract DarkPoolTest is Test {
         assertEq(pool.reserved(trader2, address(baseToken)), 0);
         assertEq(pool.balances(trader2, address(quoteToken)), notional - fee);
 
-        // After the delay the unbond releases only what's left (nothing): the
-        // trade legitimately consumed the reserved funds, no underflow.
+        // Settlement consumed the reserved funds and retired the pending
+        // request with them: nothing is left to release, and no stale timer
+        // lingers to unlock future reserves early.
+        assertEq(pool.pendingUnreserve(trader1, address(quoteToken)), 0);
+        assertEq(pool.unreserveReadyAt(trader1, address(quoteToken)), 0);
         vm.warp(block.timestamp + pool.UNRESERVE_DELAY());
         vm.prank(trader1);
+        vm.expectRevert("nothing pending");
         pool.releaseUnreserve(address(quoteToken));
         assertEq(pool.reserved(trader1, address(quoteToken)), 0);
         assertEq(pool.balances(trader1, address(quoteToken)), 0);
-        assertEq(pool.pendingUnreserve(trader1, address(quoteToken)), 0);
     }
 
     function test_submitBatch_revertsWhenFundsNotReserved() public {
@@ -1061,6 +1064,57 @@ contract DarkPoolTest is Test {
         assertEq(pool.reserved(trader1, address(quoteToken)), notional);
         assertEq(pool.balances(trader1, address(baseToken)), 0);
         assertEq(pool.reserved(trader2, address(baseToken)), size);
+    }
+
+    /// #165 stale-unbond regression: settlement that consumes reserved funds
+    /// must also retire the matching pendingUnreserve and its maturity timer.
+    /// Otherwise a trader could arm an unbond, let a match consume it, reserve
+    /// fresh funds, and yank them out the instant the stale timer matures —
+    /// front-running the next settlement with no fresh cooldown.
+    function test_settlementRetiresPendingUnreserve_freshReserveStaysLocked() public {
+        uint256 price = 100e18;
+        uint256 size = 10e18;
+        uint256 notional = price * size / 1e18;
+
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
+
+        // trader1 arms an unbond on the exact funds about to be matched.
+        vm.prank(trader1);
+        pool.requestUnreserve(address(quoteToken), notional);
+
+        IDarkPool.Match[] memory matches = new IDarkPool.Match[](1);
+        matches[0] = IDarkPool.Match({
+            bidOrderId: bytes32(uint256(1)),
+            askOrderId: bytes32(uint256(2)),
+            bidTrader: trader1,
+            askTrader: trader2,
+            baseToken: address(baseToken),
+            quoteToken: address(quoteToken),
+            price: price,
+            size: size
+        });
+        uint256[6] memory inputs;
+        inputs[0] = 1;
+
+        // Settlement consumes trader1's reserved quote; the pending request and
+        // its timer must be cleared, not left dangling.
+        vm.prank(operator);
+        pool.submitBatch(bytes32(uint256(11)), bytes32(0), new bytes(256), inputs, matches);
+        assertEq(pool.reserved(trader1, address(quoteToken)), 0);
+        assertEq(pool.pendingUnreserve(trader1, address(quoteToken)), 0);
+        assertEq(pool.unreserveReadyAt(trader1, address(quoteToken)), 0);
+
+        // trader1 reserves fresh quote to trade again.
+        _depositAndReserve(trader1, address(quoteToken), notional);
+
+        // Past the ORIGINAL deadline the fresh reserve must NOT be releasable:
+        // settlement retired the stale request, so nothing is pending.
+        vm.warp(block.timestamp + pool.UNRESERVE_DELAY());
+        vm.prank(trader1);
+        vm.expectRevert("nothing pending");
+        pool.releaseUnreserve(address(quoteToken));
+        assertEq(pool.reserved(trader1, address(quoteToken)), notional);
     }
 
     // --- Helpers ---

--- a/crates/dp-settlement/abi/DarkPool.json
+++ b/crates/dp-settlement/abi/DarkPool.json
@@ -48,6 +48,19 @@
   },
   {
     "type": "function",
+    "name": "UNRESERVE_DELAY",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "acceptOwnership",
     "inputs": [],
     "outputs": [],
@@ -291,6 +304,30 @@
   },
   {
     "type": "function",
+    "name": "pendingUnreserve",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "positionLimit",
     "inputs": [],
     "outputs": [
@@ -301,6 +338,19 @@
       }
     ],
     "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "releaseUnreserve",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
   },
   {
     "type": "function",
@@ -321,6 +371,66 @@
     "inputs": [],
     "outputs": [],
     "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "requestUnreserve",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "reserve",
+    "inputs": [
+      {
+        "name": "token",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "reserved",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
   },
   {
     "type": "function",
@@ -669,6 +779,30 @@
   },
   {
     "type": "function",
+    "name": "unreserveReadyAt",
+    "inputs": [
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      },
+      {
+        "name": "",
+        "type": "address",
+        "internalType": "address"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "verifier",
     "inputs": [],
     "outputs": [
@@ -865,6 +999,31 @@
   },
   {
     "type": "event",
+    "name": "Reserved",
+    "inputs": [
+      {
+        "name": "trader",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
     "name": "SessionSubmitted",
     "inputs": [
       {
@@ -916,6 +1075,62 @@
         "type": "address",
         "indexed": false,
         "internalType": "address"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "UnreserveRequested",
+    "inputs": [
+      {
+        "name": "trader",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      },
+      {
+        "name": "readyAt",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unreserved",
+    "inputs": [
+      {
+        "name": "trader",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "token",
+        "type": "address",
+        "indexed": true,
+        "internalType": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256",
+        "indexed": false,
+        "internalType": "uint256"
       }
     ],
     "anonymous": false

--- a/crates/dp-settlement/tests/anvil_e2e.rs
+++ b/crates/dp-settlement/tests/anvil_e2e.rs
@@ -225,6 +225,12 @@ async fn settles_batch_end_to_end() {
     await_tx!(pool.setTokenAllowed(quote_addr, true));
     await_tx!(pool.deposit(base_addr, size));
     await_tx!(pool.deposit(quote_addr, notional));
+    // Settlement debits the locked `reserved` escrow (#165), so matched funds
+    // must be reserved out of free balance before the batch can settle.
+    // signer_addr is both bid and ask here: reserve quote for the bid leg and
+    // base for the ask leg.
+    await_tx!(pool.reserve(quote_addr, notional));
+    await_tx!(pool.reserve(base_addr, size));
     await_tx!(pool.addOperator(signer_addr));
 
     // Spawn watcher and await its subscribe_logs handshake before submitting.


### PR DESCRIPTION
Closes #165

Settlement debited free `balances` with checked math, so a single underfunded trader in a batch underflowed and reverted the whole submitBatch/settleAuction. Any trader could block settlement of every other valid match just by withdrawing before the batch landed.

Funds now have to be reserved before they can be matched. `_settleMatch` debits the `reserved` escrow instead of free balance and credits proceeds back to free balance. Reserved funds aren't directly withdrawable, and pulling them back out goes through requestUnreserve/releaseUnreserve with a cooldown (UNRESERVE_DELAY) that outlasts the matching-to-settlement window, so a matched trader can't yank collateral out from under a pending batch. The all-or-nothing revert stays as the fail-safe: skipping the bad match would break batch-proof atomicity (publicInputs[0] attests matches.length) and let the operator pick winners, so that option's out.

Binding the off-chain solvency witness to the on-chain `reserved` balance (the operator-builds-a-bad-batch case) is the other half and lands separately since it overlaps the proof-binding work in #153.

All 120 contract tests pass, including a multi-match case asserting the batch reverts atomically with no partial settlement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a fund reservation system allowing users to lock funds in escrow for settlement.
  * Added a one-hour delay for releasing reserved funds, requiring explicit unlock requests.
  * Settlement operations now consume reserved funds rather than free balances, improving capital control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->