### PR TITLE
auction: Key self-trade prevention on trader address

### DIFF
--- a/crates/dp-api/tests/handler.rs
+++ b/crates/dp-api/tests/handler.rs
@@ -25,6 +25,21 @@ use uuid::Uuid;
 
 static KEY_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Distinct `trader` address per call. Self-trade prevention keys on `trader`
+/// (#168), so a crossing bid/ask placed under one address would be skipped as
+/// a self-cross. The `0xEE` prefix keeps these clear of `Address::ZERO` and
+/// the small hand-written addresses used elsewhere; the same scheme is
+/// mirrored in the `dp-auction` and `dp-engine` test helpers. Tests wanting a
+/// shared owner use `place_test_order_as`.
+fn next_trader() -> Address {
+    static SEQ: AtomicU64 = AtomicU64::new(1);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let mut bytes = [0u8; 20];
+    bytes[0] = 0xEE;
+    bytes[12..].copy_from_slice(&n.to_be_bytes());
+    Address::from(bytes)
+}
+
 fn new_handler() -> ApiHandler {
     let store = Arc::new(MemStore::new());
     let engine = Engine::new(store, Duration::from_secs(1));
@@ -68,16 +83,9 @@ async fn place_test_order(
     price: &str,
     size: &str,
 ) -> String {
-    // Distinct trader per call. Self-trade prevention keys on `trader`
-    // (#168), so a crossing bid/ask placed under one address would be
-    // skipped as a self-cross. Tests wanting a shared owner use
-    // `place_test_order_as`.
     let n = KEY_COUNTER.fetch_add(1, Ordering::SeqCst);
-    let mut tbytes = [0u8; 20];
-    tbytes[0] = 0xEE;
-    tbytes[12..].copy_from_slice(&n.to_be_bytes());
     let d = DecryptedOrder {
-        trader: Address::from(tbytes),
+        trader: next_trader(),
         pair: pair.to_string(),
         side,
         price: price.parse().unwrap(),

--- a/crates/dp-api/tests/handler.rs
+++ b/crates/dp-api/tests/handler.rs
@@ -68,9 +68,16 @@ async fn place_test_order(
     price: &str,
     size: &str,
 ) -> String {
+    // Distinct trader per call. Self-trade prevention keys on `trader`
+    // (#168), so a crossing bid/ask placed under one address would be
+    // skipped as a self-cross. Tests wanting a shared owner use
+    // `place_test_order_as`.
     let n = KEY_COUNTER.fetch_add(1, Ordering::SeqCst);
+    let mut tbytes = [0u8; 20];
+    tbytes[0] = 0xEE;
+    tbytes[12..].copy_from_slice(&n.to_be_bytes());
     let d = DecryptedOrder {
-        trader: Address::ZERO,
+        trader: Address::from(tbytes),
         pair: pair.to_string(),
         side,
         price: price.parse().unwrap(),
@@ -235,15 +242,16 @@ async fn place_order_proof_too_large() {
 #[tokio::test]
 async fn cancel_order_success() {
     let h = new_handler();
-    // place_test_order owns the order as Address::ZERO; cancel is caller-
-    // scoped, so the request carries a matching wallet identity.
-    let id = place_test_order(&h, "ETH/USDC", Side::Buy, "1800", "5").await;
+    // Cancel is caller-scoped: the order's owner and the request's wallet
+    // identity must be the same address.
+    let owner = Address::repeat_byte(3);
+    let id = place_test_order_as(&h, owner, "ETH/USDC", Side::Buy, "1800", "5").await;
     h.cancel_order(wallet_req(
         CancelOrderRequest {
             order_id: id,
             reason: "testing".into(),
         },
-        Address::ZERO,
+        owner,
     ))
     .await
     .unwrap();
@@ -331,10 +339,11 @@ async fn cancel_order_without_wallet_identity_is_not_found() {
 #[tokio::test]
 async fn get_order_success() {
     let h = new_handler();
-    // place_test_order owns the order as Address::ZERO.
-    let id = place_test_order(&h, "ETH/USDC", Side::Buy, "1800", "5").await;
+    // GetOrder is caller-scoped: owner and wallet identity must match.
+    let owner = Address::repeat_byte(3);
+    let id = place_test_order_as(&h, owner, "ETH/USDC", Side::Buy, "1800", "5").await;
     let resp = h
-        .get_order(wallet_req(GetOrderRequest { order_id: id }, Address::ZERO))
+        .get_order(wallet_req(GetOrderRequest { order_id: id }, owner))
         .await
         .unwrap()
         .into_inner();

--- a/crates/dp-api/tests/rest.rs
+++ b/crates/dp-api/tests/rest.rs
@@ -410,12 +410,14 @@ async fn sse_stream_no_pair_filter_returns_200() {
 async fn sse_stream_receives_auction_events() {
     let (app, engine) = registered_app();
 
-    // Place crossing orders so the auction tick produces a match.
-    let make_body = |side: dp_types::Side, price: &str| {
+    // Place crossing orders so the auction tick produces a match. Distinct
+    // traders per leg: self-trade prevention keys on `trader` (#168), so a
+    // shared address would make the bid/ask self-cross and emit no auction.
+    let make_body = |trader: alloy_primitives::Address, side: dp_types::Side, price: &str| {
         use base64::engine::general_purpose::STANDARD;
         use base64::Engine;
         let d = dp_crypto::DecryptedOrder {
-            trader: alloy_primitives::Address::ZERO,
+            trader,
             pair: "ETH/USDC".into(),
             side,
             price: price.parse().unwrap(),
@@ -431,9 +433,9 @@ async fn sse_stream_receives_auction_events() {
         .to_string()
     };
 
-    for (side, price) in [
-        (dp_types::Side::Buy, "1800"),
-        (dp_types::Side::Sell, "1800"),
+    for (trader, side, price) in [
+        (alloy_primitives::Address::repeat_byte(1), dp_types::Side::Buy, "1800"),
+        (alloy_primitives::Address::repeat_byte(2), dp_types::Side::Sell, "1800"),
     ] {
         let resp = app
             .clone()
@@ -442,7 +444,7 @@ async fn sse_stream_receives_auction_events() {
                     .method("POST")
                     .uri("/v1/orders")
                     .header("content-type", "application/json")
-                    .body(Body::from(make_body(side, price)))
+                    .body(Body::from(make_body(trader, side, price)))
                     .unwrap(),
             )
             .await

--- a/crates/dp-api/tests/rest.rs
+++ b/crates/dp-api/tests/rest.rs
@@ -434,8 +434,16 @@ async fn sse_stream_receives_auction_events() {
     };
 
     for (trader, side, price) in [
-        (alloy_primitives::Address::repeat_byte(1), dp_types::Side::Buy, "1800"),
-        (alloy_primitives::Address::repeat_byte(2), dp_types::Side::Sell, "1800"),
+        (
+            alloy_primitives::Address::repeat_byte(1),
+            dp_types::Side::Buy,
+            "1800",
+        ),
+        (
+            alloy_primitives::Address::repeat_byte(2),
+            dp_types::Side::Sell,
+            "1800",
+        ),
     ] {
         let resp = app
             .clone()

--- a/crates/dp-auction/src/lib.rs
+++ b/crates/dp-auction/src/lib.rs
@@ -143,8 +143,8 @@ fn cumulative_volume(orders: &[Order], pred: impl Fn(&Order) -> bool) -> Decimal
 /// Greedy fill under strict price-time priority. `bids`/`asks` arrive already
 /// in `(price, seq)` order (established in [`run`]); each order is matched in
 /// that order against the opposing side, highest priority first, until its
-/// remaining size is exhausted. Self-trades (orders sharing a
-/// `commitment_key`) are skipped.
+/// remaining size is exhausted. Self-trades (orders from the same verified
+/// `trader` address) are skipped.
 fn match_orders(bids: &[Order], asks: &[Order], price: Decimal) -> Vec<Match> {
     let mut eligible_bids: Vec<Order> = bids
         .iter()
@@ -170,7 +170,15 @@ fn match_orders(bids: &[Order], asks: &[Order], price: Decimal) -> Vec<Match> {
                 continue;
             }
 
-            if bid.commitment_key == ask.commitment_key {
+            // Self-trade prevention keys on the verified on-chain `trader`
+            // address, not the client-chosen per-order `commitment_key`
+            // (#168). The commitment_key is trader-supplied, so keying on it
+            // let one trader wash-trade across two keys and wrongly blocked
+            // two distinct traders who happened to reuse a key. `trader` is
+            // the address the engine verified against the submitting caller
+            // (see `dp-engine` `place_order`), so it cannot be spoofed to
+            // dodge — or forge — a self-cross.
+            if bid.trader == ask.trader {
                 continue;
             }
 
@@ -219,11 +227,25 @@ mod tests {
     use super::*;
     use chrono::Utc;
     use dp_types::Side;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    /// Each freshly built order gets a distinct `trader` address. Self-trade
+    /// prevention keys on `trader` (#168), so leaving every order at
+    /// `Address::ZERO` would make every two-sided test look like a self-cross
+    /// and match nothing. Tests that *want* a self-trade copy one order's
+    /// `trader` onto the other explicitly.
+    fn unique_trader() -> alloy_primitives::Address {
+        static SEQ: AtomicU64 = AtomicU64::new(1);
+        let n = SEQ.fetch_add(1, Ordering::Relaxed);
+        let mut bytes = [0u8; 20];
+        bytes[12..].copy_from_slice(&n.to_be_bytes());
+        alloy_primitives::Address::from(bytes)
+    }
 
     fn new_order(side: Side, price: i64, size: i64) -> Order {
         Order {
             id: Uuid::new_v4(),
-            trader: alloy_primitives::Address::ZERO,
+            trader: unique_trader(),
             pair: "TEST/USD".to_string(),
             side,
             price: Decimal::from(price),
@@ -331,13 +353,33 @@ mod tests {
         assert!(result.matched_volume > Decimal::ZERO);
     }
 
+    /// #168: a trader cannot cross their own bid and ask, even when the two
+    /// orders carry *different* `commitment_key`s — the wash-trade path the
+    /// old commitment_key-based check let through. Prevention keys on the
+    /// verified `trader` address instead.
     #[test]
     fn self_match_prevention() {
         let bid = new_order(Side::Buy, 1800, 10);
         let mut ask = new_order(Side::Sell, 1790, 10);
-        ask.commitment_key = bid.commitment_key.clone();
+        ask.trader = bid.trader;
+        // Distinct keys prove the block is driven by `trader`, not the key.
+        assert_ne!(bid.commitment_key, ask.commitment_key);
 
         assert!(run(test_auction_id(), "TEST/USD", &[bid], &[ask]).is_none());
+    }
+
+    /// #168: two *distinct* traders who happen to reuse the same
+    /// `commitment_key` must still match — the false-positive the old check
+    /// produced. Prevention no longer keys on the shared key.
+    #[test]
+    fn distinct_traders_sharing_commitment_key_still_match() {
+        let bid = new_order(Side::Buy, 1800, 10);
+        let mut ask = new_order(Side::Sell, 1790, 10);
+        ask.commitment_key = bid.commitment_key.clone();
+        assert_ne!(bid.trader, ask.trader);
+
+        let result = run(test_auction_id(), "TEST/USD", &[bid], &[ask]).expect("expected match");
+        assert_eq!(result.matched_volume, Decimal::from(10));
     }
 
     #[test]

--- a/crates/dp-auction/src/lib.rs
+++ b/crates/dp-auction/src/lib.rs
@@ -170,14 +170,23 @@ fn match_orders(bids: &[Order], asks: &[Order], price: Decimal) -> Vec<Match> {
                 continue;
             }
 
-            // Self-trade prevention keys on the verified on-chain `trader`
-            // address, not the client-chosen per-order `commitment_key`
-            // (#168). The commitment_key is trader-supplied, so keying on it
-            // let one trader wash-trade across two keys and wrongly blocked
-            // two distinct traders who happened to reuse a key. `trader` is
-            // the address the engine verified against the submitting caller
-            // (see `dp-engine` `place_order`), so it cannot be spoofed to
-            // dodge — or forge — a self-cross.
+            // Self-trade prevention keys on the `trader` address, not the
+            // client-chosen per-order `commitment_key` (#168). The
+            // commitment_key is trader-supplied, so keying on it wrongly
+            // blocked two distinct traders who happened to reuse a key (fixed
+            // here unconditionally) and let one trader wash-trade across two
+            // keys.
+            //
+            // `trader` is the *right* key, but note it is only spoof-proof
+            // when the engine bound it to the verified caller. That binding
+            // runs only for wallet-authenticated callers (`dp-engine`
+            // `place_order` checks `decrypted.trader == caller` only when a
+            // caller is present). Under the MVP's API-key auth the caller is
+            // `None`, so `trader` is still client-supplied: a wash trader can
+            // set two different addresses and evade this check exactly as they
+            // could with two keys. This closes the wash-trade vector only once
+            // wallet auth (SIWE) lands; until then it is the correct field to
+            // key on and the false-positive fix stands.
             if bid.trader == ask.trader {
                 continue;
             }
@@ -229,15 +238,17 @@ mod tests {
     use dp_types::Side;
     use std::sync::atomic::{AtomicU64, Ordering};
 
-    /// Each freshly built order gets a distinct `trader` address. Self-trade
-    /// prevention keys on `trader` (#168), so leaving every order at
-    /// `Address::ZERO` would make every two-sided test look like a self-cross
-    /// and match nothing. Tests that *want* a self-trade copy one order's
-    /// `trader` onto the other explicitly.
-    fn unique_trader() -> alloy_primitives::Address {
+    /// Distinct `trader` address per order. Self-trade prevention keys on
+    /// `trader` (#168), so reusing one address across both legs would read as
+    /// a self-cross and match nothing. The `0xEE` prefix keeps these clear of
+    /// `Address::ZERO` and the small hand-written addresses used elsewhere;
+    /// the same scheme is mirrored in `dp-engine` and `dp-api` test helpers.
+    /// Tests that *want* a self-trade copy one order's `trader` onto the other.
+    fn next_trader() -> alloy_primitives::Address {
         static SEQ: AtomicU64 = AtomicU64::new(1);
         let n = SEQ.fetch_add(1, Ordering::Relaxed);
         let mut bytes = [0u8; 20];
+        bytes[0] = 0xEE;
         bytes[12..].copy_from_slice(&n.to_be_bytes());
         alloy_primitives::Address::from(bytes)
     }
@@ -245,7 +256,7 @@ mod tests {
     fn new_order(side: Side, price: i64, size: i64) -> Order {
         Order {
             id: Uuid::new_v4(),
-            trader: unique_trader(),
+            trader: next_trader(),
             pair: "TEST/USD".to_string(),
             side,
             price: Decimal::from(price),

--- a/crates/dp-engine/src/test_helpers.rs
+++ b/crates/dp-engine/src/test_helpers.rs
@@ -311,17 +311,17 @@ pub fn last_proof_for_batch(store: &dyn Store, batch_id: Uuid) -> Option<Vec<u8>
     found
 }
 
-/// Allocate a distinct `trader` address per placed order. Self-trade
-/// prevention keys on `trader` (#168), so a crossing bid/ask that shared an
-/// address would be skipped as a self-cross and match nothing. Tests that
-/// *want* a self-trade place both legs under one address with
-/// [`place_plaintext_order_as`].
-fn next_test_trader() -> alloy_primitives::Address {
+/// Distinct `trader` address per placed order. Self-trade prevention keys on
+/// `trader` (#168), so a crossing bid/ask sharing an address would be skipped
+/// as a self-cross and match nothing. The `0xEE` prefix keeps these clear of
+/// `Address::ZERO` and the small hand-written addresses (`repeat_byte(1)`,
+/// `0x..01`) used elsewhere; the same scheme is mirrored in the `dp-auction`
+/// and `dp-api` test helpers. Tests that *want* a self-trade place both legs
+/// under one address with [`place_plaintext_order_as`].
+fn next_trader() -> alloy_primitives::Address {
     use std::sync::atomic::AtomicU64;
     static SEQ: AtomicU64 = AtomicU64::new(1);
     let n = SEQ.fetch_add(1, Ordering::Relaxed);
-    // 0xEE prefix keeps these clear of `Address::ZERO` and the small
-    // hand-written addresses (`repeat_byte(1)`, `0x..01`) used elsewhere.
     let mut bytes = [0u8; 20];
     bytes[0] = 0xEE;
     bytes[12..].copy_from_slice(&n.to_be_bytes());
@@ -339,7 +339,7 @@ pub async fn place_plaintext_order(
 ) -> Result<dp_types::Order, crate::EngineError> {
     place_plaintext_order_as(
         engine,
-        next_test_trader(),
+        next_trader(),
         pair,
         side,
         price,

--- a/crates/dp-engine/src/test_helpers.rs
+++ b/crates/dp-engine/src/test_helpers.rs
@@ -311,6 +311,23 @@ pub fn last_proof_for_batch(store: &dyn Store, batch_id: Uuid) -> Option<Vec<u8>
     found
 }
 
+/// Allocate a distinct `trader` address per placed order. Self-trade
+/// prevention keys on `trader` (#168), so a crossing bid/ask that shared an
+/// address would be skipped as a self-cross and match nothing. Tests that
+/// *want* a self-trade place both legs under one address with
+/// [`place_plaintext_order_as`].
+fn next_test_trader() -> alloy_primitives::Address {
+    use std::sync::atomic::AtomicU64;
+    static SEQ: AtomicU64 = AtomicU64::new(1);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    // 0xEE prefix keeps these clear of `Address::ZERO` and the small
+    // hand-written addresses (`repeat_byte(1)`, `0x..01`) used elsewhere.
+    let mut bytes = [0u8; 20];
+    bytes[0] = 0xEE;
+    bytes[12..].copy_from_slice(&n.to_be_bytes());
+    alloy_primitives::Address::from(bytes)
+}
+
 pub async fn place_plaintext_order(
     engine: &crate::Engine,
     pair: &str,
@@ -320,7 +337,33 @@ pub async fn place_plaintext_order(
     commitment_key: &str,
     ttl: Duration,
 ) -> Result<dp_types::Order, crate::EngineError> {
-    let trader = alloy_primitives::Address::ZERO;
+    place_plaintext_order_as(
+        engine,
+        next_test_trader(),
+        pair,
+        side,
+        price,
+        size,
+        commitment_key,
+        ttl,
+    )
+    .await
+}
+
+/// Like [`place_plaintext_order`] but places the order under an explicit
+/// `trader` address — used to exercise trader-keyed self-trade prevention
+/// (#168) by placing both legs under the same address.
+#[allow(clippy::too_many_arguments)]
+pub async fn place_plaintext_order_as(
+    engine: &crate::Engine,
+    trader: alloy_primitives::Address,
+    pair: &str,
+    side: dp_types::Side,
+    price: rust_decimal::Decimal,
+    size: rust_decimal::Decimal,
+    commitment_key: &str,
+    ttl: Duration,
+) -> Result<dp_types::Order, crate::EngineError> {
     let (commit, ct) = crate::engine::build_decrypted_ciphertext(
         trader,
         pair,

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -11,8 +11,8 @@ use rust_decimal::Decimal;
 use uuid::Uuid;
 
 use crate::test_helpers::{
-    count_events, last_proof_for_batch, place_plaintext_order, BlockingAggregator,
-    FailingAggregator, StubAggregator, StubSubmitter, XorDecrypter,
+    count_events, last_proof_for_batch, place_plaintext_order, place_plaintext_order_as,
+    BlockingAggregator, FailingAggregator, StubAggregator, StubSubmitter, XorDecrypter,
 };
 use crate::Engine;
 
@@ -167,6 +167,52 @@ async fn run_auction_tick_produces_notification() {
     assert_eq!(notifs[0].pair, "BTC-USD");
     assert_eq!(notifs[0].matched_volume, dec(5));
     assert_eq!(notifs[0].match_count, 1);
+}
+
+/// #168: a single trader cannot cross their own bid and ask, even when the
+/// two orders carry different `commitment_key`s. Exercises the full
+/// place → book → auction path, not just the auction unit, to prove the
+/// verified `trader` address is what reaches matching.
+#[tokio::test]
+async fn run_auction_tick_blocks_self_cross_by_trader() {
+    let (engine, store) = make_engine();
+    let trader = Address::repeat_byte(7);
+
+    place_plaintext_order_as(
+        &engine,
+        trader,
+        "BTC-USD",
+        Side::Buy,
+        dec(100),
+        dec(5),
+        "buy-key",
+        Duration::from_secs(60),
+    )
+    .await
+    .unwrap();
+    place_plaintext_order_as(
+        &engine,
+        trader,
+        "BTC-USD",
+        Side::Sell,
+        dec(100),
+        dec(5),
+        "sell-key",
+        Duration::from_secs(60),
+    )
+    .await
+    .unwrap();
+
+    let notifs = engine.run_auction_tick().await;
+    assert!(
+        notifs.is_empty(),
+        "same-trader bid/ask must not self-cross, got {notifs:?}"
+    );
+    assert_eq!(
+        count_events(store.as_ref(), EventType::OrderMatched),
+        0,
+        "no match should be recorded for a self-cross"
+    );
 }
 
 #[tokio::test]
@@ -1070,9 +1116,12 @@ async fn full_pipeline_encrypted_order_to_settlement() {
     engine.set_aggregator(aggregator.clone());
     engine.set_submitter(submitter);
 
-    let encrypt_order = |side: Side, price: Decimal, key: &str| -> (Vec<u8>, Vec<u8>) {
+    // Distinct traders per leg: self-trade prevention keys on `trader`
+    // (#168), so a shared address would make the bid/ask self-cross and the
+    // tick would produce no match.
+    let encrypt_order = |trader: Address, side: Side, price: Decimal, key: &str| -> (Vec<u8>, Vec<u8>) {
         let order = DecryptedOrder {
-            trader: Address::ZERO,
+            trader,
             pair: "ETH-USD".into(),
             side,
             price,
@@ -1085,8 +1134,10 @@ async fn full_pipeline_encrypted_order_to_settlement() {
         (vec![0u8; 32], ciphertext)
     };
 
-    let (bid_commit, bid_ct) = encrypt_order(Side::Buy, dec(2000), "bid-key");
-    let (ask_commit, ask_ct) = encrypt_order(Side::Sell, dec(1900), "ask-key");
+    let (bid_commit, bid_ct) =
+        encrypt_order(Address::repeat_byte(1), Side::Buy, dec(2000), "bid-key");
+    let (ask_commit, ask_ct) =
+        encrypt_order(Address::repeat_byte(2), Side::Sell, dec(1900), "ask-key");
 
     let bid_order = engine
         .place_encrypted_order(bid_commit, vec![], bid_ct, None)

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -1119,20 +1119,21 @@ async fn full_pipeline_encrypted_order_to_settlement() {
     // Distinct traders per leg: self-trade prevention keys on `trader`
     // (#168), so a shared address would make the bid/ask self-cross and the
     // tick would produce no match.
-    let encrypt_order = |trader: Address, side: Side, price: Decimal, key: &str| -> (Vec<u8>, Vec<u8>) {
-        let order = DecryptedOrder {
-            trader,
-            pair: "ETH-USD".into(),
-            side,
-            price,
-            size: dec(1),
-            commitment_key: key.into(),
-            ttl: 60_000_000_000,
+    let encrypt_order =
+        |trader: Address, side: Side, price: Decimal, key: &str| -> (Vec<u8>, Vec<u8>) {
+            let order = DecryptedOrder {
+                trader,
+                pair: "ETH-USD".into(),
+                side,
+                price,
+                size: dec(1),
+                commitment_key: key.into(),
+                ttl: 60_000_000_000,
+            };
+            let plaintext = serde_json::to_vec(&order).unwrap();
+            let ciphertext = ecies::encrypt(&pk_bytes, &plaintext).unwrap();
+            (vec![0u8; 32], ciphertext)
         };
-        let plaintext = serde_json::to_vec(&order).unwrap();
-        let ciphertext = ecies::encrypt(&pk_bytes, &plaintext).unwrap();
-        (vec![0u8; 32], ciphertext)
-    };
 
     let (bid_commit, bid_ct) =
         encrypt_order(Address::repeat_byte(1), Side::Buy, dec(2000), "bid-key");

--- a/crates/dp-engine/tests/multi_pair.rs
+++ b/crates/dp-engine/tests/multi_pair.rs
@@ -32,6 +32,19 @@ fn new_engine() -> Engine {
     engine
 }
 
+/// Distinct trader per placed order. Self-trade prevention keys on the
+/// verified `trader` address (#168), so a crossing bid/ask sharing an
+/// address would be skipped as a self-cross and match nothing.
+fn next_trader() -> Address {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static SEQ: AtomicU64 = AtomicU64::new(1);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    let mut bytes = [0u8; 20];
+    bytes[0] = 0xEE;
+    bytes[12..].copy_from_slice(&n.to_be_bytes());
+    Address::from(bytes)
+}
+
 async fn place(
     engine: &Engine,
     pair: &str,
@@ -41,7 +54,7 @@ async fn place(
     key: &str,
 ) -> Result<dp_types::Order, dp_engine::EngineError> {
     let d = DecryptedOrder {
-        trader: Address::ZERO,
+        trader: next_trader(),
         pair: pair.into(),
         side,
         price: dec(price),

--- a/crates/dp-engine/tests/multi_pair.rs
+++ b/crates/dp-engine/tests/multi_pair.rs
@@ -33,8 +33,9 @@ fn new_engine() -> Engine {
 }
 
 /// Distinct trader per placed order. Self-trade prevention keys on the
-/// verified `trader` address (#168), so a crossing bid/ask sharing an
-/// address would be skipped as a self-cross and match nothing.
+/// `trader` address (#168), so a crossing bid/ask sharing an address would be
+/// skipped as a self-cross and match nothing. `0xEE` prefix scheme mirrors
+/// the `dp-auction` and `dp-api` test helpers.
 fn next_trader() -> Address {
     use std::sync::atomic::{AtomicU64, Ordering};
     static SEQ: AtomicU64 = AtomicU64::new(1);


### PR DESCRIPTION
Closes #168

Self-trade prevention was keyed on the per-order `commitment_key`, which the client picks. That blocked two genuinely separate traders whenever they reused a key, and it let one trader wash-trade by splitting a bid and an ask across two keys. Keying on the `trader` address instead fixes the false-positive for good, since that's the field that actually says who placed the order.

It only half-closes the wash-trade hole, and the comment in `match_orders` spells out why. `trader` is spoof-proof only once the engine binds it to the verified caller, and that binding runs for wallet-authenticated callers alone: `place_order` checks `decrypted.trader == caller` only when a caller is present. The MVP authenticates with an API key, so the caller is `None`, `trader` stays client-supplied, and a wash trader can set two addresses to slip past exactly as before. SIWE wallet auth is what actually shuts the vector. The in-circuit trader-id derivation was already handled in #153.

The crossing-auction tests had both legs on `Address::ZERO`, which now reads as a self-cross, so most of the diff is just handing each order its own `0xEE`-prefixed trader (same scheme in dp-auction, dp-engine and dp-api) and lining the handler tests' order owner up with the request wallet. New cases cover the wash-trade and the false-positive.