### PR TITLE
[fix] Reconcile frontend order book with #178 (mock-only)

### DIFF
--- a/front/app/app/trade/_components/charts/DepthChart.stories.tsx
+++ b/front/app/app/trade/_components/charts/DepthChart.stories.tsx
@@ -1,21 +1,16 @@
 import * as React from 'react'
-import { create } from '@bufbuild/protobuf'
 
-import {
-  GetOrderBookResponseSchema,
-  PriceLevelSchema,
-} from '@/lib/sdk/proto/darkpool/v1/darkpool_pb.js'
-import type { GetOrderBookResponse, PriceLevel } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb.js'
+import type { OrderBook, PriceLevel } from '@/lib/sdk/orderbook'
 
 import { DepthChartView } from './DepthChart'
 import { buildDepthSeries } from '../../_lib/charts/selectors'
 
 function level(price: string, totalSize: string, orderCount = 1): PriceLevel {
-  return create(PriceLevelSchema, { price, totalSize, orderCount })
+  return { price, totalSize, orderCount }
 }
 
-function book(bids: PriceLevel[], asks: PriceLevel[]): GetOrderBookResponse {
-  return create(GetOrderBookResponseSchema, { pair: 'ETH/USDC', bids, asks })
+function book(bids: PriceLevel[], asks: PriceLevel[]): OrderBook {
+  return { pair: 'ETH/USDC', bids, asks }
 }
 
 const FRAME = 'border border-brand-border bg-brand-surface p-4 w-[640px] h-[280px]'

--- a/front/app/app/trade/_components/orderbook/OrderBook.stories.tsx
+++ b/front/app/app/trade/_components/orderbook/OrderBook.stories.tsx
@@ -10,7 +10,6 @@ import { createFactoryContext, mockAuctionSummary, mockOrderBook } from '@/lib/s
 import {
   CancelOrderResponseSchema,
   GetAuctionHistoryResponseSchema,
-  GetOrderBookResponseSchema,
   GetOrderResponseSchema,
   OrderInfoSchema,
   PlaceOrderResponseSchema,
@@ -46,7 +45,7 @@ interface ClientOverrides {
 function buildClient(overrides: ClientOverrides = {}): DarkPoolClient {
   const ctx = createFactoryContext({ seed: overrides.seed ?? 7 })
   const book = overrides.bookEmpty
-    ? create(GetOrderBookResponseSchema, { pair: ctx.pair, bids: [], asks: [] })
+    ? { pair: ctx.pair, bids: [], asks: [] }
     : mockOrderBook(ctx, { depth: 12 })
   const auctions = overrides.noAuctions
     ? []

--- a/front/app/app/trade/_hooks/orderbook/useOrderBook.ts
+++ b/front/app/app/trade/_hooks/orderbook/useOrderBook.ts
@@ -7,10 +7,9 @@ import { useDarkPoolClient } from '@/lib/sdk/provider'
 import { DEFAULT_PAIR } from '@/lib/sdk/mocks/factories'
 import {
   GetAuctionHistoryRequestSchema,
-  GetOrderBookRequestSchema,
   type GetAuctionHistoryResponse,
-  type GetOrderBookResponse,
 } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { OrderBook } from '@/lib/sdk/orderbook'
 
 /**
  * 1000 ms = cadence of the F1.2 mock store's perturb tick. Faster polling
@@ -26,13 +25,13 @@ export interface UseOrderBookOptions {
   refetchIntervalMs?: number
 }
 
-export function useOrderBook(opts: UseOrderBookOptions = {}): UseQueryResult<GetOrderBookResponse> {
+export function useOrderBook(opts: UseOrderBookOptions = {}): UseQueryResult<OrderBook> {
   const client = useDarkPoolClient()
   const pair = opts.pair ?? DEFAULT_PAIR
   const refetchInterval = opts.refetchIntervalMs ?? ORDERBOOK_POLL_MS
   return useQuery({
     queryKey: ['darkpool', 'orderbook', pair],
-    queryFn: () => client.getOrderBook(create(GetOrderBookRequestSchema, { pair })),
+    queryFn: () => client.getOrderBook({ pair }),
     refetchInterval,
     // Keep the prior snapshot visible during the in-flight refetch so the
     // table doesn't flash a loading state on every tick.

--- a/front/app/app/trade/_lib/charts/selectors.test.ts
+++ b/front/app/app/trade/_lib/charts/selectors.test.ts
@@ -1,25 +1,18 @@
 import { create } from '@bufbuild/protobuf'
 import { describe, expect, it } from 'vitest'
 
-import {
-  GetOrderBookResponseSchema,
-  PriceLevelSchema,
-  AuctionSummarySchema,
-} from '@/lib/sdk/proto/darkpool/v1/darkpool_pb.js'
-import type {
-  AuctionSummary,
-  GetOrderBookResponse,
-  PriceLevel,
-} from '@/lib/sdk/proto/darkpool/v1/darkpool_pb.js'
+import { AuctionSummarySchema } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb.js'
+import type { AuctionSummary } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb.js'
+import type { OrderBook, PriceLevel } from '@/lib/sdk/orderbook'
 
 import { TIMEFRAME_MS, buildDepthSeries, selectAuctionsInWindow } from './selectors'
 
 function level(price: string, totalSize: string, orderCount = 1): PriceLevel {
-  return create(PriceLevelSchema, { price, totalSize, orderCount })
+  return { price, totalSize, orderCount }
 }
 
-function book(bids: PriceLevel[], asks: PriceLevel[]): GetOrderBookResponse {
-  return create(GetOrderBookResponseSchema, { pair: 'ETH/USDC', bids, asks })
+function book(bids: PriceLevel[], asks: PriceLevel[]): OrderBook {
+  return { pair: 'ETH/USDC', bids, asks }
 }
 
 function auction(timestampUnix: number, clearingPrice: string): AuctionSummary {

--- a/front/app/app/trade/_lib/charts/selectors.ts
+++ b/front/app/app/trade/_lib/charts/selectors.ts
@@ -1,8 +1,5 @@
-import type {
-  AuctionSummary,
-  GetOrderBookResponse,
-  PriceLevel,
-} from '@/lib/sdk/proto/darkpool/v1/darkpool_pb.js'
+import type { AuctionSummary } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb.js'
+import type { OrderBook, PriceLevel } from '@/lib/sdk/orderbook'
 import { Decimal } from '@/lib/units'
 
 export interface DepthPoint {
@@ -43,7 +40,7 @@ function cumulate(levels: readonly PriceLevel[]): DepthPoint[] {
   return out
 }
 
-export function buildDepthSeries(book: GetOrderBookResponse): DepthSeries {
+export function buildDepthSeries(book: OrderBook): DepthSeries {
   const bids = cumulate(book.bids)
   const asks = cumulate(book.asks)
 

--- a/front/app/app/trade/_lib/orderbook/depth.test.ts
+++ b/front/app/app/trade/_lib/orderbook/depth.test.ts
@@ -1,12 +1,11 @@
-import { create } from '@bufbuild/protobuf'
 import { describe, expect, it } from 'vitest'
 
-import { PriceLevelSchema } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { PriceLevel } from '@/lib/sdk/orderbook'
 
 import { computeDepthRows, formatDelta } from './depth'
 
-function level(price: string, totalSize: string, orderCount = 1) {
-  return create(PriceLevelSchema, { price, totalSize, orderCount })
+function level(price: string, totalSize: string, orderCount = 1): PriceLevel {
+  return { price, totalSize, orderCount }
 }
 
 describe('computeDepthRows', () => {

--- a/front/app/app/trade/_lib/orderbook/depth.ts
+++ b/front/app/app/trade/_lib/orderbook/depth.ts
@@ -1,6 +1,6 @@
 import { Decimal } from '@/lib/units'
 
-import type { PriceLevel } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { PriceLevel } from '@/lib/sdk/orderbook'
 
 export interface DepthRow {
   level: PriceLevel

--- a/front/lib/contracts/generated.ts
+++ b/front/lib/contracts/generated.ts
@@ -42,6 +42,13 @@ export const darkPoolAbi = [
   },
   {
     type: 'function',
+    inputs: [{ name: '', internalType: 'address', type: 'address' }],
+    name: 'allowedTokens',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     inputs: [{ name: '', internalType: 'bytes32', type: 'bytes32' }],
     name: 'auctionToSession',
     outputs: [{ name: '', internalType: 'bytes32', type: 'bytes32' }],
@@ -211,6 +218,16 @@ export const darkPoolAbi = [
       { name: 'positionLimit_', internalType: 'uint256', type: 'uint256' },
     ],
     name: 'setPolicy',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'token', internalType: 'address', type: 'address' },
+      { name: 'allowed', internalType: 'bool', type: 'bool' },
+    ],
+    name: 'setTokenAllowed',
     outputs: [],
     stateMutability: 'nonpayable',
   },
@@ -508,6 +525,20 @@ export const darkPoolAbi = [
       },
     ],
     name: 'SessionSubmitted',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'token',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      { name: 'allowed', internalType: 'bool', type: 'bool', indexed: false },
+    ],
+    name: 'TokenAllowed',
   },
   {
     type: 'event',

--- a/front/lib/contracts/generated.ts
+++ b/front/lib/contracts/generated.ts
@@ -29,6 +29,13 @@ export const darkPoolAbi = [
   {
     type: 'function',
     inputs: [],
+    name: 'UNRESERVE_DELAY',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
     name: 'acceptOwnership',
     outputs: [],
     stateMutability: 'nonpayable',
@@ -153,10 +160,27 @@ export const darkPoolAbi = [
   },
   {
     type: 'function',
+    inputs: [
+      { name: '', internalType: 'address', type: 'address' },
+      { name: '', internalType: 'address', type: 'address' },
+    ],
+    name: 'pendingUnreserve',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
     inputs: [],
     name: 'positionLimit',
     outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
     stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'token', internalType: 'address', type: 'address' }],
+    name: 'releaseUnreserve',
+    outputs: [],
+    stateMutability: 'nonpayable',
   },
   {
     type: 'function',
@@ -171,6 +195,36 @@ export const darkPoolAbi = [
     name: 'renounceOwnership',
     outputs: [],
     stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'token', internalType: 'address', type: 'address' },
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'requestUnreserve',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: 'token', internalType: 'address', type: 'address' },
+      { name: 'amount', internalType: 'uint256', type: 'uint256' },
+    ],
+    name: 'reserve',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: '', internalType: 'address', type: 'address' },
+      { name: '', internalType: 'address', type: 'address' },
+    ],
+    name: 'reserved',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
   },
   {
     type: 'function',
@@ -318,6 +372,16 @@ export const darkPoolAbi = [
     name: 'unpause',
     outputs: [],
     stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [
+      { name: '', internalType: 'address', type: 'address' },
+      { name: '', internalType: 'address', type: 'address' },
+    ],
+    name: 'unreserveReadyAt',
+    outputs: [{ name: '', internalType: 'uint256', type: 'uint256' }],
+    stateMutability: 'view',
   },
   {
     type: 'function',
@@ -506,6 +570,31 @@ export const darkPoolAbi = [
     anonymous: false,
     inputs: [
       {
+        name: 'trader',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'token',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'amount',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'Reserved',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
         name: 'sessionId',
         internalType: 'bytes32',
         type: 'bytes32',
@@ -552,6 +641,62 @@ export const darkPoolAbi = [
       },
     ],
     name: 'Unpaused',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'trader',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'token',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'amount',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+      {
+        name: 'readyAt',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'UnreserveRequested',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [
+      {
+        name: 'trader',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'token',
+        internalType: 'address',
+        type: 'address',
+        indexed: true,
+      },
+      {
+        name: 'amount',
+        internalType: 'uint256',
+        type: 'uint256',
+        indexed: false,
+      },
+    ],
+    name: 'Unreserved',
   },
   {
     type: 'event',

--- a/front/lib/mock-store.ts
+++ b/front/lib/mock-store.ts
@@ -10,23 +10,15 @@
 // singleton, stashed on a `Symbol.for`-keyed slot of `globalThis` so it
 // survives Next.js hot-module reloads in dev.
 
-import { create as createMessage } from '@bufbuild/protobuf'
 import { useSyncExternalStore } from 'react'
 import { createStore, type StoreApi } from 'zustand/vanilla'
 
 import { Decimal, toWireSize } from './units'
 
-import {
-  GetOrderBookResponseSchema,
-  PriceLevelSchema,
-  Side,
-} from './sdk/proto/darkpool/v1/darkpool_pb.js'
-import type {
-  AuctionSummary,
-  GetOrderBookResponse,
-  OrderInfo,
-  PriceLevel,
-} from './sdk/proto/darkpool/v1/darkpool_pb.js'
+import { Side } from './sdk/proto/darkpool/v1/darkpool_pb.js'
+import type { AuctionSummary, OrderInfo } from './sdk/proto/darkpool/v1/darkpool_pb.js'
+// Order book is mock-only since #178 — hand-written types, not generated.
+import type { OrderBook, PriceLevel } from './sdk/orderbook.js'
 
 import {
   DEFAULT_MID,
@@ -47,7 +39,7 @@ import {
 
 export interface MockStoreState {
   pair: string
-  orderbook: GetOrderBookResponse
+  orderbook: OrderBook
   /** Newest first. Capped at `RECENT_AUCTIONS_CAP`. */
   recentAuctions: AuctionSummary[]
   balances: Balances
@@ -259,25 +251,25 @@ export function useMockStore<T>(selector: (state: MockStore) => T): T {
 
 // ─── Orderbook mutation helpers ──────────────────────────────────────────
 
-function perturbBook(ctx: FactoryContext, book: GetOrderBookResponse): GetOrderBookResponse {
+function perturbBook(ctx: FactoryContext, book: OrderBook): OrderBook {
   const tweak = (level: PriceLevel): PriceLevel => {
     if (!ctx.faker.datatype.boolean({ probability: PERTURB_PROBABILITY })) return level
     const goesUp = ctx.faker.datatype.boolean()
     const factor = goesUp ? UP_FACTOR : DOWN_FACTOR
-    return createMessage(PriceLevelSchema, {
+    return {
       price: level.price,
       totalSize: scaleWireSize(level.totalSize, factor, SIZE_FLOOR),
       orderCount: level.orderCount,
-    })
+    }
   }
-  return createMessage(GetOrderBookResponseSchema, {
+  return {
     pair: book.pair,
     bids: book.bids.map(tweak),
     asks: book.asks.map(tweak),
-  })
+  }
 }
 
-function addOrderToBook(book: GetOrderBookResponse, order: OrderInfo): GetOrderBookResponse {
+function addOrderToBook(book: OrderBook, order: OrderInfo): OrderBook {
   const isBuy = order.side === Side.BUY
   const sideLevels = isBuy ? book.bids : book.asks
   const otherLevels = isBuy ? book.asks : book.bids
@@ -287,27 +279,27 @@ function addOrderToBook(book: GetOrderBookResponse, order: OrderInfo): GetOrderB
   if (idx >= 0) {
     const existing = sideLevels[idx]
     updated = [...sideLevels]
-    updated[idx] = createMessage(PriceLevelSchema, {
+    updated[idx] = {
       price: existing.price,
       totalSize: toWireSize(new Decimal(existing.totalSize).plus(order.remainingSize)),
       orderCount: existing.orderCount + 1,
-    })
+    }
   } else {
-    const inserted = createMessage(PriceLevelSchema, {
+    const inserted: PriceLevel = {
       price: order.price,
       totalSize: order.remainingSize,
       orderCount: 1,
-    })
+    }
     updated = sortSide(isBuy, [...sideLevels, inserted])
   }
-  return createMessage(GetOrderBookResponseSchema, {
+  return {
     pair: book.pair,
     bids: isBuy ? updated : otherLevels,
     asks: isBuy ? otherLevels : updated,
-  })
+  }
 }
 
-function removeOrderFromBook(book: GetOrderBookResponse, order: OrderInfo): GetOrderBookResponse {
+function removeOrderFromBook(book: OrderBook, order: OrderInfo): OrderBook {
   const isBuy = order.side === Side.BUY
   const sideLevels = isBuy ? book.bids : book.asks
   const otherLevels = isBuy ? book.asks : book.bids
@@ -321,17 +313,17 @@ function removeOrderFromBook(book: GetOrderBookResponse, order: OrderInfo): GetO
     updated = sideLevels.filter((_, i) => i !== idx)
   } else {
     updated = [...sideLevels]
-    updated[idx] = createMessage(PriceLevelSchema, {
+    updated[idx] = {
       price: existing.price,
       totalSize: toWireSize(newSize),
       orderCount: existing.orderCount - 1,
-    })
+    }
   }
-  return createMessage(GetOrderBookResponseSchema, {
+  return {
     pair: book.pair,
     bids: isBuy ? updated : otherLevels,
     asks: isBuy ? otherLevels : updated,
-  })
+  }
 }
 
 function sortSide(isBuy: boolean, levels: PriceLevel[]): PriceLevel[] {

--- a/front/lib/sdk/client.test.ts
+++ b/front/lib/sdk/client.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   CancelOrderRequestSchema,
   GetAuctionHistoryRequestSchema,
-  GetOrderBookRequestSchema,
   GetOrderRequestSchema,
   PlaceOrderRequestSchema,
   Side,
@@ -141,14 +140,20 @@ describe('RestClient.getOrder', () => {
 })
 
 describe('RestClient.getOrderBook', () => {
-  it('GETs /v1/orderbook with the pair query param', async () => {
+  // #178 removed the public pre-settlement order book from the backend — a
+  // dark pool does not expose cross-trader depth, so there is no
+  // GET /v1/orderbook to call. The REST path is an explicit UNIMPLEMENTED
+  // throw and never touches the network; the panel runs on the mock store.
+  it('throws UNIMPLEMENTED without making a request', async () => {
     const { fetch, calls } = captureFetch(
       makeJsonResponse({ pair: 'ETH/USDC', bids: [], asks: [] })
     )
     const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
-    const resp = await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
-    expect(calls[0].url).toBe(`${BASE}/v1/orderbook?pair=ETH%2FUSDC`)
-    expect(resp.bids).toEqual([])
+    await expect(client.getOrderBook({ pair: 'ETH/USDC' })).rejects.toMatchObject({
+      name: 'DarkPoolError',
+      code: DARK_POOL_ERROR_CODES.UNIMPLEMENTED,
+    })
+    expect(calls).toHaveLength(0)
   })
 })
 
@@ -249,7 +254,9 @@ describe('RestClient error mapping', () => {
     )
     const client = new RestClient({ baseUrl: BASE, apiKey: KEY, fetch })
     await expect(
-      client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+      client.getAuctionHistory(
+        create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 0 })
+      )
     ).rejects.toMatchObject({
       code: DARK_POOL_ERROR_CODES.UNAVAILABLE,
       retryable: true,
@@ -317,7 +324,7 @@ describe('MockClient', () => {
 
   it('getOrderBook returns an empty book for the configured pair', async () => {
     const mock = new MockClient()
-    const book = await mock.getOrderBook(create(GetOrderBookRequestSchema, { pair: '' }))
+    const book = await mock.getOrderBook({ pair: '' })
     expect(book.pair).toBe('ETH/USDC')
     expect(book.bids).toEqual([])
     expect(book.asks).toEqual([])
@@ -427,7 +434,7 @@ describe('createDarkPoolClient', () => {
       },
     })
 
-    await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    await client.getOrderBook({ pair: 'ETH/USDC' })
     await client.placeOrder(create(PlaceOrderRequestSchema))
     await client.getAuctionHistory(
       create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 0 })
@@ -506,14 +513,16 @@ describe('methodOverridesFromEnv', () => {
   })
 })
 
-// ─── I2.4 wire test: NEXT_PUBLIC_USE_MOCKS_ORDERBOOK=false flips just  ──
-//      `getOrderBook` to the live RestClient while everything else stays
-//      on the StoreMockClient. Locks the documented Phase-2 ramp so a
-//      regression in either the env parser or the routing client surfaces
-//      here instead of as a silent mocked response in the browser.
+// ─── Order book is mock-only since #178 ──────────────────────────────────
+//      The public pre-settlement order book was removed from the backend
+//      (no GET /v1/orderbook). NEXT_PUBLIC_USE_MOCKS_ORDERBOOK still parses,
+//      but flipping it false routes getOrderBook to the RestClient, whose
+//      path is now an explicit UNIMPLEMENTED throw — there is no live
+//      endpoint to flip to. This locks that contract so a regression
+//      surfaces here instead of as a runtime 404 in the browser.
 
-describe('Phase 2 flip — NEXT_PUBLIC_USE_MOCKS_ORDERBOOK=false', () => {
-  it('routes getOrderBook to REST while siblings stay on the StoreMockClient', async () => {
+describe('Order book is mock-only — NEXT_PUBLIC_USE_MOCKS_ORDERBOOK=false', () => {
+  it('routes getOrderBook to REST, which throws UNIMPLEMENTED without a request', async () => {
     const overrides = methodOverridesFromEnv({
       NEXT_PUBLIC_USE_MOCKS_ORDERBOOK: 'false',
     })
@@ -534,15 +543,14 @@ describe('Phase 2 flip — NEXT_PUBLIC_USE_MOCKS_ORDERBOOK=false', () => {
       methodOverrides: overrides,
     })
 
-    await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    await expect(client.getOrderBook({ pair: 'ETH/USDC' })).rejects.toMatchObject({
+      code: DARK_POOL_ERROR_CODES.UNIMPLEMENTED,
+    })
     await client.getAuctionHistory(
       create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 50 })
     )
 
-    expect(calls).toHaveLength(1)
-    expect(calls[0].url).toBe(`${BASE}/v1/orderbook?pair=ETH%2FUSDC`)
-    const headers = calls[0].init.headers as Record<string, string>
-    expect(headers['x-api-key']).toBe(KEY)
+    expect(calls).toHaveLength(0)
     expect(mockCalls).toEqual(['getAuctionHistory'])
   })
 })
@@ -576,7 +584,7 @@ describe('Phase 2 flip — NEXT_PUBLIC_USE_MOCKS_AUCTION_HISTORY=false', () => {
     await client.getAuctionHistory(
       create(GetAuctionHistoryRequestSchema, { pair: 'ETH/USDC', limit: 50 })
     )
-    await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    await client.getOrderBook({ pair: 'ETH/USDC' })
 
     expect(calls).toHaveLength(1)
     expect(calls[0].url).toBe(`${BASE}/v1/auctions?pair=ETH%2FUSDC&limit=50`)

--- a/front/lib/sdk/client.ts
+++ b/front/lib/sdk/client.ts
@@ -18,7 +18,6 @@ import type { DescMessage, MessageShape } from '@bufbuild/protobuf'
 import {
   CancelOrderResponseSchema,
   GetAuctionHistoryResponseSchema,
-  GetOrderBookResponseSchema,
   GetOrderResponseSchema,
   OrderInfoSchema,
   PlaceOrderRequestSchema,
@@ -31,14 +30,15 @@ import type {
   CancelOrderResponse,
   GetAuctionHistoryRequest,
   GetAuctionHistoryResponse,
-  GetOrderBookRequest,
-  GetOrderBookResponse,
   GetOrderRequest,
   GetOrderResponse,
   PlaceOrderRequest,
   PlaceOrderResponse,
   StreamAuctionsRequest,
 } from './proto/darkpool/v1/darkpool_pb.js'
+// The order book is mock-only since #178 removed it from the wire — see
+// ./orderbook for the rationale. These types are hand-written, not generated.
+import type { OrderBook, OrderBookRequest } from './orderbook.js'
 
 // ─── Error model ──────────────────────────────────────────────────────────
 //
@@ -154,7 +154,7 @@ export interface DarkPoolClient {
   placeOrder(req: PlaceOrderRequest): Promise<PlaceOrderResponse>
   cancelOrder(req: CancelOrderRequest): Promise<CancelOrderResponse>
   getOrder(req: GetOrderRequest): Promise<GetOrderResponse>
-  getOrderBook(req: GetOrderBookRequest): Promise<GetOrderBookResponse>
+  getOrderBook(req: OrderBookRequest): Promise<OrderBook>
   getAuctionHistory(req: GetAuctionHistoryRequest): Promise<GetAuctionHistoryResponse>
   streamAuctions(req: StreamAuctionsRequest, opts?: StreamOptions): AsyncIterable<AuctionEvent>
 }
@@ -217,11 +217,19 @@ export class RestClient implements DarkPoolClient {
     )
   }
 
-  getOrderBook(req: GetOrderBookRequest): Promise<GetOrderBookResponse> {
-    const search = new URLSearchParams()
-    if (req.pair) search.set('pair', req.pair)
-    const qs = search.toString()
-    return this.requestJson('GET', `/v1/orderbook${qs ? `?${qs}` : ''}`, GetOrderBookResponseSchema)
+  async getOrderBook(req: OrderBookRequest): Promise<OrderBook> {
+    void req
+    // #178 removed the public pre-settlement order book from the backend
+    // (no GET /v1/orderbook). A dark pool deliberately hides cross-trader
+    // depth, so there is no real endpoint to call — the panel runs on the
+    // mock store. Keep this method on the interface (the UI calls it) but
+    // make the REST path an explicit, actionable failure.
+    throw new DarkPoolError(
+      DARK_POOL_ERROR_CODES.UNIMPLEMENTED,
+      'The public order book was removed in #178 — a dark pool does not expose ' +
+        'pre-settlement depth. Set NEXT_PUBLIC_USE_MOCKS_ORDERBOOK=true to run the ' +
+        'panel on the mock store.'
+    )
   }
 
   getAuctionHistory(req: GetAuctionHistoryRequest): Promise<GetAuctionHistoryResponse> {
@@ -354,12 +362,8 @@ export class MockClient implements DarkPoolClient {
     return create(GetOrderResponseSchema, { order })
   }
 
-  async getOrderBook(req: GetOrderBookRequest): Promise<GetOrderBookResponse> {
-    return create(GetOrderBookResponseSchema, {
-      pair: req.pair || this.pair,
-      bids: [],
-      asks: [],
-    })
+  async getOrderBook(req: OrderBookRequest): Promise<OrderBook> {
+    return { pair: req.pair || this.pair, bids: [], asks: [] }
   }
 
   async getAuctionHistory(req: GetAuctionHistoryRequest): Promise<GetAuctionHistoryResponse> {
@@ -456,7 +460,7 @@ class RoutingClient implements DarkPoolClient {
   getOrder(req: GetOrderRequest): Promise<GetOrderResponse> {
     return this.pick('getOrder').getOrder(req)
   }
-  getOrderBook(req: GetOrderBookRequest): Promise<GetOrderBookResponse> {
+  getOrderBook(req: OrderBookRequest): Promise<OrderBook> {
     return this.pick('getOrderBook').getOrderBook(req)
   }
   getAuctionHistory(req: GetAuctionHistoryRequest): Promise<GetAuctionHistoryResponse> {

--- a/front/lib/sdk/index.ts
+++ b/front/lib/sdk/index.ts
@@ -39,17 +39,6 @@ export {
   type GetOrderResponseJson,
   GetOrderResponseSchema,
 
-  // Order book
-  type GetOrderBookRequest,
-  type GetOrderBookRequestJson,
-  GetOrderBookRequestSchema,
-  type GetOrderBookResponse,
-  type GetOrderBookResponseJson,
-  GetOrderBookResponseSchema,
-  type PriceLevel,
-  type PriceLevelJson,
-  PriceLevelSchema,
-
   // Auctions
   type GetAuctionHistoryRequest,
   type GetAuctionHistoryRequestJson,
@@ -79,9 +68,9 @@ export {
   DarkPoolService,
 } from './proto/darkpool/v1/darkpool_pb.js'
 
-// Friendly alias: the proto names the orderbook payload
-// `GetOrderBookResponse`, but consumers think of it as the order book itself.
-export type { GetOrderBookResponse as OrderBook } from './proto/darkpool/v1/darkpool_pb.js'
+// Order book — mock-only since #178 removed it from the wire. These are
+// hand-written domain types, not generated from the proto. See ./orderbook.
+export type { OrderBook, OrderBookRequest, PriceLevel } from './orderbook.js'
 
 // ─── F1.2 mocks (#69) ────────────────────────────────────────────────────
 //

--- a/front/lib/sdk/mocks/client.test.ts
+++ b/front/lib/sdk/mocks/client.test.ts
@@ -7,7 +7,6 @@ import { createMockStore } from '../../mock-store'
 import {
   CancelOrderRequestSchema,
   GetAuctionHistoryRequestSchema,
-  GetOrderBookRequestSchema,
   GetOrderRequestSchema,
   PlaceOrderRequestSchema,
   Side,
@@ -99,7 +98,7 @@ describe('StoreMockClient.getOrder', () => {
 describe('StoreMockClient.getOrderBook', () => {
   it('returns the live store snapshot', async () => {
     const { store, client } = freshClient()
-    const resp = await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    const resp = await client.getOrderBook({ pair: 'ETH/USDC' })
     expect(resp.bids).toEqual(store.getState().orderbook.bids)
     expect(resp.asks).toEqual(store.getState().orderbook.asks)
     expect(resp.pair).toBe('ETH/USDC')
@@ -107,13 +106,13 @@ describe('StoreMockClient.getOrderBook', () => {
 
   it('falls back to the store pair when no pair is requested', async () => {
     const { client } = freshClient()
-    const resp = await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: '' }))
+    const resp = await client.getOrderBook({ pair: '' })
     expect(resp.pair).toBe('ETH/USDC')
   })
 
   it('keeps the orderbook sorted (best bid first, best ask first)', async () => {
     const { client } = freshClient()
-    const resp = await client.getOrderBook(create(GetOrderBookRequestSchema, { pair: 'ETH/USDC' }))
+    const resp = await client.getOrderBook({ pair: 'ETH/USDC' })
     for (let i = 1; i < resp.bids.length; i++) {
       expect(new Decimal(resp.bids[i].price).lt(resp.bids[i - 1].price)).toBe(true)
     }

--- a/front/lib/sdk/mocks/client.ts
+++ b/front/lib/sdk/mocks/client.ts
@@ -25,7 +25,6 @@ import {
   AuctionEventSchema,
   CancelOrderResponseSchema,
   GetAuctionHistoryResponseSchema,
-  GetOrderBookResponseSchema,
   GetOrderResponseSchema,
   PlaceOrderResponseSchema,
 } from '../proto/darkpool/v1/darkpool_pb.js'
@@ -36,8 +35,6 @@ import type {
   CancelOrderResponse,
   GetAuctionHistoryRequest,
   GetAuctionHistoryResponse,
-  GetOrderBookRequest,
-  GetOrderBookResponse,
   GetOrderRequest,
   GetOrderResponse,
   PlaceOrderRequest,
@@ -45,6 +42,8 @@ import type {
   StreamAuctionsRequest,
 } from '../proto/darkpool/v1/darkpool_pb.js'
 import { Side } from '../proto/darkpool/v1/darkpool_pb.js'
+// Order book is mock-only since #178 — hand-written types, not generated.
+import type { OrderBook, OrderBookRequest } from '../orderbook.js'
 
 // ─── PlaceOrder payload bridge ────────────────────────────────────────────
 //
@@ -143,15 +142,15 @@ export class StoreMockClient implements DarkPoolClient {
     return createMessage(GetOrderResponseSchema, { order })
   }
 
-  async getOrderBook(req: GetOrderBookRequest): Promise<GetOrderBookResponse> {
+  async getOrderBook(req: OrderBookRequest): Promise<OrderBook> {
     const book = this.store.getState().orderbook
-    // Echo the requested pair when the client asked for one (mirroring the
-    // REST handler's behavior). Empty `pair` → fall back to the store pair.
-    return createMessage(GetOrderBookResponseSchema, {
+    // Echo the requested pair when the client asked for one. Empty `pair` →
+    // fall back to the store pair.
+    return {
       pair: req.pair || book.pair || this.pair,
       bids: book.bids,
       asks: book.asks,
-    })
+    }
   }
 
   async getAuctionHistory(req: GetAuctionHistoryRequest): Promise<GetAuctionHistoryResponse> {

--- a/front/lib/sdk/mocks/factories.ts
+++ b/front/lib/sdk/mocks/factories.ts
@@ -13,19 +13,10 @@ import { Faker, en } from '@faker-js/faker'
 
 import { Decimal, toWirePrice, toWireSize } from '../../units'
 
-import {
-  AuctionSummarySchema,
-  GetOrderBookResponseSchema,
-  OrderInfoSchema,
-  PriceLevelSchema,
-  Side,
-} from '../proto/darkpool/v1/darkpool_pb.js'
-import type {
-  AuctionSummary,
-  GetOrderBookResponse,
-  OrderInfo,
-  PriceLevel,
-} from '../proto/darkpool/v1/darkpool_pb.js'
+import { AuctionSummarySchema, OrderInfoSchema, Side } from '../proto/darkpool/v1/darkpool_pb.js'
+import type { AuctionSummary, OrderInfo } from '../proto/darkpool/v1/darkpool_pb.js'
+// Order book is mock-only since #178 — hand-written types, not generated.
+import type { OrderBook, PriceLevel } from '../orderbook.js'
 
 // ─── Pair / market defaults ───────────────────────────────────────────────
 //
@@ -137,11 +128,11 @@ export function mockPriceLevel(ctx: FactoryContext, opts: MockPriceLevelOptions)
       ? opts.totalSize
       : sampleDecimal(ctx.faker, { min: '0.5', max: '50', dp: SIZE_DP })
   const orderCount = opts.orderCount ?? ctx.faker.number.int({ min: 1, max: 12 })
-  return create(PriceLevelSchema, {
+  return {
     price: toWirePrice(opts.price),
     totalSize: toWireSize(size),
     orderCount,
-  })
+  }
 }
 
 // ─── mockOrderBook ────────────────────────────────────────────────────────
@@ -157,10 +148,7 @@ export interface MockOrderBookOptions {
   pair?: string
 }
 
-export function mockOrderBook(
-  ctx: FactoryContext,
-  opts: MockOrderBookOptions = {}
-): GetOrderBookResponse {
+export function mockOrderBook(ctx: FactoryContext, opts: MockOrderBookOptions = {}): OrderBook {
   const mid = opts.mid !== undefined ? new Decimal(opts.mid.toString()) : DEFAULT_MID
   const depth = opts.depth ?? 12
   const tick = opts.tickSize !== undefined ? new Decimal(opts.tickSize.toString()) : new Decimal(1)
@@ -180,7 +168,7 @@ export function mockOrderBook(
   bids.sort((a, b) => new Decimal(b.price).cmp(new Decimal(a.price)))
   asks.sort((a, b) => new Decimal(a.price).cmp(new Decimal(b.price)))
 
-  return create(GetOrderBookResponseSchema, { pair, bids, asks })
+  return { pair, bids, asks }
 }
 
 // ─── mockOrderInfo ────────────────────────────────────────────────────────
@@ -334,7 +322,7 @@ export function scaleWireSize(
 }
 
 /** Return the midpoint of best bid / best ask. Throws if either side is empty. */
-export function midFromBook(book: GetOrderBookResponse): Decimal {
+export function midFromBook(book: OrderBook): Decimal {
   if (book.bids.length === 0 || book.asks.length === 0) {
     throw new Error('factories: cannot compute mid on an empty side')
   }

--- a/front/lib/sdk/orderbook.ts
+++ b/front/lib/sdk/orderbook.ts
@@ -1,0 +1,40 @@
+// Order book domain types — mock-only as of #178.
+//
+// The backend removed the public pre-settlement order book in
+// commit d4cb56b ("Remove pre-settlement orderbook; scope order reads to
+// caller"): there is no `GetOrderBook` RPC and no `GetOrderBookResponse` /
+// `PriceLevel` message in crates/dp-api/proto/darkpool/v1/darkpool.proto
+// anymore. Serving live cross-trader depth would defeat the dark pool — an
+// observer could reconstruct incoming liquidity and cross it in the same
+// auction round.
+//
+// The trading UI still renders an order book, but it is sourced entirely
+// from the Phase-1 mock store (gate it with NEXT_PUBLIC_USE_MOCKS_ORDERBOOK).
+// These hand-written types replace the formerly-generated proto messages so
+// the panel, depth lib, and depth chart keep their shape without a wire
+// backing. They never cross the network, so they are plain interfaces with
+// no protobuf runtime — decimal fields stay canonical wire strings.
+
+/** One aggregated price level in the (mock) order book. */
+export interface PriceLevel {
+  /** Canonical decimal string — never coerce to JS number. */
+  price: string
+  /** Aggregate resting size at this level, as a canonical decimal string. */
+  totalSize: string
+  /** Number of resting orders aggregated into this level. */
+  orderCount: number
+}
+
+/** A full order-book snapshot: best-of-book at index 0 on each side. */
+export interface OrderBook {
+  pair: string
+  /** Descending price (best bid first). */
+  bids: PriceLevel[]
+  /** Ascending price (best ask first). */
+  asks: PriceLevel[]
+}
+
+/** Query for {@link DarkPoolClient.getOrderBook}. */
+export interface OrderBookRequest {
+  pair: string
+}

--- a/front/lib/sdk/proto/darkpool/v1/darkpool_pb.ts
+++ b/front/lib/sdk/proto/darkpool/v1/darkpool_pb.ts
@@ -11,25 +11,36 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file darkpool/v1/darkpool.proto.
  */
 export const file_darkpool_v1_darkpool: GenFile = /*@__PURE__*/
-  fileDesc("ChpkYXJrcG9vbC92MS9kYXJrcG9vbC5wcm90bxILZGFya3Bvb2wudjEiUQoRUGxhY2VPcmRlclJlcXVlc3QSEgoKY29tbWl0bWVudBgBIAEoDBINCgVwcm9vZhgCIAEoDBIZChFlbmNyeXB0ZWRfcGF5bG9hZBgDIAEoDCI7ChJQbGFjZU9yZGVyUmVzcG9uc2USJQoFb3JkZXIYASABKAsyFi5kYXJrcG9vbC52MS5PcmRlckluZm8iNgoSQ2FuY2VsT3JkZXJSZXF1ZXN0EhAKCG9yZGVyX2lkGAEgASgJEg4KBnJlYXNvbhgCIAEoCSIVChNDYW5jZWxPcmRlclJlc3BvbnNlIiMKD0dldE9yZGVyUmVxdWVzdBIQCghvcmRlcl9pZBgBIAEoCSI5ChBHZXRPcmRlclJlc3BvbnNlEiUKBW9yZGVyGAEgASgLMhYuZGFya3Bvb2wudjEuT3JkZXJJbmZvIiMKE0dldE9yZGVyQm9va1JlcXVlc3QSDAoEcGFpchgBIAEoCSJyChRHZXRPcmRlckJvb2tSZXNwb25zZRIMCgRwYWlyGAEgASgJEiUKBGJpZHMYAiADKAsyFy5kYXJrcG9vbC52MS5QcmljZUxldmVsEiUKBGFza3MYAyADKAsyFy5kYXJrcG9vbC52MS5QcmljZUxldmVsIkQKClByaWNlTGV2ZWwSDQoFcHJpY2UYASABKAkSEgoKdG90YWxfc2l6ZRgCIAEoCRITCgtvcmRlcl9jb3VudBgDIAEoBSI3ChhHZXRBdWN0aW9uSGlzdG9yeVJlcXVlc3QSDAoEcGFpchgBIAEoCRINCgVsaW1pdBgCIAEoBSJKChlHZXRBdWN0aW9uSGlzdG9yeVJlc3BvbnNlEi0KCGF1Y3Rpb25zGAEgAygLMhsuZGFya3Bvb2wudjEuQXVjdGlvblN1bW1hcnkijwEKDkF1Y3Rpb25TdW1tYXJ5EhIKCmF1Y3Rpb25faWQYASABKAkSDAoEcGFpchgCIAEoCRIWCg5jbGVhcmluZ19wcmljZRgDIAEoCRIWCg5tYXRjaGVkX3ZvbHVtZRgEIAEoCRITCgttYXRjaF9jb3VudBgFIAEoBRIWCg50aW1lc3RhbXBfdW5peBgGIAEoAyIlChVTdHJlYW1BdWN0aW9uc1JlcXVlc3QSDAoEcGFpchgBIAEoCSKNAQoMQXVjdGlvbkV2ZW50EhIKCmF1Y3Rpb25faWQYASABKAkSDAoEcGFpchgCIAEoCRIWCg5jbGVhcmluZ19wcmljZRgDIAEoCRIWCg5tYXRjaGVkX3ZvbHVtZRgEIAEoCRITCgttYXRjaF9jb3VudBgFIAEoBRIWCg50aW1lc3RhbXBfdW5peBgGIAEoAyLHAQoJT3JkZXJJbmZvEgoKAmlkGAEgASgJEgwKBHBhaXIYAiABKAkSHwoEc2lkZRgDIAEoDjIRLmRhcmtwb29sLnYxLlNpZGUSDQoFcHJpY2UYBCABKAkSDAoEc2l6ZRgFIAEoCRIWCg5yZW1haW5pbmdfc2l6ZRgGIAEoCRIWCg5jb21taXRtZW50X2tleRgHIAEoCRIZChFzdWJtaXR0ZWRfYXRfdW5peBgIIAEoAxIXCg9leHBpcmVzX2F0X3VuaXgYCSABKAMizwEKCFBhaXJJbmZvEgwKBHBhaXIYASABKAkSEgoKYmFzZV90b2tlbhgCIAEoCRITCgtxdW90ZV90b2tlbhgDIAEoCRIWCg5taW5fb3JkZXJfc2l6ZRgEIAEoCRIRCgl0aWNrX3NpemUYBSABKAkSIAoTYXVjdGlvbl9pbnRlcnZhbF9tcxgGIAEoDUgAiAEBEicKBnN0YXR1cxgHIAEoDjIXLmRhcmtwb29sLnYxLlBhaXJTdGF0dXNCFgoUX2F1Y3Rpb25faW50ZXJ2YWxfbXMiEgoQTGlzdFBhaXJzUmVxdWVzdCI5ChFMaXN0UGFpcnNSZXNwb25zZRIkCgVwYWlycxgBIAMoCzIVLmRhcmtwb29sLnYxLlBhaXJJbmZvIhcKFUxpc3RQYWlyc0FkbWluUmVxdWVzdCI+ChZMaXN0UGFpcnNBZG1pblJlc3BvbnNlEiQKBXBhaXJzGAEgAygLMhUuZGFya3Bvb2wudjEuUGFpckluZm8isQEKE1JlZ2lzdGVyUGFpclJlcXVlc3QSDAoEcGFpchgBIAEoCRISCgpiYXNlX3Rva2VuGAIgASgJEhMKC3F1b3RlX3Rva2VuGAMgASgJEhYKDm1pbl9vcmRlcl9zaXplGAQgASgJEhEKCXRpY2tfc2l6ZRgFIAEoCRIgChNhdWN0aW9uX2ludGVydmFsX21zGAYgASgNSACIAQFCFgoUX2F1Y3Rpb25faW50ZXJ2YWxfbXMiOwoUUmVnaXN0ZXJQYWlyUmVzcG9uc2USIwoEcGFpchgBIAEoCzIVLmRhcmtwb29sLnYxLlBhaXJJbmZvIiIKElN1c3BlbmRQYWlyUmVxdWVzdBIMCgRwYWlyGAEgASgJIhUKE1N1c3BlbmRQYWlyUmVzcG9uc2UiIQoRRGVsaXN0UGFpclJlcXVlc3QSDAoEcGFpchgBIAEoCSIuChJEZWxpc3RQYWlyUmVzcG9uc2USGAoQY2FuY2VsbGVkX29yZGVycxgBIAEoDSo5CgRTaWRlEhQKEFNJREVfVU5TUEVDSUZJRUQQABIMCghTSURFX0JVWRABEg0KCVNJREVfU0VMTBACKnYKClBhaXJTdGF0dXMSGwoXUEFJUl9TVEFUVVNfVU5TUEVDSUZJRUQQABIWChJQQUlSX1NUQVRVU19BQ1RJVkUQARIZChVQQUlSX1NUQVRVU19TVVNQRU5ERUQQAhIYChRQQUlSX1NUQVRVU19ERUxJU1RFRBADMuoFCg9EYXJrUG9vbFNlcnZpY2USZAoKUGxhY2VPcmRlchIeLmRhcmtwb29sLnYxLlBsYWNlT3JkZXJSZXF1ZXN0Gh8uZGFya3Bvb2wudjEuUGxhY2VPcmRlclJlc3BvbnNlIhWC0+STAg86ASoiCi92MS9vcmRlcnMSbwoLQ2FuY2VsT3JkZXISHy5kYXJrcG9vbC52MS5DYW5jZWxPcmRlclJlcXVlc3QaIC5kYXJrcG9vbC52MS5DYW5jZWxPcmRlclJlc3BvbnNlIh2C0+STAhcqFS92MS9vcmRlcnMve29yZGVyX2lkfRJmCghHZXRPcmRlchIcLmRhcmtwb29sLnYxLkdldE9yZGVyUmVxdWVzdBodLmRhcmtwb29sLnYxLkdldE9yZGVyUmVzcG9uc2UiHYLT5JMCFxIVL3YxL29yZGVycy97b3JkZXJfaWR9EmoKDEdldE9yZGVyQm9vaxIgLmRhcmtwb29sLnYxLkdldE9yZGVyQm9va1JlcXVlc3QaIS5kYXJrcG9vbC52MS5HZXRPcmRlckJvb2tSZXNwb25zZSIVgtPkkwIPEg0vdjEvb3JkZXJib29rEngKEUdldEF1Y3Rpb25IaXN0b3J5EiUuZGFya3Bvb2wudjEuR2V0QXVjdGlvbkhpc3RvcnlSZXF1ZXN0GiYuZGFya3Bvb2wudjEuR2V0QXVjdGlvbkhpc3RvcnlSZXNwb25zZSIUgtPkkwIOEgwvdjEvYXVjdGlvbnMSUwoOU3RyZWFtQXVjdGlvbnMSIi5kYXJrcG9vbC52MS5TdHJlYW1BdWN0aW9uc1JlcXVlc3QaGS5kYXJrcG9vbC52MS5BdWN0aW9uRXZlbnQiADABEl0KCUxpc3RQYWlycxIdLmRhcmtwb29sLnYxLkxpc3RQYWlyc1JlcXVlc3QaHi5kYXJrcG9vbC52MS5MaXN0UGFpcnNSZXNwb25zZSIRgtPkkwILEgkvdjEvcGFpcnMy5wMKFERhcmtQb29sQWRtaW5TZXJ2aWNlEm8KDFJlZ2lzdGVyUGFpchIgLmRhcmtwb29sLnYxLlJlZ2lzdGVyUGFpclJlcXVlc3QaIS5kYXJrcG9vbC52MS5SZWdpc3RlclBhaXJSZXNwb25zZSIagtPkkwIUOgEqIg8vdjEvYWRtaW4vcGFpcnMSewoLU3VzcGVuZFBhaXISHy5kYXJrcG9vbC52MS5TdXNwZW5kUGFpclJlcXVlc3QaIC5kYXJrcG9vbC52MS5TdXNwZW5kUGFpclJlc3BvbnNlIimC0+STAiM6ASoyHi92MS9hZG1pbi9wYWlycy97cGFpcn0vc3VzcGVuZBJtCgpEZWxpc3RQYWlyEh4uZGFya3Bvb2wudjEuRGVsaXN0UGFpclJlcXVlc3QaHy5kYXJrcG9vbC52MS5EZWxpc3RQYWlyUmVzcG9uc2UiHoLT5JMCGCoWL3YxL2FkbWluL3BhaXJzL3twYWlyfRJyCg5MaXN0UGFpcnNBZG1pbhIiLmRhcmtwb29sLnYxLkxpc3RQYWlyc0FkbWluUmVxdWVzdBojLmRhcmtwb29sLnYxLkxpc3RQYWlyc0FkbWluUmVzcG9uc2UiF4LT5JMCERIPL3YxL2FkbWluL3BhaXJzQkRaQmdpdGh1Yi5jb20vZGFya3Bvb2wtZXhjaGFuZ2Uvc2VydmVyL2FwaS9nZW4vZGFya3Bvb2wvdjE7ZGFya3Bvb2x2MWIGcHJvdG8z", [file_google_api_annotations]);
+  fileDesc("ChpkYXJrcG9vbC92MS9kYXJrcG9vbC5wcm90bxILZGFya3Bvb2wudjEiUQoRUGxhY2VPcmRlclJlcXVlc3QSEgoKY29tbWl0bWVudBgBIAEoDBINCgVwcm9vZhgCIAEoDBIZChFlbmNyeXB0ZWRfcGF5bG9hZBgDIAEoDCI7ChJQbGFjZU9yZGVyUmVzcG9uc2USJQoFb3JkZXIYASABKAsyFi5kYXJrcG9vbC52MS5PcmRlckluZm8iNgoSQ2FuY2VsT3JkZXJSZXF1ZXN0EhAKCG9yZGVyX2lkGAEgASgJEg4KBnJlYXNvbhgCIAEoCSIVChNDYW5jZWxPcmRlclJlc3BvbnNlIiMKD0dldE9yZGVyUmVxdWVzdBIQCghvcmRlcl9pZBgBIAEoCSI5ChBHZXRPcmRlclJlc3BvbnNlEiUKBW9yZGVyGAEgASgLMhYuZGFya3Bvb2wudjEuT3JkZXJJbmZvIiEKEUxpc3RPcmRlcnNSZXF1ZXN0EgwKBHBhaXIYASABKAkiPAoSTGlzdE9yZGVyc1Jlc3BvbnNlEiYKBm9yZGVycxgBIAMoCzIWLmRhcmtwb29sLnYxLk9yZGVySW5mbyI3ChhHZXRBdWN0aW9uSGlzdG9yeVJlcXVlc3QSDAoEcGFpchgBIAEoCRINCgVsaW1pdBgCIAEoBSJKChlHZXRBdWN0aW9uSGlzdG9yeVJlc3BvbnNlEi0KCGF1Y3Rpb25zGAEgAygLMhsuZGFya3Bvb2wudjEuQXVjdGlvblN1bW1hcnkijwEKDkF1Y3Rpb25TdW1tYXJ5EhIKCmF1Y3Rpb25faWQYASABKAkSDAoEcGFpchgCIAEoCRIWCg5jbGVhcmluZ19wcmljZRgDIAEoCRIWCg5tYXRjaGVkX3ZvbHVtZRgEIAEoCRITCgttYXRjaF9jb3VudBgFIAEoBRIWCg50aW1lc3RhbXBfdW5peBgGIAEoAyIlChVTdHJlYW1BdWN0aW9uc1JlcXVlc3QSDAoEcGFpchgBIAEoCSKNAQoMQXVjdGlvbkV2ZW50EhIKCmF1Y3Rpb25faWQYASABKAkSDAoEcGFpchgCIAEoCRIWCg5jbGVhcmluZ19wcmljZRgDIAEoCRIWCg5tYXRjaGVkX3ZvbHVtZRgEIAEoCRITCgttYXRjaF9jb3VudBgFIAEoBRIWCg50aW1lc3RhbXBfdW5peBgGIAEoAyLHAQoJT3JkZXJJbmZvEgoKAmlkGAEgASgJEgwKBHBhaXIYAiABKAkSHwoEc2lkZRgDIAEoDjIRLmRhcmtwb29sLnYxLlNpZGUSDQoFcHJpY2UYBCABKAkSDAoEc2l6ZRgFIAEoCRIWCg5yZW1haW5pbmdfc2l6ZRgGIAEoCRIWCg5jb21taXRtZW50X2tleRgHIAEoCRIZChFzdWJtaXR0ZWRfYXRfdW5peBgIIAEoAxIXCg9leHBpcmVzX2F0X3VuaXgYCSABKAMizwEKCFBhaXJJbmZvEgwKBHBhaXIYASABKAkSEgoKYmFzZV90b2tlbhgCIAEoCRITCgtxdW90ZV90b2tlbhgDIAEoCRIWCg5taW5fb3JkZXJfc2l6ZRgEIAEoCRIRCgl0aWNrX3NpemUYBSABKAkSIAoTYXVjdGlvbl9pbnRlcnZhbF9tcxgGIAEoDUgAiAEBEicKBnN0YXR1cxgHIAEoDjIXLmRhcmtwb29sLnYxLlBhaXJTdGF0dXNCFgoUX2F1Y3Rpb25faW50ZXJ2YWxfbXMiEgoQTGlzdFBhaXJzUmVxdWVzdCI5ChFMaXN0UGFpcnNSZXNwb25zZRIkCgVwYWlycxgBIAMoCzIVLmRhcmtwb29sLnYxLlBhaXJJbmZvIhcKFUxpc3RQYWlyc0FkbWluUmVxdWVzdCI+ChZMaXN0UGFpcnNBZG1pblJlc3BvbnNlEiQKBXBhaXJzGAEgAygLMhUuZGFya3Bvb2wudjEuUGFpckluZm8isQEKE1JlZ2lzdGVyUGFpclJlcXVlc3QSDAoEcGFpchgBIAEoCRISCgpiYXNlX3Rva2VuGAIgASgJEhMKC3F1b3RlX3Rva2VuGAMgASgJEhYKDm1pbl9vcmRlcl9zaXplGAQgASgJEhEKCXRpY2tfc2l6ZRgFIAEoCRIgChNhdWN0aW9uX2ludGVydmFsX21zGAYgASgNSACIAQFCFgoUX2F1Y3Rpb25faW50ZXJ2YWxfbXMiOwoUUmVnaXN0ZXJQYWlyUmVzcG9uc2USIwoEcGFpchgBIAEoCzIVLmRhcmtwb29sLnYxLlBhaXJJbmZvIiIKElN1c3BlbmRQYWlyUmVxdWVzdBIMCgRwYWlyGAEgASgJIhUKE1N1c3BlbmRQYWlyUmVzcG9uc2UiIQoRRGVsaXN0UGFpclJlcXVlc3QSDAoEcGFpchgBIAEoCSIuChJEZWxpc3RQYWlyUmVzcG9uc2USGAoQY2FuY2VsbGVkX29yZGVycxgBIAEoDSo5CgRTaWRlEhQKEFNJREVfVU5TUEVDSUZJRUQQABIMCghTSURFX0JVWRABEg0KCVNJREVfU0VMTBACKnYKClBhaXJTdGF0dXMSGwoXUEFJUl9TVEFUVVNfVU5TUEVDSUZJRUQQABIWChJQQUlSX1NUQVRVU19BQ1RJVkUQARIZChVQQUlSX1NUQVRVU19TVVNQRU5ERUQQAhIYChRQQUlSX1NUQVRVU19ERUxJU1RFRBADMuEFCg9EYXJrUG9vbFNlcnZpY2USZAoKUGxhY2VPcmRlchIeLmRhcmtwb29sLnYxLlBsYWNlT3JkZXJSZXF1ZXN0Gh8uZGFya3Bvb2wudjEuUGxhY2VPcmRlclJlc3BvbnNlIhWC0+STAg86ASoiCi92MS9vcmRlcnMSbwoLQ2FuY2VsT3JkZXISHy5kYXJrcG9vbC52MS5DYW5jZWxPcmRlclJlcXVlc3QaIC5kYXJrcG9vbC52MS5DYW5jZWxPcmRlclJlc3BvbnNlIh2C0+STAhcqFS92MS9vcmRlcnMve29yZGVyX2lkfRJmCghHZXRPcmRlchIcLmRhcmtwb29sLnYxLkdldE9yZGVyUmVxdWVzdBodLmRhcmtwb29sLnYxLkdldE9yZGVyUmVzcG9uc2UiHYLT5JMCFxIVL3YxL29yZGVycy97b3JkZXJfaWR9EmEKCkxpc3RPcmRlcnMSHi5kYXJrcG9vbC52MS5MaXN0T3JkZXJzUmVxdWVzdBofLmRhcmtwb29sLnYxLkxpc3RPcmRlcnNSZXNwb25zZSISgtPkkwIMEgovdjEvb3JkZXJzEngKEUdldEF1Y3Rpb25IaXN0b3J5EiUuZGFya3Bvb2wudjEuR2V0QXVjdGlvbkhpc3RvcnlSZXF1ZXN0GiYuZGFya3Bvb2wudjEuR2V0QXVjdGlvbkhpc3RvcnlSZXNwb25zZSIUgtPkkwIOEgwvdjEvYXVjdGlvbnMSUwoOU3RyZWFtQXVjdGlvbnMSIi5kYXJrcG9vbC52MS5TdHJlYW1BdWN0aW9uc1JlcXVlc3QaGS5kYXJrcG9vbC52MS5BdWN0aW9uRXZlbnQiADABEl0KCUxpc3RQYWlycxIdLmRhcmtwb29sLnYxLkxpc3RQYWlyc1JlcXVlc3QaHi5kYXJrcG9vbC52MS5MaXN0UGFpcnNSZXNwb25zZSIRgtPkkwILEgkvdjEvcGFpcnMy5wMKFERhcmtQb29sQWRtaW5TZXJ2aWNlEm8KDFJlZ2lzdGVyUGFpchIgLmRhcmtwb29sLnYxLlJlZ2lzdGVyUGFpclJlcXVlc3QaIS5kYXJrcG9vbC52MS5SZWdpc3RlclBhaXJSZXNwb25zZSIagtPkkwIUOgEqIg8vdjEvYWRtaW4vcGFpcnMSewoLU3VzcGVuZFBhaXISHy5kYXJrcG9vbC52MS5TdXNwZW5kUGFpclJlcXVlc3QaIC5kYXJrcG9vbC52MS5TdXNwZW5kUGFpclJlc3BvbnNlIimC0+STAiM6ASoyHi92MS9hZG1pbi9wYWlycy97cGFpcn0vc3VzcGVuZBJtCgpEZWxpc3RQYWlyEh4uZGFya3Bvb2wudjEuRGVsaXN0UGFpclJlcXVlc3QaHy5kYXJrcG9vbC52MS5EZWxpc3RQYWlyUmVzcG9uc2UiHoLT5JMCGCoWL3YxL2FkbWluL3BhaXJzL3twYWlyfRJyCg5MaXN0UGFpcnNBZG1pbhIiLmRhcmtwb29sLnYxLkxpc3RQYWlyc0FkbWluUmVxdWVzdBojLmRhcmtwb29sLnYxLkxpc3RQYWlyc0FkbWluUmVzcG9uc2UiF4LT5JMCERIPL3YxL2FkbWluL3BhaXJzQkRaQmdpdGh1Yi5jb20vZGFya3Bvb2wtZXhjaGFuZ2Uvc2VydmVyL2FwaS9nZW4vZGFya3Bvb2wvdjE7ZGFya3Bvb2x2MWIGcHJvdG8z", [file_google_api_annotations]);
 
 /**
  * PlaceOrderRequest carries only the encrypt-only trio. The engine never
- * sees plaintext on the wire; the operator decrypts server-side and the
- * commitment binds the ciphertext to the proof.
+ * sees plaintext on the wire; the operator decrypts server-side.
+ *
+ * NOTE (issue #158): `commitment` and `proof` are NOT cryptographically
+ * verified today. The engine ignores the client commitment and re-derives
+ * the canonical Poseidon commitment over the decrypted fields; the proof is
+ * accepted unverified. Order validity is operator-enforced, not
+ * proof-enforced. A verified per-order proof is deferred to ADR 0001 /
+ * issues #97-#98. Do not treat these two fields as a cryptographic guarantee.
+ *
+ * Both fields are still SYNTACTICALLY required: `validate_place_order`
+ * rejects an empty `commitment` or `proof`. Until real verification lands,
+ * clients must keep sending non-empty bytes for both (placeholder bytes are
+ * fine — they are not checked, only their presence is).
  *
  * @generated from message darkpool.v1.PlaceOrderRequest
  */
 export type PlaceOrderRequest = Message<"darkpool.v1.PlaceOrderRequest"> & {
   /**
-   * binds proof to ciphertext
+   * client commitment; re-derived & overridden server-side (unverified)
    *
    * @generated from field: bytes commitment = 1;
    */
   commitment: Uint8Array;
 
   /**
-   * aggregated or per-order ZK proof
+   * per-order ZK proof; ACCEPTED UNVERIFIED (see note)
    *
    * @generated from field: bytes proof = 2;
    */
@@ -45,21 +56,32 @@ export type PlaceOrderRequest = Message<"darkpool.v1.PlaceOrderRequest"> & {
 
 /**
  * PlaceOrderRequest carries only the encrypt-only trio. The engine never
- * sees plaintext on the wire; the operator decrypts server-side and the
- * commitment binds the ciphertext to the proof.
+ * sees plaintext on the wire; the operator decrypts server-side.
+ *
+ * NOTE (issue #158): `commitment` and `proof` are NOT cryptographically
+ * verified today. The engine ignores the client commitment and re-derives
+ * the canonical Poseidon commitment over the decrypted fields; the proof is
+ * accepted unverified. Order validity is operator-enforced, not
+ * proof-enforced. A verified per-order proof is deferred to ADR 0001 /
+ * issues #97-#98. Do not treat these two fields as a cryptographic guarantee.
+ *
+ * Both fields are still SYNTACTICALLY required: `validate_place_order`
+ * rejects an empty `commitment` or `proof`. Until real verification lands,
+ * clients must keep sending non-empty bytes for both (placeholder bytes are
+ * fine — they are not checked, only their presence is).
  *
  * @generated from message darkpool.v1.PlaceOrderRequest
  */
 export type PlaceOrderRequestJson = {
   /**
-   * binds proof to ciphertext
+   * client commitment; re-derived & overridden server-side (unverified)
    *
    * @generated from field: bytes commitment = 1;
    */
   commitment?: string;
 
   /**
-   * aggregated or per-order ZK proof
+   * per-order ZK proof; ACCEPTED UNVERIFIED (see note)
    *
    * @generated from field: bytes proof = 2;
    */
@@ -218,125 +240,62 @@ export const GetOrderResponseSchema: GenMessage<GetOrderResponse, {jsonType: Get
   messageDesc(file_darkpool_v1_darkpool, 5);
 
 /**
- * @generated from message darkpool.v1.GetOrderBookRequest
+ * @generated from message darkpool.v1.ListOrdersRequest
  */
-export type GetOrderBookRequest = Message<"darkpool.v1.GetOrderBookRequest"> & {
+export type ListOrdersRequest = Message<"darkpool.v1.ListOrdersRequest"> & {
   /**
+   * optional filter; empty = every pair
+   *
    * @generated from field: string pair = 1;
    */
   pair: string;
 };
 
 /**
- * @generated from message darkpool.v1.GetOrderBookRequest
+ * @generated from message darkpool.v1.ListOrdersRequest
  */
-export type GetOrderBookRequestJson = {
+export type ListOrdersRequestJson = {
   /**
+   * optional filter; empty = every pair
+   *
    * @generated from field: string pair = 1;
    */
   pair?: string;
 };
 
 /**
- * Describes the message darkpool.v1.GetOrderBookRequest.
- * Use `create(GetOrderBookRequestSchema)` to create a new message.
+ * Describes the message darkpool.v1.ListOrdersRequest.
+ * Use `create(ListOrdersRequestSchema)` to create a new message.
  */
-export const GetOrderBookRequestSchema: GenMessage<GetOrderBookRequest, {jsonType: GetOrderBookRequestJson}> = /*@__PURE__*/
+export const ListOrdersRequestSchema: GenMessage<ListOrdersRequest, {jsonType: ListOrdersRequestJson}> = /*@__PURE__*/
   messageDesc(file_darkpool_v1_darkpool, 6);
 
 /**
- * @generated from message darkpool.v1.GetOrderBookResponse
+ * @generated from message darkpool.v1.ListOrdersResponse
  */
-export type GetOrderBookResponse = Message<"darkpool.v1.GetOrderBookResponse"> & {
+export type ListOrdersResponse = Message<"darkpool.v1.ListOrdersResponse"> & {
   /**
-   * @generated from field: string pair = 1;
+   * @generated from field: repeated darkpool.v1.OrderInfo orders = 1;
    */
-  pair: string;
-
-  /**
-   * @generated from field: repeated darkpool.v1.PriceLevel bids = 2;
-   */
-  bids: PriceLevel[];
-
-  /**
-   * @generated from field: repeated darkpool.v1.PriceLevel asks = 3;
-   */
-  asks: PriceLevel[];
+  orders: OrderInfo[];
 };
 
 /**
- * @generated from message darkpool.v1.GetOrderBookResponse
+ * @generated from message darkpool.v1.ListOrdersResponse
  */
-export type GetOrderBookResponseJson = {
+export type ListOrdersResponseJson = {
   /**
-   * @generated from field: string pair = 1;
+   * @generated from field: repeated darkpool.v1.OrderInfo orders = 1;
    */
-  pair?: string;
-
-  /**
-   * @generated from field: repeated darkpool.v1.PriceLevel bids = 2;
-   */
-  bids?: PriceLevelJson[];
-
-  /**
-   * @generated from field: repeated darkpool.v1.PriceLevel asks = 3;
-   */
-  asks?: PriceLevelJson[];
+  orders?: OrderInfoJson[];
 };
 
 /**
- * Describes the message darkpool.v1.GetOrderBookResponse.
- * Use `create(GetOrderBookResponseSchema)` to create a new message.
+ * Describes the message darkpool.v1.ListOrdersResponse.
+ * Use `create(ListOrdersResponseSchema)` to create a new message.
  */
-export const GetOrderBookResponseSchema: GenMessage<GetOrderBookResponse, {jsonType: GetOrderBookResponseJson}> = /*@__PURE__*/
+export const ListOrdersResponseSchema: GenMessage<ListOrdersResponse, {jsonType: ListOrdersResponseJson}> = /*@__PURE__*/
   messageDesc(file_darkpool_v1_darkpool, 7);
-
-/**
- * @generated from message darkpool.v1.PriceLevel
- */
-export type PriceLevel = Message<"darkpool.v1.PriceLevel"> & {
-  /**
-   * @generated from field: string price = 1;
-   */
-  price: string;
-
-  /**
-   * @generated from field: string total_size = 2;
-   */
-  totalSize: string;
-
-  /**
-   * @generated from field: int32 order_count = 3;
-   */
-  orderCount: number;
-};
-
-/**
- * @generated from message darkpool.v1.PriceLevel
- */
-export type PriceLevelJson = {
-  /**
-   * @generated from field: string price = 1;
-   */
-  price?: string;
-
-  /**
-   * @generated from field: string total_size = 2;
-   */
-  totalSize?: string;
-
-  /**
-   * @generated from field: int32 order_count = 3;
-   */
-  orderCount?: number;
-};
-
-/**
- * Describes the message darkpool.v1.PriceLevel.
- * Use `create(PriceLevelSchema)` to create a new message.
- */
-export const PriceLevelSchema: GenMessage<PriceLevel, {jsonType: PriceLevelJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 8);
 
 /**
  * @generated from message darkpool.v1.GetAuctionHistoryRequest
@@ -377,7 +336,7 @@ export type GetAuctionHistoryRequestJson = {
  * Use `create(GetAuctionHistoryRequestSchema)` to create a new message.
  */
 export const GetAuctionHistoryRequestSchema: GenMessage<GetAuctionHistoryRequest, {jsonType: GetAuctionHistoryRequestJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 9);
+  messageDesc(file_darkpool_v1_darkpool, 8);
 
 /**
  * @generated from message darkpool.v1.GetAuctionHistoryResponse
@@ -404,7 +363,7 @@ export type GetAuctionHistoryResponseJson = {
  * Use `create(GetAuctionHistoryResponseSchema)` to create a new message.
  */
 export const GetAuctionHistoryResponseSchema: GenMessage<GetAuctionHistoryResponse, {jsonType: GetAuctionHistoryResponseJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 10);
+  messageDesc(file_darkpool_v1_darkpool, 9);
 
 /**
  * @generated from message darkpool.v1.AuctionSummary
@@ -481,7 +440,7 @@ export type AuctionSummaryJson = {
  * Use `create(AuctionSummarySchema)` to create a new message.
  */
 export const AuctionSummarySchema: GenMessage<AuctionSummary, {jsonType: AuctionSummaryJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 11);
+  messageDesc(file_darkpool_v1_darkpool, 10);
 
 /**
  * @generated from message darkpool.v1.StreamAuctionsRequest
@@ -512,7 +471,7 @@ export type StreamAuctionsRequestJson = {
  * Use `create(StreamAuctionsRequestSchema)` to create a new message.
  */
 export const StreamAuctionsRequestSchema: GenMessage<StreamAuctionsRequest, {jsonType: StreamAuctionsRequestJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 12);
+  messageDesc(file_darkpool_v1_darkpool, 11);
 
 /**
  * @generated from message darkpool.v1.AuctionEvent
@@ -589,7 +548,7 @@ export type AuctionEventJson = {
  * Use `create(AuctionEventSchema)` to create a new message.
  */
 export const AuctionEventSchema: GenMessage<AuctionEvent, {jsonType: AuctionEventJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 13);
+  messageDesc(file_darkpool_v1_darkpool, 12);
 
 /**
  * @generated from message darkpool.v1.OrderInfo
@@ -696,7 +655,7 @@ export type OrderInfoJson = {
  * Use `create(OrderInfoSchema)` to create a new message.
  */
 export const OrderInfoSchema: GenMessage<OrderInfo, {jsonType: OrderInfoJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 14);
+  messageDesc(file_darkpool_v1_darkpool, 13);
 
 /**
  * @generated from message darkpool.v1.PairInfo
@@ -783,7 +742,7 @@ export type PairInfoJson = {
  * Use `create(PairInfoSchema)` to create a new message.
  */
 export const PairInfoSchema: GenMessage<PairInfo, {jsonType: PairInfoJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 15);
+  messageDesc(file_darkpool_v1_darkpool, 14);
 
 /**
  * @generated from message darkpool.v1.ListPairsRequest
@@ -802,7 +761,7 @@ export type ListPairsRequestJson = {
  * Use `create(ListPairsRequestSchema)` to create a new message.
  */
 export const ListPairsRequestSchema: GenMessage<ListPairsRequest, {jsonType: ListPairsRequestJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 16);
+  messageDesc(file_darkpool_v1_darkpool, 15);
 
 /**
  * @generated from message darkpool.v1.ListPairsResponse
@@ -829,7 +788,7 @@ export type ListPairsResponseJson = {
  * Use `create(ListPairsResponseSchema)` to create a new message.
  */
 export const ListPairsResponseSchema: GenMessage<ListPairsResponse, {jsonType: ListPairsResponseJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 17);
+  messageDesc(file_darkpool_v1_darkpool, 16);
 
 /**
  * @generated from message darkpool.v1.ListPairsAdminRequest
@@ -848,7 +807,7 @@ export type ListPairsAdminRequestJson = {
  * Use `create(ListPairsAdminRequestSchema)` to create a new message.
  */
 export const ListPairsAdminRequestSchema: GenMessage<ListPairsAdminRequest, {jsonType: ListPairsAdminRequestJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 18);
+  messageDesc(file_darkpool_v1_darkpool, 17);
 
 /**
  * @generated from message darkpool.v1.ListPairsAdminResponse
@@ -875,7 +834,7 @@ export type ListPairsAdminResponseJson = {
  * Use `create(ListPairsAdminResponseSchema)` to create a new message.
  */
 export const ListPairsAdminResponseSchema: GenMessage<ListPairsAdminResponse, {jsonType: ListPairsAdminResponseJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 19);
+  messageDesc(file_darkpool_v1_darkpool, 18);
 
 /**
  * @generated from message darkpool.v1.RegisterPairRequest
@@ -952,7 +911,7 @@ export type RegisterPairRequestJson = {
  * Use `create(RegisterPairRequestSchema)` to create a new message.
  */
 export const RegisterPairRequestSchema: GenMessage<RegisterPairRequest, {jsonType: RegisterPairRequestJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 20);
+  messageDesc(file_darkpool_v1_darkpool, 19);
 
 /**
  * @generated from message darkpool.v1.RegisterPairResponse
@@ -979,7 +938,7 @@ export type RegisterPairResponseJson = {
  * Use `create(RegisterPairResponseSchema)` to create a new message.
  */
 export const RegisterPairResponseSchema: GenMessage<RegisterPairResponse, {jsonType: RegisterPairResponseJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 21);
+  messageDesc(file_darkpool_v1_darkpool, 20);
 
 /**
  * @generated from message darkpool.v1.SuspendPairRequest
@@ -1006,7 +965,7 @@ export type SuspendPairRequestJson = {
  * Use `create(SuspendPairRequestSchema)` to create a new message.
  */
 export const SuspendPairRequestSchema: GenMessage<SuspendPairRequest, {jsonType: SuspendPairRequestJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 22);
+  messageDesc(file_darkpool_v1_darkpool, 21);
 
 /**
  * @generated from message darkpool.v1.SuspendPairResponse
@@ -1025,7 +984,7 @@ export type SuspendPairResponseJson = {
  * Use `create(SuspendPairResponseSchema)` to create a new message.
  */
 export const SuspendPairResponseSchema: GenMessage<SuspendPairResponse, {jsonType: SuspendPairResponseJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 23);
+  messageDesc(file_darkpool_v1_darkpool, 22);
 
 /**
  * @generated from message darkpool.v1.DelistPairRequest
@@ -1052,7 +1011,7 @@ export type DelistPairRequestJson = {
  * Use `create(DelistPairRequestSchema)` to create a new message.
  */
 export const DelistPairRequestSchema: GenMessage<DelistPairRequest, {jsonType: DelistPairRequestJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 24);
+  messageDesc(file_darkpool_v1_darkpool, 23);
 
 /**
  * @generated from message darkpool.v1.DelistPairResponse
@@ -1079,7 +1038,7 @@ export type DelistPairResponseJson = {
  * Use `create(DelistPairResponseSchema)` to create a new message.
  */
 export const DelistPairResponseSchema: GenMessage<DelistPairResponse, {jsonType: DelistPairResponseJson}> = /*@__PURE__*/
-  messageDesc(file_darkpool_v1_darkpool, 25);
+  messageDesc(file_darkpool_v1_darkpool, 24);
 
 /**
  * @generated from enum darkpool.v1.Side
@@ -1177,12 +1136,19 @@ export const DarkPoolService: GenService<{
     output: typeof GetOrderResponseSchema;
   },
   /**
-   * @generated from rpc darkpool.v1.DarkPoolService.GetOrderBook
+   * Lists the authenticated caller's own resting orders ("my orders").
+   * Scoped to the wallet identity; a trader never sees another trader's
+   * orders. There is deliberately no public pre-settlement order book —
+   * serving live cross-trader depth would defeat the dark pool (an
+   * observer could reconstruct incoming liquidity and cross it in the
+   * same auction round).
+   *
+   * @generated from rpc darkpool.v1.DarkPoolService.ListOrders
    */
-  getOrderBook: {
+  listOrders: {
     methodKind: "unary";
-    input: typeof GetOrderBookRequestSchema;
-    output: typeof GetOrderBookResponseSchema;
+    input: typeof ListOrdersRequestSchema;
+    output: typeof ListOrdersResponseSchema;
   },
   /**
    * @generated from rpc darkpool.v1.DarkPoolService.GetAuctionHistory


### PR DESCRIPTION
## Why

`main`'s **Frontend CI is currently red** (last several merges are `failure`). Two stale generated-artifact drifts, both landed by recent backend PRs without a frontend follow-up:

1. **#178 (orderbook privacy)** removed the public pre-settlement order book from the backend — no `GetOrderBook` RPC / `PriceLevel` message in the proto anymore. The committed TS SDK drifted from the proto (`npm run sdk:gen` produces a diff), and the SDK seam / mocks / orderbook panel still referenced the removed wire types (typecheck breaks once the SDK is regenerated).
2. **#164 (deposit allowlist)** added `TokenAllowed` / `setTokenAllowed` to the DarkPool ABI, but `lib/contracts/generated.ts` was never regenerated → `generated.test.ts` fails.

Every open frontend PR (#179, #181, #182, #180) fails the same Frontend job because they branch from this broken `main`. Merging this unblocks all of them.

## What

The order book becomes a **mock-only, frontend-local** concept (per product decision — a dark pool deliberately exposes no cross-trader depth):

- New `lib/sdk/orderbook.ts` with hand-written `OrderBook` / `PriceLevel` / `OrderBookRequest` types (no protobuf backing).
- SDK seam, mock store, depth lib, and depth chart point at the local types; all generated `GetOrderBook*`/`PriceLevel*` references dropped.
- `RestClient.getOrderBook` throws `UNIMPLEMENTED` — there is no `/v1/orderbook` endpoint. The panel runs on the mock store (`NEXT_PUBLIC_USE_MOCKS_ORDERBOOK`); flipping the flag to REST is now an explicit, actionable error instead of a runtime 404.
- Regenerated the TS SDK from the proto and `lib/contracts/generated.ts` from the ABIs.

## Verification (local)

All Frontend CI gates green: `sdk:gen` clean · typecheck · lint · format · **482 vitest tests** · `next build`. `codegen` is idempotent (no further diff).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token allowance and unreserve/reserve management added to contract interfaces.

* **Changes**
  * Order book is now mock-only in the UI; enable mocks to view it.
  * Public pre-settlement order book endpoint removed; attempting to use it will fail.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->