### PR TITLE
auction: Quantize clearing price, gate unsettleable fills

### DIFF
--- a/crates/dp-auction/src/lib.rs
+++ b/crates/dp-auction/src/lib.rs
@@ -11,8 +11,11 @@ use uuid::Uuid;
 /// never settle on-chain. Quantising here keeps the auction from emitting a
 /// price the encoder will later reject after the matches were already
 /// recorded (issue #167). Kept as a local literal rather than depending on
-/// `dp-zk` (which pulls in arkworks) for one constant.
-const CLEARING_PRICE_DP: u32 = 8;
+/// `dp-zk` (which pulls in arkworks) for one constant; the two are pinned
+/// together by a guard test in `dp-engine` (the only crate depending on
+/// both), so drift in either becomes a test failure instead of a silent
+/// trading halt. Public solely so that guard can compare against it.
+pub const CLEARING_PRICE_DP: u32 = 8;
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuctionResult {

--- a/crates/dp-auction/src/lib.rs
+++ b/crates/dp-auction/src/lib.rs
@@ -5,6 +5,15 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+/// Decimal places the clearing price is quantised to. Must match
+/// `dp_zk::encoding::DECIMAL_SCALE`: the ZK scalar encoder rejects any value
+/// carrying more precision than this, so a clearing price beyond it could
+/// never settle on-chain. Quantising here keeps the auction from emitting a
+/// price the encoder will later reject after the matches were already
+/// recorded (issue #167). Kept as a local literal rather than depending on
+/// `dp-zk` (which pulls in arkworks) for one constant.
+const CLEARING_PRICE_DP: u32 = 8;
+
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuctionResult {
     pub auction_id: Uuid,
@@ -108,7 +117,16 @@ fn compute_clearing_price(bids: &[Order], asks: &[Order]) -> Decimal {
 
     let lo = tied_prices[0];
     let hi = tied_prices[tied_prices.len() - 1];
-    ((lo + hi) / Decimal::from(2)).normalize()
+    // Halving the midpoint of two prices can introduce one extra decimal
+    // place (e.g. 0.00000001 and 0.00000002 → 0.000000015). The ZK encoder
+    // rejects anything beyond `CLEARING_PRICE_DP` dp, which previously let the
+    // engine record matches it could never settle (issue #167). Round the
+    // midpoint to `CLEARING_PRICE_DP` dp so the clearing price is always
+    // encodable; the rounded value stays within `[lo, hi]`, both of which are
+    // volume-maximising clearing prices, so the matched set is unchanged.
+    ((lo + hi) / Decimal::from(2))
+        .round_dp(CLEARING_PRICE_DP)
+        .normalize()
 }
 
 fn cumulative_volume(orders: &[Order], pred: impl Fn(&Order) -> bool) -> Decimal {
@@ -216,8 +234,52 @@ mod tests {
         }
     }
 
+    /// Like [`new_order`] but takes a `Decimal` price so tests can exercise
+    /// sub-integer (and sub-tick) prices.
+    fn new_order_px(side: Side, price: Decimal, size: i64) -> Order {
+        Order {
+            price,
+            ..new_order(side, 0, size)
+        }
+    }
+
     fn test_auction_id() -> Uuid {
         Uuid::nil()
+    }
+
+    /// Issue #167: when the midpoint of two tied clearing prices would carry
+    /// more than 8 dp (odd last digit halved), it must be quantised down to a
+    /// price the ZK encoder accepts — and stay within `[lo, hi]`, both of
+    /// which are valid volume-maximising clearing prices.
+    #[test]
+    fn clearing_price_quantized_to_encodable_precision() {
+        // Naive midpoint of these is 0.000000015 (9 dp), which
+        // `decimal_to_scalar` rejects — silently dropping a batch whose
+        // matches were already recorded.
+        let lo = Decimal::new(1, 8); // 0.00000001
+        let hi = Decimal::new(2, 8); // 0.00000002
+        let bids = vec![new_order_px(Side::Buy, hi, 10)];
+        let asks = vec![new_order_px(Side::Sell, lo, 10)];
+
+        let result = run(test_auction_id(), "TEST/USD", &bids, &asks).expect("expected result");
+
+        assert!(
+            result.clearing_price.scale() <= 8,
+            "clearing price {} must encode within 8 dp",
+            result.clearing_price
+        );
+        assert!(
+            result.clearing_price >= lo && result.clearing_price <= hi,
+            "quantised clearing price {} must stay within [{lo}, {hi}]",
+            result.clearing_price
+        );
+        assert!(
+            result
+                .matches
+                .iter()
+                .all(|m| m.price == result.clearing_price),
+            "every fill must price at the quantised clearing price"
+        );
     }
 
     #[test]

--- a/crates/dp-auction/src/lib.rs
+++ b/crates/dp-auction/src/lib.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 /// carrying more precision than this, so a clearing price beyond it could
 /// never settle on-chain. Quantising here keeps the auction from emitting a
 /// price the encoder will later reject after the matches were already
-/// recorded (issue #167). Kept as a local literal rather than depending on
+/// recorded. Kept as a local literal rather than depending on
 /// `dp-zk` (which pulls in arkworks) for one constant; the two are pinned
 /// together by a guard test in `dp-engine` (the only crate depending on
 /// both), so drift in either becomes a test failure instead of a silent
@@ -123,7 +123,7 @@ fn compute_clearing_price(bids: &[Order], asks: &[Order]) -> Decimal {
     // Halving the midpoint of two prices can introduce one extra decimal
     // place (e.g. 0.00000001 and 0.00000002 → 0.000000015). The ZK encoder
     // rejects anything beyond `CLEARING_PRICE_DP` dp, which previously let the
-    // engine record matches it could never settle (issue #167). Round the
+    // engine record matches it could never settle. Round the
     // midpoint to `CLEARING_PRICE_DP` dp so the clearing price is always
     // encodable; the rounded value stays within `[lo, hi]`, both of which are
     // volume-maximising clearing prices, so the matched set is unchanged.
@@ -250,7 +250,7 @@ mod tests {
         Uuid::nil()
     }
 
-    /// Issue #167: when the midpoint of two tied clearing prices would carry
+    /// When the midpoint of two tied clearing prices would carry
     /// more than 8 dp (odd last digit halved), it must be quantised down to a
     /// price the ZK encoder accepts — and stay within `[lo, hi]`, both of
     /// which are valid volume-maximising clearing prices.

--- a/crates/dp-engine/src/tick.rs
+++ b/crates/dp-engine/src/tick.rs
@@ -46,7 +46,7 @@ pub(crate) struct PendingAggregation {
 /// scalar. The downstream witness build / IVC fold encodes the clearing price
 /// via `dp_zk::decimal_to_scalar`; if that fails *after* the round's
 /// `AuctionExecuted`/`OrderMatched` events are persisted and applied, the
-/// engine has recorded matches that can never settle on-chain (#167). Order
+/// engine has recorded matches that can never settle on-chain. Order
 /// legs are already encode-checked when their commitment is built at
 /// submission, so the clearing price is the one value this gate must guard.
 fn clearing_price_encodable(
@@ -326,7 +326,7 @@ impl Engine {
             };
             let auction_elapsed = auction_start.elapsed();
 
-            // #167: never record a match the engine cannot settle. The
+            // Never record a match the engine cannot settle. The
             // clearing price is the only auction output not already
             // encode-validated upstream — order prices and sizes are checked
             // when their Poseidon commitment is built at submission, but the
@@ -530,7 +530,7 @@ mod tests {
         }
     }
 
-    /// #167: the gate must reject a clearing price the ZK encoder cannot
+    /// The gate must reject a clearing price the ZK encoder cannot
     /// represent (here, 9 dp) and accept an 8-dp one — so event persistence is
     /// blocked for exactly the unsettleable case.
     #[test]
@@ -548,7 +548,7 @@ mod tests {
         );
     }
 
-    /// Drift guard (#167): `dp_auction` quantises the clearing price to
+    /// `dp_auction` quantises the clearing price to
     /// `CLEARING_PRICE_DP` dp, and the gate above accepts up to
     /// `dp_zk::encoding::DECIMAL_SCALE` dp. The coupling is otherwise only a
     /// doc-comment. If the two diverge — e.g. the encoder scale drops to 6
@@ -829,7 +829,7 @@ mod ivc_tests {
         assert_eq!(agg.finalize_calls(), 0);
     }
 
-    /// Issue #167 regression: a cross whose midpoint clearing price would carry
+    /// A cross whose midpoint clearing price would carry
     /// 9 dp (best bid 0.00000002, best ask 0.00000001 → midpoint 0.000000015)
     /// must record the match *and* fold it. Before the fix the 9-dp price
     /// failed `decimal_to_scalar`, so the fold was skipped *after* the

--- a/crates/dp-engine/src/tick.rs
+++ b/crates/dp-engine/src/tick.rs
@@ -548,6 +548,24 @@ mod tests {
         );
     }
 
+    /// Drift guard (#167): `dp_auction` quantises the clearing price to
+    /// `CLEARING_PRICE_DP` dp, and the gate above accepts up to
+    /// `dp_zk::encoding::DECIMAL_SCALE` dp. The coupling is otherwise only a
+    /// doc-comment. If the two diverge — e.g. the encoder scale drops to 6
+    /// while quantisation stays at 8 — every cross at the extra precision is
+    /// quantised to a price the gate then rejects, silently halting trading
+    /// for those prices. This crate is the only one depending on both, so the
+    /// equality is asserted here.
+    #[test]
+    fn quantize_precision_matches_zk_encoder_scale() {
+        assert_eq!(
+            dp_auction::CLEARING_PRICE_DP,
+            dp_zk::encoding::DECIMAL_SCALE,
+            "auction quantisation precision must match the ZK encoder scale; \
+             drift halts settlement for prices between the two"
+        );
+    }
+
     #[test]
     fn build_settlement_matches_returns_witness_missing_for_missing_bid() {
         let engine = fresh_engine();

--- a/crates/dp-engine/src/tick.rs
+++ b/crates/dp-engine/src/tick.rs
@@ -42,6 +42,19 @@ pub(crate) struct PendingAggregation {
     pub auction_at: chrono::DateTime<Utc>,
 }
 
+/// Returns `Err` if the auction's clearing price cannot be encoded as a BN254
+/// scalar. The downstream witness build / IVC fold encodes the clearing price
+/// via `dp_zk::decimal_to_scalar`; if that fails *after* the round's
+/// `AuctionExecuted`/`OrderMatched` events are persisted and applied, the
+/// engine has recorded matches that can never settle on-chain (#167). Order
+/// legs are already encode-checked when their commitment is built at
+/// submission, so the clearing price is the one value this gate must guard.
+fn clearing_price_encodable(
+    result: &dp_auction::AuctionResult,
+) -> Result<(), dp_zk::EncodingError> {
+    dp_zk::decimal_to_scalar(result.clearing_price).map(|_| ())
+}
+
 impl Engine {
     #[tracing::instrument(name = "dp_engine.auction_tick", skip(self))]
     pub async fn run_auction_tick(&self) -> Vec<AuctionNotification> {
@@ -313,6 +326,26 @@ impl Engine {
             };
             let auction_elapsed = auction_start.elapsed();
 
+            // #167: never record a match the engine cannot settle. The
+            // clearing price is the only auction output not already
+            // encode-validated upstream — order prices and sizes are checked
+            // when their Poseidon commitment is built at submission, but the
+            // midpoint is derived here and can carry sub-tick precision.
+            // `dp_auction` quantises it to 8 dp; this gate is the invariant
+            // that guarantees no unsettleable `AuctionExecuted`/`OrderMatched`
+            // event is ever persisted, even if that quantisation regresses.
+            // On failure, skip the round without persisting or applying any
+            // events — the orders stay live and are retried next tick.
+            if let Err(e) = clearing_price_encodable(&result) {
+                tracing::error!(
+                    auction_id = %result.auction_id,
+                    pair = %pair,
+                    clearing_price = %result.clearing_price,
+                    "clearing price not ZK-encodable; skipping round without recording matches: {e}"
+                );
+                continue;
+            }
+
             let mut events: Vec<Event> = Vec::with_capacity(1 + result.matches.len());
             events.push(Event {
                 seq: 0,
@@ -485,6 +518,34 @@ mod tests {
     fn fresh_engine() -> Engine {
         let store = Arc::new(MemStore::new());
         Engine::new(store, Duration::from_millis(50))
+    }
+
+    fn auction_result_with_price(clearing_price: Decimal) -> dp_auction::AuctionResult {
+        dp_auction::AuctionResult {
+            auction_id: Uuid::new_v4(),
+            pair: "ETH/USDC".into(),
+            clearing_price,
+            matched_volume: Decimal::ONE,
+            matches: Vec::new(),
+        }
+    }
+
+    /// #167: the gate must reject a clearing price the ZK encoder cannot
+    /// represent (here, 9 dp) and accept an 8-dp one — so event persistence is
+    /// blocked for exactly the unsettleable case.
+    #[test]
+    fn clearing_price_gate_rejects_excess_precision() {
+        let bad = auction_result_with_price(Decimal::new(15, 9)); // 0.000000015
+        assert!(
+            clearing_price_encodable(&bad).is_err(),
+            "9 dp clearing price must be rejected"
+        );
+
+        let good = auction_result_with_price(Decimal::new(2, 8)); // 0.00000002
+        assert!(
+            clearing_price_encodable(&good).is_ok(),
+            "8 dp clearing price must be accepted"
+        );
     }
 
     #[test]
@@ -748,5 +809,72 @@ mod ivc_tests {
         // Just verify construction + setter do not panic.
         assert_eq!(agg.fold_calls(), 0);
         assert_eq!(agg.finalize_calls(), 0);
+    }
+
+    /// Issue #167 regression: a cross whose midpoint clearing price would carry
+    /// 9 dp (best bid 0.00000002, best ask 0.00000001 → midpoint 0.000000015)
+    /// must record the match *and* fold it. Before the fix the 9-dp price
+    /// failed `decimal_to_scalar`, so the fold was skipped *after* the
+    /// `OrderMatched` events were already persisted — a recorded fill that
+    /// never settled. The clearing price is now quantised to 8 dp, so the fold
+    /// runs.
+    #[tokio::test]
+    async fn fractional_midpoint_match_is_recorded_and_folds() {
+        use dp_event::Store;
+        use dp_types::EventType;
+
+        let (engine, store) = make_engine_with_pair();
+        let agg = MockFoldingAggregator::new();
+        engine.set_aggregator(Arc::clone(&agg) as Arc<dyn ProofAggregator>);
+        // Stay well below the finalize/submit boundary for this test.
+        engine.set_finalize_every(1000);
+
+        let ttl = Duration::from_secs(60);
+        place_plaintext_order(
+            &engine,
+            "ETH/USDC",
+            Side::Buy,
+            Decimal::new(2, 8), // 0.00000002
+            Decimal::ONE,
+            "key_bid",
+            ttl,
+        )
+        .await
+        .unwrap();
+        place_plaintext_order(
+            &engine,
+            "ETH/USDC",
+            Side::Sell,
+            Decimal::new(1, 8), // 0.00000001
+            Decimal::ONE,
+            "key_ask",
+            ttl,
+        )
+        .await
+        .unwrap();
+
+        engine.run_auction_tick().await;
+
+        let events = store.read_from(0, 10_000).unwrap();
+        let executed = events
+            .iter()
+            .filter(|e| e.event_type == EventType::AuctionExecuted)
+            .count();
+        let matched = events
+            .iter()
+            .filter(|e| e.event_type == EventType::OrderMatched)
+            .count();
+
+        assert_eq!(executed, 1, "auction must be recorded");
+        assert_eq!(matched, 1, "the fill must be recorded");
+        // The fold ran — i.e. the (quantised) clearing price encoded. Pre-fix
+        // this stayed 0 because `from_witness_with_admitted` rejected the
+        // 9-dp price after the matches had already been persisted.
+        assert_eq!(agg.fold_calls(), 1, "encodable clearing price must fold");
+        assert_eq!(
+            engine.active_order_count(),
+            0,
+            "both orders fully filled and removed from the book"
+        );
     }
 }


### PR DESCRIPTION
Closes #167

The midpoint clearing price `((lo + hi) / 2)` can land on 9 dp when the 8th decimal is odd. The ZK encoder caps decimals at 8, so that price fails to encode and the fold gets skipped, but only after the AuctionExecuted and OrderMatched events are already persisted and the orders pulled from the book. The match shows up in the event log and the UI and never settles on chain.

Two parts to the fix. The auction now rounds the midpoint to 8 dp, which stays inside `[lo, hi]` so the matched set doesn't change. And the engine checks the clearing price encodes before writing any event, skipping the round and leaving the orders live if it doesn't. Order prices and sizes are already encode-checked when their commitment is built at submission, so the clearing price is the only output that needed a guard.