### PR TITLE
Align backend and contract docs with the implemented code

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ cargo run   --release --bin darkpool-server
                                  # multi-key rotation mode (issue #28)
 --signer-key-uri file:/etc/dp/eth.hex   # independent Ethereum signer URI
 --aggregator-bin /usr/local/bin/dp-aggregate  # proof aggregator subprocess (omit → noop)
---eth-rpc wss://...              # settlement RPC (currently warns; submitter wiring deferred)
+--eth-rpc https://...            # settlement RPC (with --signer-key-uri + --contract-addr → on-chain)
 --api-keys k1,k2                 # comma-separated API keys (omit → no auth)
 --rate-limit 100  --rate-burst 20  --rate-stale-after 5m
 ```

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ flowchart TB
 4. The operator decrypts in memory, collects orders into a time-bounded batch (default: 5s), and runs a batch auction — computing a clearing price and matching all crossing orders. **Plaintext orders exist only in engine RAM during the auction window. The event log is an append-only file (bincode-encoded, fsync per append) containing ciphertext + commitment + proof only — never plaintext.**
 5. Matched pairs are handed to a pluggable `ProofAggregator` (subprocess / FFI / RPC), then submitted on-chain via a pluggable `Submitter`. The Solidity verifier checks the aggregated proof and transfers tokens atomically.
 
-> **Status note.** ECIES decryption and the subprocess proof aggregator are implemented. The `alloy`-based `EthSubmitter` exists in `dp-settlement`, but bootstrap glue from `--eth-rpc` to a live submitter is not yet wired in `darkpool-server`; setting the flag today logs a warning and runs with the noop submitter. All seams are pluggable. The engine, API, event store, auction, and expiry logic are production-shape; circuits and on-chain wiring need their final integrations before mainnet.
+> **Status note.** ECIES decryption and the subprocess proof aggregator are implemented. The `alloy`-based `EthSubmitter` in `dp-settlement` is wired into `darkpool-server`: setting `--eth-rpc` together with `--signer-key-uri` (and `--contract-addr`) builds a live on-chain submitter, while `--eth-rpc` without a signer logs a warning and falls back to the noop submitter. All seams are pluggable. The engine, API, event store, auction, and expiry logic are production-shape; the Groth16 settlement path is live, but the HyperNova decider verifier is still a stub and its trusted setup is pending before mainnet.
 
 ---
 
@@ -107,7 +107,7 @@ flowchart TB
 - Clearing price computed as the price that maximizes matched volume.
 - Partial fills are supported. Residual quantity carries over to the next auction round.
 - Orders expire after a configurable TTL (default: 10 min).
-- Orders from the same commitment key cannot match each other.
+- Orders from the same trader cannot match each other.
 - Minimum order size is enforced at the circuit level, not in the engine.
 
 ### Settlement

--- a/overview.md
+++ b/overview.md
@@ -1,6 +1,6 @@
 # ZK Dark Pool DEX
 ## Technical Architecture & Implementation Guide
-> Stack: Rust · Solidity · ZK Circuits (halo2 / arkworks)
+> Stack: Rust · Solidity · ZK Circuits (arkworks Groth16 + HyperNova IVC)
 
 ---
 
@@ -49,7 +49,7 @@ This mirrors how institutional dark pools work in traditional finance, where the
 
 An order passes through five discrete phases before funds change hands:
 
-1. **Commitment** — trader submits a Pedersen commitment to the order parameters and locks collateral in the escrow contract.
+1. **Commitment** — trader submits a Poseidon commitment to the order parameters and locks collateral in the escrow contract.
 2. **Proof generation** — trader runs a Rust circuit locally and produces a ZK proof that the order is valid (sufficient collateral, correct format, within limits).
 3. **Encrypted submission** — trader encrypts the full order to the operator's public key and submits the commitment, proof, and encrypted payload to the API gateway.
 4. **Batch auction** — the operator decrypts orders, collects them into time-bounded batches (default: every 5 seconds), computes a clearing price, and matches bids and asks that cross at or through that price.
@@ -61,7 +61,7 @@ An order passes through five discrete phases before funds change hands:
 - No temporal advantage within a batch — all orders in the same auction round are treated equally regardless of arrival time.
 - Partial fills are supported; residual quantity carries over to the next auction round.
 - Orders expire after a configurable TTL (default: 10 minutes).
-- Self-match prevention: orders from the same commitment key cannot match.
+- Self-match prevention: orders from the same trader cannot match.
 - Minimum order size enforced at the circuit level, not in the engine.
 - Clearing price is computed as the price that maximizes matched volume.
 
@@ -71,7 +71,7 @@ An order passes through five discrete phases before funds change hands:
 - Each batch is accompanied by an aggregated ZK proof verified by the on-chain verifier contract.
 - If the proof fails, the entire batch is rejected — no partial settlement.
 - Collateral is locked in the escrow contract at commitment time and released atomically at settlement.
-- A 0.05% protocol fee is deducted from the taker side at settlement.
+- A 0.05% protocol fee is deducted from the sell (ask) side at settlement.
 
 ### 2.4 Price Discovery
 
@@ -96,7 +96,7 @@ Price emerges from the protocol itself via the batch auction mechanism:
 
 | Layer | Language | Responsibility |
 |---|---|---|
-| ZK Circuit | Rust (halo2 / arkworks) | Generate & verify proofs of order validity |
+| ZK Circuit | Rust (arkworks Groth16) | Generate & verify proofs of order validity |
 | Matching Engine | Rust (tokio) | Batch auction logic, clearing price computation, event sourcing (`crates/dp-engine/`) |
 | Event Store | Rust (bincode + fsync) | Immutable event log (OrderPlaced, OrderMatched, BatchSubmitted, etc.) for state reconstruction and auditability (`crates/dp-event/`) |
 | Proof Aggregator | Rust (subprocess) | Combine individual proofs into a single batch proof. Spawned as a child process (`crates/dp-aggregator/`) |
@@ -153,6 +153,11 @@ The matching engine does not maintain mutable state. Instead, the order book is 
 | `OrderExpired` | Order TTL exceeded without fill |
 | `BatchSubmitted` | Matched pairs submitted on-chain for settlement |
 | `BatchConfirmed` | On-chain settlement tx confirmed |
+| `BatchSettled` | Settlement finalized on-chain (`BatchSettled` contract event observed by the watcher) |
+| `PairRegistered` | New trading pair registered via the admin API |
+| `PairSuspended` | Trading pair suspended — no new orders accepted |
+| `PairDelisted` | Trading pair delisted and its resting orders cancelled |
+| `BatchFolded` | HyperNova IVC fold step recorded (feature-gated) |
 
 **Recovery:** on startup, the engine replays the event log from the last compaction checkpoint to reconstruct the current order book state. A batch is only considered committed when the `BatchSubmitted` event is persisted.
 
@@ -164,7 +169,7 @@ The matching engine does not maintain mutable state. Instead, the order book is 
 crates/
 ├── dp-types/        # Shared domain types (Order, Fill, Side, EventType)
 ├── dp-crypto/       # ECIES decrypter + commitment computation
-├── dp-event/        # Append-only event store (MemStore + FileStore, bincode + fsync)
+├── dp-event/        # Append-only event store (MemStore + FileStore + PgStore, bincode + fsync)
 ├── dp-book/         # Order book projection + depth aggregation
 ├── dp-auction/      # Batch auction, clearing price, self-match prevention
 ├── dp-aggregator/   # Pluggable proof aggregator (noop + subprocess)
@@ -173,7 +178,7 @@ crates/
 └── dp-api/          # tonic gRPC + axum REST, validation, auth, rate-limit
                      #   includes the `darkpool-server` binary entrypoint
 front/               # Next.js demo UI (auction history, depth, clearing prices)
-contracts/           # Solidity: DarkPool.sol, Verifier.sol (planned)
-zkproof/             # halo2 / arkworks circuits + prover + aggregator (planned)
+contracts/           # Solidity: DarkPool.sol, VerifierProxy.sol, Groth16Verifier.sol, HyperNovaDeciderVerifier.sol
+crates/dp-zk/        # arkworks Groth16 circuits + prover (+ HyperNova IVC via Sonobe, feature-gated)
 Cargo.toml           # workspace root
 ```


### PR DESCRIPTION
overview.md predated the Rust port and still claimed halo2, Pedersen commitments, and a taker-side fee. README's status note also said the EthSubmitter wasn't wired yet, which stopped being true once the --eth-rpc + --signer-key-uri bootstrap landed.

Brought both docs back in line with the code:
- ZK stack is arkworks Groth16 (+ HyperNova IVC via Sonobe), not halo2
- commitment is Poseidon; protocol fee comes off the sell (ask) side
- self-match prevention keys on the trader, not the commitment key
- event store has PgStore, and the event table now lists all 12 variants
- contracts are implemented (no zkproof/ crate); circuits live in crates/dp-zk
- EthSubmitter is wired into darkpool-server