### PR TITLE
zk: Check ask-side solvency against base size

### DIFF
--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -52,6 +52,16 @@ impl Drop for OrderSecrets {
 
 /// Looks up balance/position for a trader. Default impl trusts the caller
 /// — pending escrow oracle integration.
+///
+/// **Per-leg asset semantics (#170).** The solvency constraint checks each
+/// leg's balance in the asset that leg *spends*: a bid (buyer) is checked
+/// against `notional` in the quote asset, an ask (seller) against `size` in
+/// the base asset — mirroring the on-chain `_settleMatch` debits. The real
+/// oracle must therefore return the balance in the right asset for the
+/// order's side: quote for a bid, base for an ask. The lookup is keyed only
+/// by `trader_id` today because the stub is asset-blind; the escrow-backed
+/// oracle wiring (the #165/#153-overlapping follow-up) must thread the side
+/// or per-asset escrow through so the witnessed `balance` matches the leg.
 pub trait BalanceOracle: Send + Sync {
     fn lookup(&self, trader_id: &[u8; 32]) -> (Decimal, i128);
 }
@@ -887,6 +897,9 @@ fn leg_witness_from(
     dp_zk::witness::OrderLegWitness {
         trader_id: hex::encode(secret.trader_id),
         salt: hex::encode(secret.salt),
+        // Circuit checks this in the asset the leg spends: quote for a bid,
+        // base for an ask (#170). The stub oracle is asset-blind; see
+        // `BalanceOracle` for the per-asset wiring the real oracle owes.
         balance: secret.balance,
         position: secret.position.to_string(),
         limit_price: order.price,

--- a/crates/dp-zk/src/step_circuit.rs
+++ b/crates/dp-zk/src/step_circuit.rs
@@ -694,11 +694,25 @@ impl FCircuit<Fr> for AuctionStepCircuit {
             let notional = &m_price * &m_size;
 
             // ── Family 7: solvency ────────────────────────────────────────────
+            // The two legs settle different assets, so each leg's balance is
+            // denominated in the asset that leg spends and the checks differ in
+            // both asset and scale (#170). This mirrors the on-chain
+            // `_settleMatch`, which debits the bid `notional` of `quoteToken`
+            // and the ask `m.size` of `baseToken`:
+            //   • bid_balance is the buyer's quote holdings. `notional` carries
+            //     a 1e16 scale (price·size, each pre-scaled by 1e8), so lift the
+            //     1e8-scaled balance by `scale_factor` before comparing —
+            //     `bid_balance >= notional` ⇔ buyer holds the quote it pays.
+            //   • ask_balance is the seller's base holdings, already at the same
+            //     1e8 scale as `m_size`, so compare directly —
+            //     `ask_balance >= m_size` ⇔ seller holds the base it delivers.
+            // Checking the ask against `notional` (quote units) constrained the
+            // wrong asset and rejected sellers who held enough base.
             enforce_range_60(&bid_balance)?;
             enforce_range_60(&ask_balance)?;
             let bid_solvency_diff = (&bid_balance * &scale_factor - &notional) * &is_active;
             enforce_range_n(&bid_solvency_diff, SOLVENCY_DIFF_BITS)?;
-            let ask_solvency_diff = (&ask_balance * &scale_factor - &notional) * &is_active;
+            let ask_solvency_diff = (&ask_balance - &m_size) * &is_active;
             enforce_range_n(&ask_solvency_diff, SOLVENCY_DIFF_BITS)?;
 
             // ── Family 8: position limit (two-sided) ──────────────────────────
@@ -1058,7 +1072,8 @@ mod tests {
     #[test]
     fn step_rejects_insufficient_balance() {
         let (mut w, prices, sizes) = sample_witness();
-        // notional = 100 * 10 = 1000; balance 500 < 1000 → solvency fails
+        // notional = 100 * 10 = 1000; bid balance 500 < 1000 → solvency fails.
+        // The bid (buyer) pays `notional` in the quote asset.
         w.matches[0].bid.balance = Decimal::from(500);
         let ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 2).unwrap();
         let z_0 = initial_z(&ext);
@@ -1067,6 +1082,45 @@ mod tests {
         assert!(
             !satisfied,
             "expected constraint system to be unsatisfied (insufficient balance)"
+        );
+    }
+
+    /// A seller's collateral is the BASE asset it delivers (`size`), not the
+    /// quote `notional` the buyer pays. The on-chain `_settleMatch` debits
+    /// `m.size` base from the ask, so the circuit must check
+    /// `ask_balance(base) >= m_size`, not `>= notional`. Here the seller holds
+    /// 50 base — far below `notional` (1000) but well above the filled size
+    /// (10). A correct ask-side check accepts this; the old notional-based
+    /// check wrongly rejected a fully collateralized seller (#170).
+    #[test]
+    fn step_accepts_seller_collateralized_in_base() {
+        let (mut w, prices, sizes) = sample_witness();
+        w.matches[0].ask.balance = Decimal::from(50);
+        let ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 2).unwrap();
+        let z_0 = initial_z(&ext);
+        let circuit = AuctionStepCircuit::new(2).unwrap();
+        let (satisfied, _) = run_step(&circuit, z_0, ext);
+        assert!(
+            satisfied,
+            "seller holding >= the filled base size must satisfy solvency"
+        );
+    }
+
+    /// The dual of the above: a seller that does not hold even the base it is
+    /// selling (`ask_balance < m_size`) must still be rejected — #170
+    /// re-denominates the ask check, it does not remove it.
+    #[test]
+    fn step_rejects_seller_short_of_base_size() {
+        let (mut w, prices, sizes) = sample_witness();
+        // m_size = 10; seller holds only 5 base → cannot deliver the fill.
+        w.matches[0].ask.balance = Decimal::from(5);
+        let ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 2).unwrap();
+        let z_0 = initial_z(&ext);
+        let circuit = AuctionStepCircuit::new(2).unwrap();
+        let (satisfied, _) = run_step(&circuit, z_0, ext);
+        assert!(
+            !satisfied,
+            "seller short of the base it sells must fail solvency"
         );
     }
 

--- a/crates/dp-zk/src/step_circuit.rs
+++ b/crates/dp-zk/src/step_circuit.rs
@@ -1124,6 +1124,26 @@ mod tests {
         );
     }
 
+    /// Boundary of the ask-side check: a seller holding *exactly* the filled
+    /// base size (`ask_balance == m_size`) is fully collateralized and must be
+    /// accepted. The diff `ask_balance - m_size` is zero, still in range. This
+    /// pins the constraint to `>=` rather than `>` — a seller delivering its
+    /// entire base balance still settles (#170).
+    #[test]
+    fn step_accepts_seller_holding_exactly_base_size() {
+        let (mut w, prices, sizes) = sample_witness();
+        // m_size = 10; seller holds exactly 10 base → diff is 0, still solvent.
+        w.matches[0].ask.balance = Decimal::from(10);
+        let ext = AuctionExternalInputs::from_witness(&w, &prices, &sizes, 2).unwrap();
+        let z_0 = initial_z(&ext);
+        let circuit = AuctionStepCircuit::new(2).unwrap();
+        let (satisfied, _) = run_step(&circuit, z_0, ext);
+        assert!(
+            satisfied,
+            "seller holding exactly the filled base size must satisfy solvency (>=, not >)"
+        );
+    }
+
     #[test]
     fn step_rejects_forged_trader_id() {
         let (mut w, prices, sizes) = sample_witness();


### PR DESCRIPTION
Closes #170

The step circuit ran the same notional-based solvency check on both legs, but a seller's collateral is the base asset it delivers, not the quote the buyer pays. On chain `_settleMatch` already debits `m.size` of `baseToken` from the ask and `notional` of `quoteToken` from the bid, so checking the ask balance against `notional` constrained the wrong asset and would reject sellers holding plenty of base.

Each leg now reads its balance in the asset it spends: the bid keeps the quote check, the ask requires `ask_balance >= m_size` directly since base balance and match size share the 1e8 scale. New circuit tests cover a base-collateralized seller (accepted) and one short of the base it sells (rejected).

The balance oracle is still the asset-blind dev stub, so I documented the per-leg asset it owes on `BalanceOracle` and `leg_witness_from` for whoever wires the escrow-backed version.