### PR TITLE
book: Reject over-fills and make event application idempotent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
+ "tracing",
  "uuid",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,6 +2381,7 @@ dependencies = [
  "chrono",
  "dp-event",
  "dp-types",
+ "metrics",
  "parking_lot",
  "rust_decimal",
  "serde",

--- a/crates/dp-api/src/observability.rs
+++ b/crates/dp-api/src/observability.rs
@@ -31,8 +31,8 @@ use tracing_subscriber::{EnvFilter, Layer};
 // integration tests) keep importing them through this module.
 pub use dp_types::metrics::{
     M_ACTIVE_ORDERS, M_AUCTIONS_TOTAL, M_AUCTION_DURATION, M_BATCH_SUBMISSION_DURATION,
-    M_CLEARING_PRICE, M_CRYPTO_DECRYPT_TOTAL, M_EVENT_LOG_SIZE_BYTES, M_ORDERS_EXPIRED,
-    M_ORDERS_MATCHED, M_ORDERS_PLACED, M_SETTLEMENT_CONFIRMATIONS,
+    M_BOOK_OVERFILL_REJECTED, M_CLEARING_PRICE, M_CRYPTO_DECRYPT_TOTAL, M_EVENT_LOG_SIZE_BYTES,
+    M_ORDERS_EXPIRED, M_ORDERS_MATCHED, M_ORDERS_PLACED, M_SETTLEMENT_CONFIRMATIONS,
 };
 
 const AUCTION_BUCKETS: &[f64] = &[
@@ -75,6 +75,10 @@ pub fn init_metrics() -> Result<PrometheusHandle, ObservabilityError> {
         "Matches produced in successful auctions (one increment per bid/ask pair)"
     );
     describe_counter!(M_ORDERS_EXPIRED, "Orders dropped because their TTL elapsed");
+    describe_counter!(
+        M_BOOK_OVERFILL_REJECTED,
+        "Fills rejected because they exceeded an order's remaining size (event log inconsistent with book state); any non-zero value is a recovery-integrity signal"
+    );
     describe_gauge!(
         M_CLEARING_PRICE,
         "Latest auction clearing price, labeled by pair"
@@ -102,6 +106,7 @@ pub fn init_metrics() -> Result<PrometheusHandle, ObservabilityError> {
     metrics::counter!(M_AUCTIONS_TOTAL).absolute(0);
     metrics::counter!(M_ORDERS_MATCHED).absolute(0);
     metrics::counter!(M_ORDERS_EXPIRED).absolute(0);
+    metrics::counter!(M_BOOK_OVERFILL_REJECTED).absolute(0);
     metrics::counter!(M_SETTLEMENT_CONFIRMATIONS).absolute(0);
     metrics::counter!(M_ORDERS_PLACED, "side" => "buy").absolute(0);
     metrics::counter!(M_ORDERS_PLACED, "side" => "sell").absolute(0);
@@ -294,6 +299,7 @@ mod tests {
             M_ORDERS_PLACED,
             M_ORDERS_MATCHED,
             M_ORDERS_EXPIRED,
+            M_BOOK_OVERFILL_REJECTED,
             M_SETTLEMENT_CONFIRMATIONS,
             M_ACTIVE_ORDERS,
             M_EVENT_LOG_SIZE_BYTES,

--- a/crates/dp-book/Cargo.toml
+++ b/crates/dp-book/Cargo.toml
@@ -12,6 +12,7 @@ chrono = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
+metrics = { workspace = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true }

--- a/crates/dp-book/Cargo.toml
+++ b/crates/dp-book/Cargo.toml
@@ -11,6 +11,7 @@ rust_decimal = { workspace = true }
 chrono = { workspace = true }
 parking_lot = { workspace = true }
 serde = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 alloy-primitives = { workspace = true }

--- a/crates/dp-book/src/book.rs
+++ b/crates/dp-book/src/book.rs
@@ -275,6 +275,10 @@ impl Inner {
         let mut emptied: Option<String> = None;
         for (pair, book) in self.books.iter_mut() {
             if let Some(order) = book.bids.get_mut(&fill.order_id) {
+                if fill.size > order.remaining_size {
+                    warn_overfill(fill, order.remaining_size);
+                    break;
+                }
                 order.remaining_size -= fill.size;
                 if order.remaining_size <= Decimal::ZERO {
                     book.bids.remove(&fill.order_id);
@@ -285,6 +289,10 @@ impl Inner {
                 break;
             }
             if let Some(order) = book.asks.get_mut(&fill.order_id) {
+                if fill.size > order.remaining_size {
+                    warn_overfill(fill, order.remaining_size);
+                    break;
+                }
                 order.remaining_size -= fill.size;
                 if order.remaining_size <= Decimal::ZERO {
                     book.asks.remove(&fill.order_id);
@@ -299,6 +307,20 @@ impl Inner {
             self.books.remove(&p);
         }
     }
+}
+
+/// A fill larger than the order's remaining size means the event log is
+/// inconsistent with the book (a matching-engine bug, a corrupted log, or a
+/// duplicated event). Rather than subtract into a negative `remaining_size`
+/// and silently drop the order, leave it untouched and surface the
+/// inconsistency loudly. See issue #171.
+fn warn_overfill(fill: &Fill, remaining: Decimal) {
+    tracing::warn!(
+        order_id = %fill.order_id,
+        fill_size = %fill.size,
+        remaining = %remaining,
+        "apply_fill: fill exceeds remaining size; skipping inconsistent fill"
+    );
 }
 
 #[cfg(test)]
@@ -388,6 +410,73 @@ mod tests {
         let remaining = book.find_order(bid_id).unwrap();
         assert_eq!(remaining.remaining_size, Decimal::new(6, 0));
         assert!(!book.has_order(ask_id));
+    }
+
+    #[test]
+    fn overfill_is_rejected_and_leaves_order_intact() {
+        let book = OrderBook::new();
+        let bid = make_order(Side::Buy, 100, 10);
+        let bid_id = bid.id;
+        book.insert_order(bid);
+
+        // OrderMatched claiming a 15-unit fill against a 10-unit order.
+        // The ask leg targets a non-existent order, so it is a no-op.
+        book.apply(&Event {
+            seq: 1,
+            event_type: EventType::OrderMatched,
+            timestamp: Utc::now(),
+            data: EventData::OrderMatched {
+                auction_id: Uuid::new_v4(),
+                bid: Fill {
+                    order_id: bid_id,
+                    size: Decimal::new(15, 0),
+                },
+                ask: Fill {
+                    order_id: Uuid::new_v4(),
+                    size: Decimal::new(15, 0),
+                },
+                price: Decimal::new(100, 0),
+                size: Decimal::new(15, 0),
+            },
+        });
+
+        // The inconsistent fill is rejected, not absorbed: the order is
+        // left untouched rather than driven negative and removed.
+        assert_eq!(book.active_order_count(), 1);
+        let order = book.find_order(bid_id).unwrap();
+        assert_eq!(order.remaining_size, Decimal::new(10, 0));
+    }
+
+    #[test]
+    fn exact_fill_still_removes_order() {
+        // The guard rejects only fills strictly larger than remaining; an
+        // exact fill is a full fill and must still remove the order.
+        let book = OrderBook::new();
+        let bid = make_order(Side::Buy, 100, 10);
+        let bid_id = bid.id;
+        book.insert_order(bid);
+
+        book.apply(&Event {
+            seq: 1,
+            event_type: EventType::OrderMatched,
+            timestamp: Utc::now(),
+            data: EventData::OrderMatched {
+                auction_id: Uuid::new_v4(),
+                bid: Fill {
+                    order_id: bid_id,
+                    size: Decimal::new(10, 0),
+                },
+                ask: Fill {
+                    order_id: Uuid::new_v4(),
+                    size: Decimal::new(10, 0),
+                },
+                price: Decimal::new(100, 0),
+                size: Decimal::new(10, 0),
+            },
+        });
+
+        assert!(!book.has_order(bid_id));
+        assert_eq!(book.active_order_count(), 0);
     }
 
     #[test]

--- a/crates/dp-book/src/book.rs
+++ b/crates/dp-book/src/book.rs
@@ -538,6 +538,43 @@ mod tests {
     }
 
     #[test]
+    fn zero_seq_event_applies_after_seq_advanced() {
+        // seq == 0 marks an event that never went through the durable log
+        // (e.g. an expiry event built in-memory before persistence). The
+        // idempotency guard must not skip it just because the book has
+        // already advanced past seq 0 — locks the `event.seq != 0` branch.
+        let book = OrderBook::new();
+        let a = make_order(Side::Buy, 100, 1);
+        let b = make_order(Side::Buy, 100, 1);
+        let a_id = a.id;
+        let b_id = b.id;
+        book.insert_order(a);
+        book.insert_order(b);
+
+        // Advance the book's high-water seq to 5 with a real cancel.
+        book.apply(&Event {
+            seq: 5,
+            event_type: EventType::OrderCancelled,
+            timestamp: Utc::now(),
+            data: EventData::OrderCancelled {
+                order_id: a_id,
+                reason: "user".into(),
+            },
+        });
+        assert!(!book.has_order(a_id));
+
+        // A seq == 0 event must still apply even though self.seq is now 5.
+        book.apply(&Event {
+            seq: 0,
+            event_type: EventType::OrderExpired,
+            timestamp: Utc::now(),
+            data: EventData::OrderExpired { order_id: b_id },
+        });
+        assert!(!book.has_order(b_id));
+        assert_eq!(book.active_order_count(), 0);
+    }
+
+    #[test]
     fn expiration_collection() {
         let book = OrderBook::new();
         let mut order = make_order(Side::Buy, 50, 1);

--- a/crates/dp-book/src/book.rs
+++ b/crates/dp-book/src/book.rs
@@ -325,6 +325,13 @@ impl Inner {
 /// duplicated event). Rather than subtract into a negative `remaining_size`
 /// and silently drop the order, leave it untouched and surface the
 /// inconsistency loudly. See issue #171.
+///
+/// Leaving the order intact means it still claims its full remaining size
+/// and can be re-matched next auction (phantom liquidity). That is a
+/// deliberate tradeoff: the alternative (dropping it) silently destroys
+/// liquidity, and neither is correct because the situation should not
+/// occur. We refuse to mutate state from an event we have flagged as
+/// corrupt and rely on the warn + counter to get an operator to look.
 fn warn_overfill(fill: &Fill, remaining: Decimal) {
     tracing::warn!(
         order_id = %fill.order_id,
@@ -332,6 +339,7 @@ fn warn_overfill(fill: &Fill, remaining: Decimal) {
         remaining = %remaining,
         "apply_fill: fill exceeds remaining size; skipping inconsistent fill"
     );
+    metrics::counter!(dp_types::metrics::M_BOOK_OVERFILL_REJECTED).increment(1);
 }
 
 #[cfg(test)]

--- a/crates/dp-book/src/book.rs
+++ b/crates/dp-book/src/book.rs
@@ -467,6 +467,42 @@ mod tests {
     }
 
     #[test]
+    fn overfill_on_ask_is_rejected_and_leaves_order_intact() {
+        // The ask leg has its own overfill guard, separate from the bid
+        // leg's. Drive an oversized fill against a resting sell order so the
+        // `book.asks` branch is exercised, not just `book.bids`.
+        let book = OrderBook::new();
+        let ask = make_order(Side::Sell, 100, 10);
+        let ask_id = ask.id;
+        book.insert_order(ask);
+
+        // 15-unit fill against a 10-unit ask; the bid leg targets a
+        // non-existent order, so it is a no-op.
+        book.apply(&Event {
+            seq: 1,
+            event_type: EventType::OrderMatched,
+            timestamp: Utc::now(),
+            data: EventData::OrderMatched {
+                auction_id: Uuid::new_v4(),
+                bid: Fill {
+                    order_id: Uuid::new_v4(),
+                    size: Decimal::new(15, 0),
+                },
+                ask: Fill {
+                    order_id: ask_id,
+                    size: Decimal::new(15, 0),
+                },
+                price: Decimal::new(100, 0),
+                size: Decimal::new(15, 0),
+            },
+        });
+
+        assert_eq!(book.active_order_count(), 1);
+        let order = book.find_order(ask_id).unwrap();
+        assert_eq!(order.remaining_size, Decimal::new(10, 0));
+    }
+
+    #[test]
     fn exact_fill_still_removes_order() {
         // The guard rejects only fills strictly larger than remaining; an
         // exact fill is a full fill and must still remove the order.

--- a/crates/dp-book/src/book.rs
+++ b/crates/dp-book/src/book.rs
@@ -233,6 +233,17 @@ impl Default for OrderBook {
 
 impl Inner {
     fn apply(&mut self, event: &Event) {
+        // Idempotency guard. Persisted events carry a strictly-monotonic
+        // `seq` (>= 1) assigned by the store, and the live path appends
+        // (assigning `seq`) before it applies — so a `seq` at or below the
+        // highest already applied means this event has been seen, and
+        // re-running it would double-subtract in `apply_fill`. Skip it.
+        // `seq == 0` marks an event that never went through the durable log
+        // (e.g. an unpersisted event in a unit test); it cannot be deduped,
+        // so it is always applied.
+        if event.seq != 0 && event.seq <= self.seq {
+            return;
+        }
         if event.seq > self.seq {
             self.seq = event.seq;
         }
@@ -477,6 +488,45 @@ mod tests {
 
         assert!(!book.has_order(bid_id));
         assert_eq!(book.active_order_count(), 0);
+    }
+
+    #[test]
+    fn duplicate_match_is_idempotent() {
+        let book = OrderBook::new();
+        let bid = make_order(Side::Buy, 100, 10);
+        let ask = make_order(Side::Sell, 100, 4);
+        let bid_id = bid.id;
+        let ask_id = ask.id;
+        book.insert_order(bid);
+        book.insert_order(ask);
+
+        let matched = Event {
+            seq: 1,
+            event_type: EventType::OrderMatched,
+            timestamp: Utc::now(),
+            data: EventData::OrderMatched {
+                auction_id: Uuid::new_v4(),
+                bid: Fill {
+                    order_id: bid_id,
+                    size: Decimal::new(4, 0),
+                },
+                ask: Fill {
+                    order_id: ask_id,
+                    size: Decimal::new(4, 0),
+                },
+                price: Decimal::new(100, 0),
+                size: Decimal::new(4, 0),
+            },
+        };
+
+        book.apply(&matched);
+        // Re-applying the same event (same seq) must be a no-op, not a
+        // second 4-unit subtraction that would leave the bid at 2.
+        book.apply(&matched);
+
+        let remaining = book.find_order(bid_id).unwrap();
+        assert_eq!(remaining.remaining_size, Decimal::new(6, 0));
+        assert!(!book.has_order(ask_id));
     }
 
     #[test]

--- a/crates/dp-types/src/metrics.rs
+++ b/crates/dp-types/src/metrics.rs
@@ -18,3 +18,9 @@ pub const M_EVENT_LOG_SIZE_BYTES: &str = "darkpool_event_log_size_bytes";
 /// key's success series go to zero before deleting it during a rotation
 /// drain.
 pub const M_CRYPTO_DECRYPT_TOTAL: &str = "darkpool_crypto_decrypt_total";
+/// Fills rejected by the book because they exceeded an order's remaining
+/// size — the event log disagreed with book state (matching-engine bug,
+/// corrupted log, or duplicate). Force-registered at zero so operators can
+/// alert on it leaving zero; any non-zero value is a recovery-integrity
+/// signal. See issue #171.
+pub const M_BOOK_OVERFILL_REJECTED: &str = "darkpool_book_overfill_rejected_total";


### PR DESCRIPTION
Closes #171

apply_fill subtracted the fill from remaining_size with no bounds check. remaining_size is a signed Decimal, so an over-fill never underflowed or panicked; it just went negative and the <= ZERO check then quietly dropped an order that should have kept its liquidity. Separately, apply tracked the high-water seq but never gated on it, so replaying or duplicating a persisted OrderMatched ran apply_fill twice and double-subtracted. Neither is reachable by an external caller under the API-key trust model, but both let a matching-engine bug or a corrupted log silently corrupt recovered state instead of failing loud.

apply_fill now leaves the order untouched and logs when a fill exceeds remaining size. apply skips any event whose seq was already applied; seq == 0 events never go through the durable log, so they still apply. Tests cover the rejected over-fill, the exact-fill boundary, and the idempotent duplicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The system now rejects order fills that exceed remaining order size, preventing inconsistent states.
  * Duplicate events are now handled idempotently, eliminating unintended duplicate processing.

* **Observability**
  * Added monitoring metric to track rejected overfill attempts for operational visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->