### PR TITLE
[F1.13] Accessibility + reduced-motion + responsive QA pass

### DIFF
--- a/front/app/app/_components/ConnectButton.tsx
+++ b/front/app/app/_components/ConnectButton.tsx
@@ -24,6 +24,10 @@ export function ConnectButton() {
       {({ account, openAccountModal, openConnectModal, mounted }) => {
         const ready = mounted
         const connected = ready && Boolean(account)
+        // While the hydration gate hides the wrapper (aria-hidden), the
+        // inner button must not be focusable — a focusable element inside
+        // aria-hidden is an axe `aria-hidden-focus` violation (#80).
+        const gateTabIndex = ready ? undefined : -1
         return (
           <div
             aria-hidden={!ready}
@@ -34,6 +38,7 @@ export function ConnectButton() {
                 variant="ghost"
                 onClick={openAccountModal}
                 aria-label={`Wallet ${account.address}`}
+                tabIndex={gateTabIndex}
                 className={HEADER_BUTTON_CLASS}
               >
                 <WalletIcon className="mr-3 text-brand-fg" />
@@ -44,6 +49,7 @@ export function ConnectButton() {
                 variant="ghost"
                 onClick={openConnectModal}
                 aria-haspopup="dialog"
+                tabIndex={gateTabIndex}
                 className={HEADER_BUTTON_CLASS}
               >
                 <WalletIcon className="mr-3 text-brand-muted" />

--- a/front/app/app/_shell/CommandPrompt.tsx
+++ b/front/app/app/_shell/CommandPrompt.tsx
@@ -38,7 +38,9 @@ export function CommandPrompt() {
           Real Cmd-K behavior (jump-to-section, place-order shortcuts, wallet actions) lands in a
           follow-up issue. The shortcut is wired so the affordance is honest.
         </DialogDescription>
-        <div className="mt-6 font-mono text-label-md uppercase text-brand-muted/70">
+        {/* Full-strength muted: brand-muted is already ~3:1 on the canvas —
+            a /70 alpha pushes ambient metadata below any readable floor (#80). */}
+        <div className="mt-6 font-mono text-label-md uppercase text-brand-muted">
           [ TRACKED · TODO ]
         </div>
       </DialogContent>

--- a/front/app/app/_shell/PairSelector.tsx
+++ b/front/app/app/_shell/PairSelector.tsx
@@ -8,6 +8,15 @@ export function PairSelector() {
     <details
       className="relative"
       onToggle={(event) => setOpen((event.currentTarget as HTMLDetailsElement).open)}
+      // Native <details> toggles with Enter/Space but never closes on
+      // Escape — standard disclosure keyboard contract (#80). Focus
+      // returns to the summary so the keyboard user isn't stranded.
+      onKeyDown={(event) => {
+        if (event.key !== 'Escape' || !event.currentTarget.open) return
+        event.preventDefault()
+        event.currentTarget.open = false
+        event.currentTarget.querySelector('summary')?.focus()
+      }}
     >
       <summary
         aria-label="Trading pair selector"

--- a/front/app/app/_shell/PairSelector.tsx
+++ b/front/app/app/_shell/PairSelector.tsx
@@ -40,7 +40,9 @@ export function PairSelector() {
         >
           ETH / USDC
         </div>
-        <div className="mt-2 font-mono text-label-md uppercase text-brand-muted/70">
+        {/* Full-strength muted: brand-muted is already ~3:1 on the canvas —
+            a /70 alpha pushes ambient metadata below any readable floor (#80). */}
+        <div className="mt-2 font-mono text-label-md uppercase text-brand-muted">
           MULTI-PAIR · POST-MVP
         </div>
       </div>

--- a/front/app/app/layout.tsx
+++ b/front/app/app/layout.tsx
@@ -42,7 +42,10 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
           </a>
           <Banner />
           <Rail />
-          <main id="main" className="pt-16 lg:pl-56">
+          {/* tabIndex={-1} lets the skip link programmatically focus the
+              region on browsers that don't move sequential focus to
+              fragment targets. */}
+          <main id="main" tabIndex={-1} className="pt-16 lg:pl-56 focus:outline-none">
             {children}
           </main>
           <OnboardingMount />

--- a/front/app/app/layout.tsx
+++ b/front/app/app/layout.tsx
@@ -30,9 +30,21 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
                 'body input,body textarea,body [contenteditable=true]{cursor:text !important}',
             }}
           />
+          {/* Keyboard users land on the banner/rail chrome first — give
+              them a one-Tab bypass straight to the panels (#80). Visible
+              only while focused; styled as a bracketed mono tag per
+              DESIGN.md (zero radius, 1px outline, lime focus ring). */}
+          <a
+            href="#main"
+            className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-50 focus:border focus:border-brand-border focus:bg-brand-bg focus:px-4 focus:py-2 focus:font-mono focus:text-label-lg focus:uppercase focus:tracking-label focus:text-brand-fg focus:outline focus:outline-1 focus:outline-offset-2 focus:outline-brand-accent"
+          >
+            [ SKIP TO CONTENT ]
+          </a>
           <Banner />
           <Rail />
-          <main className="pt-16 lg:pl-56">{children}</main>
+          <main id="main" className="pt-16 lg:pl-56">
+            {children}
+          </main>
           <OnboardingMount />
           <HistoryBoot />
           <SettlementWatcher />

--- a/front/app/app/portfolio/_components/ExportCsvButton.tsx
+++ b/front/app/app/portfolio/_components/ExportCsvButton.tsx
@@ -40,7 +40,7 @@ export function ExportCsvButton({ fills }: ExportCsvButtonProps): JSX.Element {
       type="button"
       onClick={handleClick}
       disabled={disabled}
-      className="border border-brand-border px-3 py-1 font-mono text-label-md uppercase tracking-labelWide text-brand-muted transition-colors hover:border-brand-muted hover:text-brand-fg disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-brand-accent"
+      className="whitespace-nowrap border border-brand-border px-3 py-1 font-mono text-label-md uppercase tracking-labelWide text-brand-muted transition-colors hover:border-brand-muted hover:text-brand-fg disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-2 focus-visible:outline-brand-accent"
       aria-label="Export fill history as CSV"
     >
       [ EXPORT CSV ]

--- a/front/app/app/portfolio/_components/FillHistoryTable.tsx
+++ b/front/app/app/portfolio/_components/FillHistoryTable.tsx
@@ -44,16 +44,25 @@ export function FillHistoryTable({ fills }: FillHistoryTableProps): JSX.Element 
       className="flex min-h-[280px] flex-col border border-brand-border bg-brand-surface"
     >
       <TableTitleBar count={fills.length} fills={fills} />
-      <TableHeader />
-      {fills.length === 0 ? (
-        <FillHistoryEmpty />
-      ) : (
-        <ol className="flex-1 overflow-y-auto">
-          {fills.map((f) => (
-            <FillHistoryRow key={f.fillId} fill={f} link={links.get(f.fillId) ?? null} />
-          ))}
-        </ol>
-      )}
+      {/* Below ~576px the fixed columns (10rem time + 4rem side + 9rem
+          batch) outgrow the viewport and the 1fr numeric columns collapse
+          to zero, overlapping their text (#80). Scroll the table
+          horizontally instead of letting columns crush. */}
+      <div className="flex flex-1 flex-col overflow-x-auto">
+        <div className="flex min-w-[36rem] flex-col">
+          <TableHeader />
+          {fills.length > 0 ? (
+            <ol className="flex-1 overflow-y-auto">
+              {fills.map((f) => (
+                <FillHistoryRow key={f.fillId} fill={f} link={links.get(f.fillId) ?? null} />
+              ))}
+            </ol>
+          ) : null}
+        </div>
+      </div>
+      {/* Empty state sits outside the min-width scroller so it centers on
+          the visible panel, not on the 36rem virtual table. */}
+      {fills.length === 0 ? <FillHistoryEmpty /> : null}
     </section>
   )
 }
@@ -61,7 +70,7 @@ export function FillHistoryTable({ fills }: FillHistoryTableProps): JSX.Element 
 function TableTitleBar({ count, fills }: { count: number; fills: readonly Fill[] }) {
   return (
     <div className="flex h-9 items-center justify-between border-b border-brand-border px-4">
-      <span className="font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
+      <span className="whitespace-nowrap font-mono text-label-md uppercase tracking-labelWide text-brand-muted">
         [ FILL HISTORY · {count.toString().padStart(2, '0')} ]
       </span>
       <ExportCsvButton fills={fills} />

--- a/front/app/app/portfolio/_components/FillHistoryTable.tsx
+++ b/front/app/app/portfolio/_components/FillHistoryTable.tsx
@@ -70,10 +70,13 @@ function TableTitleBar({ count, fills }: { count: number; fills: readonly Fill[]
 }
 
 function TableHeader() {
+  // Visual column guide only — not an ARIA table. An orphan role="row"
+  // (no table/rowgroup ancestor) is an axe violation; each list row below
+  // carries a complete aria-label instead (#80).
   return (
     <div
+      aria-hidden="true"
       className="grid grid-cols-[10rem_4rem_minmax(0,1fr)_minmax(0,1fr)_minmax(0,9rem)] gap-3 border-b border-brand-border bg-brand-surface px-4 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
-      role="row"
     >
       <span>TIME</span>
       <span>SIDE</span>

--- a/front/app/app/portfolio/_components/FillHistoryTable.tsx
+++ b/front/app/app/portfolio/_components/FillHistoryTable.tsx
@@ -47,8 +47,15 @@ export function FillHistoryTable({ fills }: FillHistoryTableProps): JSX.Element 
       {/* Below ~576px the fixed columns (10rem time + 4rem side + 9rem
           batch) outgrow the viewport and the 1fr numeric columns collapse
           to zero, overlapping their text (#80). Scroll the table
-          horizontally instead of letting columns crush. */}
-      <div className="flex flex-1 flex-col overflow-x-auto">
+          horizontally instead of letting columns crush. tabIndex + region
+          keep the scroller keyboard-reachable (WCAG 2.1.1) — rows are
+          plain text, so there may be nothing focusable inside. */}
+      <div
+        tabIndex={0}
+        role="region"
+        aria-label="Fill history table"
+        className="flex flex-1 flex-col overflow-x-auto focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-accent"
+      >
         <div className="flex min-w-[36rem] flex-col">
           <TableHeader />
           {fills.length > 0 ? (

--- a/front/app/app/portfolio/_components/PortfolioPanel.a11y.test.tsx
+++ b/front/app/app/portfolio/_components/PortfolioPanel.a11y.test.tsx
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+
+// Automated axe-core scan of the /portfolio surface (#80). Renders the
+// real panel in jsdom (fake-indexeddb backs the Dexie fill history) and
+// asserts zero WCAG A/AA violations — see front/test/axe.ts for scope.
+
+import 'fake-indexeddb/auto'
+
+import * as React from 'react'
+import { afterEach, describe, it } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+
+import type { Fill } from '@/lib/mock-store'
+import { Side } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import { walletStore } from '@/lib/wallet/mock-store'
+import { expectNoAxeViolations } from '@/test/axe'
+
+import { FillHistoryTable } from './FillHistoryTable'
+import { PortfolioPanel } from './PortfolioPanel'
+
+function fill(overrides: Partial<Fill> = {}): Fill {
+  return {
+    fillId: 'f-001',
+    orderId: 'o-001',
+    auctionId: 'a-001',
+    side: Side.BUY,
+    price: '3000.12',
+    size: '1.5',
+    timestampUnix: 1_700_000_000n,
+    ...overrides,
+  }
+}
+
+describe('PortfolioPanel a11y', () => {
+  afterEach(() => {
+    walletStore.disconnect()
+    cleanup()
+  })
+
+  it('has no axe violations when disconnected', async () => {
+    render(<PortfolioPanel />)
+    await expectNoAxeViolations()
+  })
+
+  it('has no axe violations when connected', async () => {
+    walletStore.connect()
+    render(<PortfolioPanel />)
+    await expectNoAxeViolations()
+  })
+
+  it('has no axe violations with a populated fill history', async () => {
+    render(
+      <FillHistoryTable
+        fills={[fill(), fill({ fillId: 'f-002', orderId: 'o-002', side: Side.SELL })]}
+      />
+    )
+    await expectNoAxeViolations()
+  })
+})

--- a/front/app/app/trade/_components/Shell.a11y.test.tsx
+++ b/front/app/app/trade/_components/Shell.a11y.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+
+// Automated axe-core scan of the /trade shell (#80). jsdom applies no
+// stylesheets, so BOTH the desktop and mobile layouts are present in the
+// DOM at once — any duplicate-ID finding here is real, not an artifact.
+// Also scans with the mobile order-entry sheet open (Radix portal).
+
+import * as React from 'react'
+import { afterEach, describe, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { walletStore } from '@/lib/wallet/mock-store'
+import { expectNoAxeViolations } from '@/test/axe'
+
+import { Shell } from './Shell'
+
+describe('Shell a11y', () => {
+  afterEach(() => {
+    walletStore.disconnect()
+    cleanup()
+  })
+
+  it('has no axe violations when disconnected', async () => {
+    render(<Shell />)
+    await expectNoAxeViolations()
+  })
+
+  it('has no axe violations when connected', async () => {
+    walletStore.connect()
+    render(<Shell />)
+    await expectNoAxeViolations()
+  })
+
+  it('has no axe violations with the mobile order-entry sheet open', async () => {
+    render(<Shell />)
+    fireEvent.click(screen.getByRole('button', { name: 'Open order entry' }))
+    await expectNoAxeViolations()
+  })
+})

--- a/front/app/app/trade/_components/balances/BalancesPanel.a11y.test.tsx
+++ b/front/app/app/trade/_components/balances/BalancesPanel.a11y.test.tsx
@@ -1,0 +1,49 @@
+// @vitest-environment jsdom
+
+// Automated axe-core scan of the balances panel (#80) in its
+// disconnected and connected states. See front/test/axe.ts for scope.
+
+import * as React from 'react'
+import { afterEach, describe, it, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+
+// Same inert stubs as DepositModal.test.tsx — useBalances pulls config +
+// wagmi into the import graph.
+vi.mock('@/lib/config', () => ({
+  config: { useMocks: true, chainId: 31337, contracts: null },
+}))
+vi.mock('wagmi', () => ({
+  useReadContracts: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    refetch: () => {},
+  }),
+  useWatchContractEvent: () => {},
+  useWriteContract: () => ({ writeContractAsync: async () => '0x' }),
+  useConfig: () => ({}),
+}))
+vi.mock('wagmi/actions', () => ({ waitForTransactionReceipt: async () => ({}) }))
+
+import { walletStore } from '@/lib/wallet/mock-store'
+import { expectNoAxeViolations } from '@/test/axe'
+
+import { BalancesPanel } from './BalancesPanel'
+
+describe('BalancesPanel a11y', () => {
+  afterEach(() => {
+    walletStore.disconnect()
+    cleanup()
+  })
+
+  it('has no axe violations when disconnected', async () => {
+    render(<BalancesPanel />)
+    await expectNoAxeViolations()
+  })
+
+  it('has no axe violations when connected', async () => {
+    walletStore.connect()
+    render(<BalancesPanel />)
+    await expectNoAxeViolations()
+  })
+})

--- a/front/app/app/trade/_components/deposit/DepositForm.tsx
+++ b/front/app/app/trade/_components/deposit/DepositForm.tsx
@@ -138,6 +138,7 @@ export function DepositForm({ initialToken = 'USDC', onConfirmed, titleId }: Dep
           {!validation.ok && validation.reason !== 'empty' && amount !== '' ? (
             <p
               id="deposit-error"
+              role="alert"
               className="font-mono text-label-md uppercase tracking-label text-brand-fg"
             >
               {validation.message}

--- a/front/app/app/trade/_components/deposit/DepositModal.a11y.test.tsx
+++ b/front/app/app/trade/_components/deposit/DepositModal.a11y.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+// Automated axe-core scan of the deposit/withdraw modals (#80). Radix
+// dialogs portal into document.body, so the scan targets the whole
+// document. Also locks the amount-validation error as role="alert".
+
+import * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+// Pin mock mode and stub wagmi inert (same as DepositModal.test.tsx) so
+// the form stays on the walletStore path.
+vi.mock('@/lib/config', () => ({
+  config: { useMocks: true, chainId: 31337, contracts: null },
+}))
+vi.mock('wagmi', () => ({
+  useReadContracts: () => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    refetch: () => {},
+  }),
+  useWatchContractEvent: () => {},
+  useWriteContract: () => ({ writeContractAsync: async () => '0x' }),
+  useConfig: () => ({}),
+}))
+vi.mock('wagmi/actions', () => ({ waitForTransactionReceipt: async () => ({}) }))
+
+import { walletStore } from '@/lib/wallet/mock-store'
+import { expectNoAxeViolations } from '@/test/axe'
+
+import { DepositModal } from './DepositModal'
+import { WithdrawModal } from './WithdrawModal'
+
+describe('Deposit/Withdraw modal a11y', () => {
+  beforeEach(() => {
+    walletStore.connect()
+    walletStore.resetTxState()
+  })
+
+  afterEach(() => {
+    walletStore.disconnect()
+    walletStore.resetTxState()
+    cleanup()
+  })
+
+  it('deposit modal open has no axe violations', async () => {
+    render(<DepositModal open onOpenChange={() => {}} />)
+    await expectNoAxeViolations()
+  })
+
+  it('withdraw modal open has no axe violations', async () => {
+    render(<WithdrawModal open onOpenChange={() => {}} />)
+    await expectNoAxeViolations()
+  })
+
+  it('announces the amount validation error as an alert', async () => {
+    render(<DepositModal open onOpenChange={() => {}} />)
+    fireEvent.change(screen.getByPlaceholderText('0.00'), { target: { value: '-5' } })
+    const alerts = screen.getAllByRole('alert')
+    expect(alerts.some((a) => a.id === 'deposit-error')).toBe(true)
+    await expectNoAxeViolations()
+  })
+})

--- a/front/app/app/trade/_components/deposit/WithdrawForm.tsx
+++ b/front/app/app/trade/_components/deposit/WithdrawForm.tsx
@@ -130,6 +130,7 @@ export function WithdrawForm({ initialToken = 'USDC', onConfirmed, titleId }: Wi
           {!validation.ok && validation.reason !== 'empty' && amount !== '' ? (
             <p
               id="withdraw-error"
+              role="alert"
               className="font-mono text-label-md uppercase tracking-label text-brand-fg"
             >
               {validation.message}

--- a/front/app/app/trade/_components/entry/BuySellTabs.test.tsx
+++ b/front/app/app/trade/_components/entry/BuySellTabs.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+// Locks the ARIA tabs keyboard contract on the BUY/SELL segmented
+// control (#80): roving tabindex (one Tab stop), arrows move the
+// selection, Home/End jump to first/last.
+
+import * as React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import type { OrderSide } from '../../_lib/entry/validate'
+import { BuySellTabs } from './BuySellTabs'
+
+function Harness({ initial = 'buy' as OrderSide }) {
+  const [side, setSide] = React.useState<OrderSide>(initial)
+  return <BuySellTabs value={side} onChange={setSide} />
+}
+
+const tab = (name: string) => screen.getByRole('tab', { name })
+
+describe('BuySellTabs keyboard', () => {
+  afterEach(cleanup)
+
+  it('exposes a single Tab stop via roving tabindex', () => {
+    render(<Harness />)
+    expect(tab('[ BUY ]').tabIndex).toBe(0)
+    expect(tab('[ SELL ]').tabIndex).toBe(-1)
+  })
+
+  it('moves selection and focus with ArrowRight / ArrowLeft', () => {
+    render(<Harness />)
+    tab('[ BUY ]').focus()
+    fireEvent.keyDown(tab('[ BUY ]'), { key: 'ArrowRight' })
+    expect(tab('[ SELL ]').getAttribute('aria-selected')).toBe('true')
+    expect(document.activeElement).toBe(tab('[ SELL ]'))
+
+    fireEvent.keyDown(tab('[ SELL ]'), { key: 'ArrowLeft' })
+    expect(tab('[ BUY ]').getAttribute('aria-selected')).toBe('true')
+    expect(document.activeElement).toBe(tab('[ BUY ]'))
+  })
+
+  it('jumps to first/last with Home / End', () => {
+    render(<Harness />)
+    tab('[ BUY ]').focus()
+    fireEvent.keyDown(tab('[ BUY ]'), { key: 'End' })
+    expect(tab('[ SELL ]').getAttribute('aria-selected')).toBe('true')
+
+    fireEvent.keyDown(tab('[ SELL ]'), { key: 'Home' })
+    expect(tab('[ BUY ]').getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('ignores arrows while disabled', () => {
+    render(<BuySellTabs value="buy" onChange={() => {}} disabled />)
+    fireEvent.keyDown(tab('[ BUY ]'), { key: 'ArrowRight' })
+    expect(tab('[ BUY ]').getAttribute('aria-selected')).toBe('true')
+    expect(tab('[ SELL ]').getAttribute('aria-selected')).toBe('false')
+  })
+})

--- a/front/app/app/trade/_components/entry/BuySellTabs.tsx
+++ b/front/app/app/trade/_components/entry/BuySellTabs.tsx
@@ -25,15 +25,22 @@ interface OptionProps {
   onClick: () => void
 }
 
-function Option({ side, label, active, disabled, onClick }: OptionProps) {
+const Option = React.forwardRef<HTMLButtonElement, OptionProps>(function Option(
+  { side, label, active, disabled, onClick },
+  ref
+) {
   return (
     <button
+      ref={ref}
       type="button"
       role="tab"
       aria-selected={active}
       aria-controls="order-entry-form"
       data-side={side}
       data-state={active ? 'active' : 'inactive'}
+      // Roving tabindex: one Tab stop for the whole tablist; arrows move
+      // the selection (see BuySellTabs.onKeyDown).
+      tabIndex={active ? 0 : -1}
       onClick={onClick}
       disabled={disabled}
       className={cn(
@@ -51,12 +58,41 @@ function Option({ side, label, active, disabled, onClick }: OptionProps) {
       {label}
     </button>
   )
-}
+})
 
 export function BuySellTabs({ value, onChange, disabled }: BuySellTabsProps) {
+  const buyRef = React.useRef<HTMLButtonElement>(null)
+  const sellRef = React.useRef<HTMLButtonElement>(null)
+
+  // ARIA tabs keyboard contract (#80): Left/Right move the selection
+  // (selection follows focus — only two tabs), Home/End jump to the
+  // first/last tab.
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (disabled) return
+    let next: OrderSide
+    switch (event.key) {
+      case 'ArrowLeft':
+      case 'ArrowRight':
+        next = value === 'buy' ? 'sell' : 'buy'
+        break
+      case 'Home':
+        next = 'buy'
+        break
+      case 'End':
+        next = 'sell'
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+    if (next !== value) onChange(next)
+    ;(next === 'buy' ? buyRef : sellRef).current?.focus()
+  }
+
   return (
-    <div role="tablist" aria-label="Order side" className="flex gap-px">
+    <div role="tablist" aria-label="Order side" className="flex gap-px" onKeyDown={onKeyDown}>
       <Option
+        ref={buyRef}
         side="buy"
         label="[ BUY ]"
         active={value === 'buy'}
@@ -64,6 +100,7 @@ export function BuySellTabs({ value, onChange, disabled }: BuySellTabsProps) {
         onClick={() => onChange('buy')}
       />
       <Option
+        ref={sellRef}
         side="sell"
         label="[ SELL ]"
         active={value === 'sell'}

--- a/front/app/app/trade/_components/entry/OrderEntry.a11y.test.tsx
+++ b/front/app/app/trade/_components/entry/OrderEntry.a11y.test.tsx
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+
+// Automated axe-core scan of the order-entry panel (#80) in its
+// disconnected and connected states. See front/test/axe.ts for scope.
+
+import * as React from 'react'
+import { afterEach, describe, it, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+
+import { walletStore } from '@/lib/wallet/mock-store'
+import { expectNoAxeViolations } from '@/test/axe'
+
+// useRealSubmission requires DarkPoolClientProvider + a Web Worker. Tests
+// run with NEXT_PUBLIC_USE_MOCKS='true' so the real path is never taken —
+// stub it out (same as OrderEntry.test.tsx).
+vi.mock('../../_hooks/entry/useRealSubmission', () => ({
+  useRealSubmission: () => ({
+    buildSteps: () => [],
+    provingPct: null,
+  }),
+}))
+
+import { OrderEntry } from './OrderEntry'
+
+describe('OrderEntry a11y', () => {
+  afterEach(() => {
+    walletStore.disconnect()
+    cleanup()
+  })
+
+  it('has no axe violations when disconnected', async () => {
+    render(<OrderEntry />)
+    await expectNoAxeViolations()
+  })
+
+  it('has no axe violations when connected', async () => {
+    walletStore.connect()
+    render(<OrderEntry />)
+    await expectNoAxeViolations()
+  })
+})

--- a/front/app/app/trade/_components/entry/ProveSubmitStages.test.tsx
+++ b/front/app/app/trade/_components/entry/ProveSubmitStages.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+// Locks the PlaceButton announcement contract (#80): the visible label
+// ticks every 100 ms with elapsed seconds during the 5–30 s proving
+// stage, so it must NOT be a live region. The single sr-only
+// role="status" announces stage transitions only (no timer), and errors
+// stay out of it — <SubmitError>'s role="alert" owns those.
+
+import * as React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import type { SubmissionPhase } from '../../_hooks/entry/useSubmitStages'
+import { PlaceButton, SubmitError } from './ProveSubmitStages'
+
+function renderButton(phase: SubmissionPhase, now = () => 1_700_000_000_000) {
+  return render(
+    <PlaceButton idleLabel="BUY · WETH" phase={phase} onClick={() => {}} accent={false} now={now} />
+  )
+}
+
+const proving = (startedAtMs?: number): SubmissionPhase => ({
+  kind: 'running',
+  stage: 'proving',
+  progress: 0.4,
+  stageStartedAtMs: startedAtMs,
+})
+
+describe('PlaceButton announcements', () => {
+  afterEach(cleanup)
+
+  it('keeps aria-live off the button (its label ticks every 100ms)', () => {
+    const { container } = renderButton(proving(1_700_000_000_000))
+    const button = container.querySelector('button')
+    expect(button?.getAttribute('aria-live')).toBeNull()
+    expect(button?.getAttribute('aria-busy')).toBe('true')
+  })
+
+  it('announces the stage without the elapsed timer', () => {
+    renderButton(proving(1_699_999_990_000), () => 1_700_000_000_000)
+    // Visible label carries the timer; the live region must not.
+    expect(screen.getByRole('button').textContent).toContain('10.0s')
+    const status = screen.getByRole('status')
+    expect(status.textContent).toContain('GENERATING PROOF')
+    expect(status.textContent).not.toMatch(/\d+\.\ds/)
+  })
+
+  it('does not change the announcement as elapsed time advances', () => {
+    const { rerender } = renderButton(proving(1_699_999_990_000), () => 1_700_000_000_000)
+    const before = screen.getByRole('status').textContent
+    rerender(
+      <PlaceButton
+        idleLabel="BUY · WETH"
+        phase={proving(1_699_999_990_000)}
+        onClick={() => {}}
+        accent={false}
+        now={() => 1_700_000_005_000}
+      />
+    )
+    expect(screen.getByRole('status').textContent).toBe(before)
+  })
+
+  it('announces success and stays silent when idle', () => {
+    const { rerender } = renderButton({ kind: 'idle' })
+    expect(screen.getByRole('status').textContent).toBe('')
+    rerender(
+      <PlaceButton
+        idleLabel="BUY · WETH"
+        phase={{ kind: 'success' }}
+        onClick={() => {}}
+        accent={false}
+      />
+    )
+    expect(screen.getByRole('status').textContent).toBe('ORDER PLACED')
+  })
+
+  it('leaves error announcements to SubmitError role="alert"', () => {
+    renderButton({ kind: 'error', message: 'Order rejected' })
+    expect(screen.getByRole('status').textContent).toBe('')
+
+    render(<SubmitError phase={{ kind: 'error', message: 'Order rejected' }} />)
+    expect(screen.getByRole('alert').textContent).toContain('Order rejected')
+  })
+})

--- a/front/app/app/trade/_components/entry/ProveSubmitStages.tsx
+++ b/front/app/app/trade/_components/entry/ProveSubmitStages.tsx
@@ -55,14 +55,29 @@ export function PlaceButton({
   const isRunning = phase.kind === 'running'
   const showSuccess = phase.kind === 'success'
 
+  // Screen-reader announcements (#80): the visible button label re-renders
+  // every 100 ms with elapsed seconds — aria-live on the button would spam
+  // screen readers through the whole 5–30 s proving stage. Instead an
+  // sr-only role="status" region announces only stage TRANSITIONS (label
+  // without the timer). Errors are announced by <SubmitError>'s
+  // role="alert" — keep them out of this region to avoid double-speak.
+  const announcement =
+    phase.kind === 'running'
+      ? `${STAGE_LABELS[phase.stage]} …`
+      : phase.kind === 'success'
+        ? 'ORDER PLACED'
+        : ''
+
   return (
     <div className="flex flex-col">
+      <span role="status" aria-atomic="true" className="sr-only">
+        {announcement}
+      </span>
       <button
         type="button"
         onClick={onClick}
         disabled={disabled || isRunning}
         aria-busy={isRunning || undefined}
-        aria-live="polite"
         className={cn(
           'relative flex h-12 items-center justify-center px-8',
           'font-mono uppercase tracking-[0.15em] text-[11px] font-medium leading-none',

--- a/front/app/app/trade/_components/entry/ProveSubmitStages.tsx
+++ b/front/app/app/trade/_components/entry/ProveSubmitStages.tsx
@@ -61,9 +61,10 @@ export function PlaceButton({
   // sr-only role="status" region announces only stage TRANSITIONS (label
   // without the timer). Errors are announced by <SubmitError>'s
   // role="alert" — keep them out of this region to avoid double-speak.
+  // No trailing ellipsis — some screen readers verbalize it.
   const announcement =
     phase.kind === 'running'
-      ? `${STAGE_LABELS[phase.stage]} …`
+      ? STAGE_LABELS[phase.stage]
       : phase.kind === 'success'
         ? 'ORDER PLACED'
         : ''

--- a/front/app/app/trade/_components/entry/ProveSubmitStages.tsx
+++ b/front/app/app/trade/_components/entry/ProveSubmitStages.tsx
@@ -129,17 +129,20 @@ function ProgressBar({
   const width = progressWidth(phase, success, provingPct)
   const visible = phase.kind === 'running' || success
   return (
+    // State-driven movement, not a hover affordance — both transitions
+    // freeze under prefers-reduced-motion per the DESIGN.md motion
+    // contract (#80); the bar still snaps to each stage's width.
     <div
       aria-hidden
       className={cn(
         'h-[2px] w-full overflow-hidden bg-brand-border/0',
-        'transition-opacity duration-150',
+        'transition-opacity duration-150 motion-reduce:transition-none',
         visible ? 'opacity-100' : 'opacity-0'
       )}
     >
       <div
         data-testid="place-progress"
-        className="h-full bg-brand-accent transition-[width] duration-150 ease-out"
+        className="h-full bg-brand-accent transition-[width] duration-150 ease-out motion-reduce:transition-none"
         style={{ width: `${(width * 100).toFixed(2)}%` }}
       />
     </div>

--- a/front/app/app/trade/_components/my-orders/MyOrdersPanel.a11y.test.tsx
+++ b/front/app/app/trade/_components/my-orders/MyOrdersPanel.a11y.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+
+// Automated axe-core scan of the My Orders panel (#80) across its three
+// states. See front/test/axe.ts for the rule scope.
+
+import { create } from '@bufbuild/protobuf'
+import * as React from 'react'
+import { afterEach, describe, it } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+
+import { OrderInfoSchema, Side } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import type { OrderInfo } from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import { walletStore } from '@/lib/wallet/mock-store'
+import { expectNoAxeViolations } from '@/test/axe'
+
+import type { UseMyOrdersReturn } from '../../_hooks/my-orders/useMyOrders'
+import type { MyOrderRow } from '../../_lib/my-orders/types'
+import { MyOrdersPanel } from './MyOrdersPanel'
+
+function mkOrder(overrides: Partial<OrderInfo> = {}): OrderInfo {
+  return create(OrderInfoSchema, {
+    id: 'o-1',
+    pair: 'ETH/USDC',
+    side: Side.BUY,
+    price: '3000',
+    size: '1',
+    remainingSize: '1',
+    commitmentKey: 'mock-k',
+    submittedAtUnix: 1700000000n,
+    expiresAtUnix: 0n,
+    ...overrides,
+  })
+}
+
+function stubHook(rows: MyOrderRow[]): () => UseMyOrdersReturn {
+  return () => ({
+    rows,
+    userPrices: new Set(rows.filter((r) => r.status === 'open').map((r) => r.order.price)),
+    cancel: () => true,
+  })
+}
+
+describe('MyOrdersPanel a11y', () => {
+  afterEach(() => {
+    walletStore.disconnect()
+    cleanup()
+  })
+
+  it('has no axe violations when disconnected', async () => {
+    render(<MyOrdersPanel useOrders={stubHook([])} />)
+    await expectNoAxeViolations()
+  })
+
+  it('has no axe violations with no orders', async () => {
+    walletStore.connect()
+    render(<MyOrdersPanel useOrders={stubHook([])} />)
+    await expectNoAxeViolations()
+  })
+
+  it('has no axe violations with open, filled and cancelled rows', async () => {
+    walletStore.connect()
+    render(
+      <MyOrdersPanel
+        useOrders={stubHook([
+          { order: mkOrder({ id: 'o-open' }), status: 'open' },
+          {
+            order: mkOrder({ id: 'o-filled', side: Side.SELL, remainingSize: '0' }),
+            status: 'filled',
+          },
+          { order: mkOrder({ id: 'o-cancelled' }), status: 'cancelled' },
+        ])}
+      />
+    )
+    await expectNoAxeViolations()
+  })
+})

--- a/front/app/app/trade/_components/my-orders/MyOrdersPanel.tsx
+++ b/front/app/app/trade/_components/my-orders/MyOrdersPanel.tsx
@@ -90,24 +90,28 @@ export function MyOrdersPanel({ useOrders = useMyOrders }: MyOrdersPanelProps = 
         <MyOrdersEmpty />
       ) : (
         // Complete ARIA table tree (table > rowgroup > row > cell) — an
-        // orphan row/rowgroup is an axe critical violation (#80).
-        <div
-          role="table"
-          aria-labelledby={headerId}
-          className="flex flex-1 flex-col overflow-y-auto"
-        >
-          <div role="rowgroup">
-            <ColumnHeader />
-          </div>
-          <div role="rowgroup">
-            {rows.map((row) => (
-              <OrderRow
-                key={row.order.id}
-                row={row}
-                link={links.get(row.order.id) ?? null}
-                onCancel={handleCancel}
-              />
-            ))}
+        // orphan row/rowgroup is an axe critical violation (#80). The
+        // horizontal scroll wrapper keeps the six fixed-ish columns
+        // (~34rem) from crushing each other below ~544px viewports.
+        <div className="flex flex-1 flex-col overflow-x-auto overflow-y-auto">
+          <div
+            role="table"
+            aria-labelledby={headerId}
+            className="flex min-w-[34rem] flex-1 flex-col"
+          >
+            <div role="rowgroup">
+              <ColumnHeader />
+            </div>
+            <div role="rowgroup">
+              {rows.map((row) => (
+                <OrderRow
+                  key={row.order.id}
+                  row={row}
+                  link={links.get(row.order.id) ?? null}
+                  onCancel={handleCancel}
+                />
+              ))}
+            </div>
           </div>
         </div>
       )}

--- a/front/app/app/trade/_components/my-orders/MyOrdersPanel.tsx
+++ b/front/app/app/trade/_components/my-orders/MyOrdersPanel.tsx
@@ -89,8 +89,16 @@ export function MyOrdersPanel({ useOrders = useMyOrders }: MyOrdersPanelProps = 
       ) : rows.length === 0 ? (
         <MyOrdersEmpty />
       ) : (
-        <div className="flex flex-1 flex-col overflow-y-auto">
-          <ColumnHeader />
+        // Complete ARIA table tree (table > rowgroup > row > cell) — an
+        // orphan row/rowgroup is an axe critical violation (#80).
+        <div
+          role="table"
+          aria-labelledby={headerId}
+          className="flex flex-1 flex-col overflow-y-auto"
+        >
+          <div role="rowgroup">
+            <ColumnHeader />
+          </div>
           <div role="rowgroup">
             {rows.map((row) => (
               <OrderRow
@@ -126,12 +134,16 @@ function ColumnHeader(): JSX.Element {
       role="row"
       className="grid grid-cols-[4.5rem_3.5rem_minmax(0,1fr)_minmax(0,1fr)_6rem_7.5rem] gap-3 border-b border-brand-border bg-brand-surface px-4 py-2 font-mono text-label-md uppercase tracking-labelWide text-brand-muted"
     >
-      <span>TIME</span>
-      <span>SIDE</span>
-      <span className="text-right">PRICE</span>
-      <span className="text-right">SIZE</span>
-      <span>STATUS</span>
-      <span className="text-right">
+      <span role="columnheader">TIME</span>
+      <span role="columnheader">SIDE</span>
+      <span role="columnheader" className="text-right">
+        PRICE
+      </span>
+      <span role="columnheader" className="text-right">
+        SIZE
+      </span>
+      <span role="columnheader">STATUS</span>
+      <span role="columnheader" className="text-right">
         {/* visually blank: the column holds the cancel action, or the
             settlement tx once a filled row links (#100) */}
         <span className="sr-only">Action / settlement transaction</span>

--- a/front/app/app/trade/_components/my-orders/MyOrdersPanel.tsx
+++ b/front/app/app/trade/_components/my-orders/MyOrdersPanel.tsx
@@ -92,8 +92,15 @@ export function MyOrdersPanel({ useOrders = useMyOrders }: MyOrdersPanelProps = 
         // Complete ARIA table tree (table > rowgroup > row > cell) — an
         // orphan row/rowgroup is an axe critical violation (#80). The
         // horizontal scroll wrapper keeps the six fixed-ish columns
-        // (~34rem) from crushing each other below ~544px viewports.
-        <div className="flex flex-1 flex-col overflow-x-auto overflow-y-auto">
+        // (~34rem) from crushing each other below ~544px viewports;
+        // tabIndex + region keep it keyboard-scrollable (WCAG 2.1.1) even
+        // when every row's cancel button is disabled.
+        <div
+          tabIndex={0}
+          role="region"
+          aria-label="My orders table"
+          className="flex flex-1 flex-col overflow-x-auto overflow-y-auto focus:outline-none focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-[-2px] focus-visible:outline-brand-accent"
+        >
           <div
             role="table"
             aria-labelledby={headerId}

--- a/front/app/app/trade/_components/my-orders/OrderRow.tsx
+++ b/front/app/app/trade/_components/my-orders/OrderRow.tsx
@@ -43,21 +43,30 @@ export function OrderRow({ row, link = null, onCancel }: OrderRowProps): JSX.Ele
         status !== 'open' ? 'opacity-60' : ''
       }`}
     >
-      <span className="uppercase tracking-label text-brand-muted">
+      <span role="cell" className="uppercase tracking-label text-brand-muted">
         {formatSubmittedAt(order.submittedAtUnix)}
       </span>
-      <span className="uppercase tracking-label text-brand-fg">{sideLabel(order.side)}</span>
-      <NumericText value={order.price} kind="price" align="right" className="text-brand-fg" />
+      <span role="cell" className="uppercase tracking-label text-brand-fg">
+        {sideLabel(order.side)}
+      </span>
       <NumericText
+        role="cell"
+        value={order.price}
+        kind="price"
+        align="right"
+        className="text-brand-fg"
+      />
+      <NumericText
+        role="cell"
         value={order.remainingSize}
         kind="size"
         align="right"
         className="text-brand-fg"
       />
-      <span className="flex justify-start">
+      <span role="cell" className="flex justify-start">
         <StatusPill status={status} />
       </span>
-      <div className="flex justify-end">
+      <div role="cell" className="flex justify-end">
         {settled ? (
           <SettlementCell link={settled} />
         ) : (

--- a/front/app/app/trade/_components/orderbook/OrderBook.a11y.test.tsx
+++ b/front/app/app/trade/_components/orderbook/OrderBook.a11y.test.tsx
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+// Automated axe-core scan of the orderbook panel (#80). Renders against a
+// stub client returning a populated book (the OrderBook.stories.tsx
+// pattern) and waits for the depth tables before scanning.
+
+import { create } from '@bufbuild/protobuf'
+import * as React from 'react'
+import { afterEach, describe, it } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+
+import type { DarkPoolClient } from '@/lib/sdk/client'
+import { createFactoryContext, mockAuctionSummary, mockOrderBook } from '@/lib/sdk/mocks'
+import { DarkPoolClientProvider } from '@/lib/sdk/provider'
+import {
+  CancelOrderResponseSchema,
+  GetAuctionHistoryResponseSchema,
+  GetOrderResponseSchema,
+  OrderInfoSchema,
+  PlaceOrderResponseSchema,
+} from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import { expectNoAxeViolations } from '@/test/axe'
+
+import { OrderBook } from './OrderBook'
+
+function buildClient(): DarkPoolClient {
+  const ctx = createFactoryContext({ seed: 7 })
+  const book = mockOrderBook(ctx, { depth: 6 })
+  const auctions = [
+    mockAuctionSummary(ctx, { clearingPrice: '2418.10', timestampUnix: 1700000010n }),
+    mockAuctionSummary(ctx, { clearingPrice: '2405.76', timestampUnix: 1700000005n }),
+  ]
+  return {
+    async placeOrder() {
+      return create(PlaceOrderResponseSchema, { order: create(OrderInfoSchema, {}) })
+    },
+    async cancelOrder() {
+      return create(CancelOrderResponseSchema, {})
+    },
+    async getOrder() {
+      return create(GetOrderResponseSchema, { order: create(OrderInfoSchema, {}) })
+    },
+    async getOrderBook() {
+      return book
+    },
+    async getAuctionHistory() {
+      return create(GetAuctionHistoryResponseSchema, { auctions })
+    },
+    async *streamAuctions() {
+      // Empty stream.
+    },
+  }
+}
+
+describe('OrderBook a11y', () => {
+  afterEach(cleanup)
+
+  it('has no axe violations with a populated depth table', async () => {
+    render(
+      <DarkPoolClientProvider client={buildClient()}>
+        <OrderBook refetchIntervalMs={3_600_000} />
+      </DarkPoolClientProvider>
+    )
+    await waitFor(() => {
+      if (!screen.queryByText('[ BIDS ]')) throw new Error('depth table not loaded yet')
+    })
+    await expectNoAxeViolations()
+  })
+})

--- a/front/app/app/trade/_components/orderbook/OrderBook.tsx
+++ b/front/app/app/trade/_components/orderbook/OrderBook.tsx
@@ -152,9 +152,12 @@ export function OrderBookContent({
 }
 
 function ColumnHeader() {
+  // Visual column guide only — not an ARIA table. An orphan role="row"
+  // (no table/rowgroup ancestor) is an axe violation; depth rows carry
+  // their own aria-labels inside the DepthTable lists (#80).
   return (
     <div
-      role="row"
+      aria-hidden="true"
       className="grid grid-cols-3 gap-2 border-b border-brand-border px-4 py-2 font-mono text-label-md uppercase text-brand-muted"
     >
       <span className="text-left">Price</span>

--- a/front/app/app/trade/_components/orderbook/OrderBook.tsx
+++ b/front/app/app/trade/_components/orderbook/OrderBook.tsx
@@ -152,14 +152,12 @@ export function OrderBookContent({
 }
 
 function ColumnHeader() {
-  // Visual column guide only — not an ARIA table. An orphan role="row"
-  // (no table/rowgroup ancestor) is an axe violation; depth rows carry
-  // their own aria-labels inside the DepthTable lists (#80).
+  // Visual column guide, not an ARIA table — an orphan role="row" (no
+  // table/rowgroup ancestor) is an axe violation (#80). The text stays
+  // readable (no aria-hidden): non-clickable depth rows are bare numbers,
+  // so this line is the only column context assistive tech gets.
   return (
-    <div
-      aria-hidden="true"
-      className="grid grid-cols-3 gap-2 border-b border-brand-border px-4 py-2 font-mono text-label-md uppercase text-brand-muted"
-    >
+    <div className="grid grid-cols-3 gap-2 border-b border-brand-border px-4 py-2 font-mono text-label-md uppercase text-brand-muted">
       <span className="text-left">Price</span>
       <span className="text-right">Size</span>
       <span className="text-right">Total</span>

--- a/front/app/app/trade/_components/tape/Countdown.test.tsx
+++ b/front/app/app/trade/_components/tape/Countdown.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment jsdom
+
+// Locks the Countdown live-region contract (#80): the per-second tick is
+// NOT announced (no aria-live on the visible bar); the single sr-only
+// role="status" region only changes on meaningful transitions (waiting →
+// counting, LIVE ↔ DELAYED). A regression here means screen readers get
+// spammed every second — do not loosen these assertions.
+
+import * as React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { Countdown } from './Countdown'
+
+describe('Countdown live region', () => {
+  afterEach(cleanup)
+
+  it('keeps aria-live off the ticking label', () => {
+    const { container } = render(
+      <Countdown latestAuctionUnixSeconds={1_700_000_000n} nowUnixSeconds={1_700_000_002} />
+    )
+    const live = container.querySelectorAll('[aria-live], [role="status"]')
+    expect(live).toHaveLength(1)
+    expect(live[0].className).toContain('sr-only')
+  })
+
+  it('does not change the announcement between second ticks', () => {
+    const { rerender } = render(
+      <Countdown
+        latestAuctionUnixSeconds={1_700_000_000n}
+        nowUnixSeconds={1_700_000_001}
+        status="live"
+      />
+    )
+    const before = screen.getByRole('status').textContent
+    rerender(
+      <Countdown
+        latestAuctionUnixSeconds={1_700_000_000n}
+        nowUnixSeconds={1_700_000_002}
+        status="live"
+      />
+    )
+    expect(screen.getByRole('status').textContent).toBe(before)
+  })
+
+  it('changes the announcement when the feed degrades', () => {
+    const { rerender } = render(
+      <Countdown
+        latestAuctionUnixSeconds={1_700_000_000n}
+        nowUnixSeconds={1_700_000_001}
+        status="live"
+      />
+    )
+    const before = screen.getByRole('status').textContent
+    rerender(
+      <Countdown
+        latestAuctionUnixSeconds={1_700_000_000n}
+        nowUnixSeconds={1_700_000_001}
+        status="degraded"
+      />
+    )
+    expect(screen.getByRole('status').textContent).not.toBe(before)
+    expect(screen.getByRole('status').textContent).toContain('delayed')
+  })
+
+  it('changes the announcement when the first auction lands', () => {
+    const { rerender } = render(
+      <Countdown latestAuctionUnixSeconds={null} nowUnixSeconds={1_700_000_001} />
+    )
+    expect(screen.getByRole('status').textContent).toContain('Waiting')
+    rerender(<Countdown latestAuctionUnixSeconds={1_700_000_000n} nowUnixSeconds={1_700_000_001} />)
+    expect(screen.getByRole('status').textContent).toContain('countdown running')
+  })
+
+  it('keeps the visible label readable on demand (not aria-hidden)', () => {
+    render(<Countdown latestAuctionUnixSeconds={1_700_000_000n} nowUnixSeconds={1_700_000_002} />)
+    const label = screen.getByText(/NEXT AUCTION IN/)
+    expect(label.closest('[aria-hidden="true"]')).toBeNull()
+  })
+})

--- a/front/app/app/trade/_components/tape/Countdown.tsx
+++ b/front/app/app/trade/_components/tape/Countdown.tsx
@@ -31,15 +31,26 @@ export function Countdown({
         secondsToNextAuction(latestAuctionUnixSeconds, nowUnixSeconds, intervalSeconds)
       )} ]`
 
+  // The visible label re-renders every second — putting aria-live on it
+  // would make screen readers announce the tick continuously (#80). The
+  // bar stays readable on demand (no aria-hidden); the SINGLE live region
+  // is the sr-only status below, whose text only changes on meaningful
+  // transitions (waiting → counting, LIVE ↔ DELAYED). StreamStatus stays
+  // presentational — do not add a nested live region there.
+  const announcement = `${waiting ? 'Waiting for first auction' : 'Auction countdown running'}${
+    status ? `. Feed ${status === 'live' ? 'live' : 'delayed'}` : ''
+  }`
+
   return (
     <div
-      aria-live="polite"
-      aria-atomic="true"
       className={`relative flex h-9 items-center justify-center border-b border-brand-border bg-brand-bg px-4 font-mono text-label-lg uppercase tracking-label ${
         waiting ? 'text-brand-muted' : 'text-brand-accent'
       }`}
     >
       {label}
+      <span role="status" aria-atomic="true" className="sr-only">
+        {announcement}
+      </span>
       {status ? (
         <span className="absolute right-3 top-1/2 -translate-y-1/2">
           <StreamStatus status={status} />

--- a/front/app/app/trade/_components/tape/StreamStatus.tsx
+++ b/front/app/app/trade/_components/tape/StreamStatus.tsx
@@ -33,8 +33,9 @@ export interface StreamStatusProps {
 }
 
 export function StreamStatus({ status }: StreamStatusProps): JSX.Element {
-  // No aria-live here: the single mount point (Countdown) already wraps this
-  // badge in a polite live region — nesting another would double-announce.
+  // No aria-live here: the single mount point (Countdown) owns the one
+  // live region (an sr-only role="status" announcing LIVE/DELAYED
+  // transitions) — nesting another would double-announce.
   return (
     <span className="inline-flex items-center gap-2 font-mono text-body-sm">
       <span className={PILL[status]} aria-hidden="true" />

--- a/front/app/app/trade/_components/tape/Tape.a11y.test.tsx
+++ b/front/app/app/trade/_components/tape/Tape.a11y.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+
+// Automated axe-core scan of the auction tape (#80): populated list with
+// the LIVE badge, and the auction drawer open (Radix portal → scan the
+// whole document). See front/test/axe.ts for the rule scope.
+
+import { create } from '@bufbuild/protobuf'
+import * as React from 'react'
+import { afterEach, describe, it, vi } from 'vitest'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+
+vi.mock('@/lib/config', () => ({
+  config: { useMocks: true, contracts: null, chainId: 31337, siweEnabled: false },
+}))
+
+import type { DarkPoolClient } from '@/lib/sdk/client'
+import { DarkPoolClientProvider } from '@/lib/sdk/provider'
+import {
+  AuctionSummarySchema,
+  GetAuctionHistoryResponseSchema,
+} from '@/lib/sdk/proto/darkpool/v1/darkpool_pb'
+import { expectNoAxeViolations } from '@/test/axe'
+
+import { Tape } from './Tape'
+import { TapeDrawer } from './TapeDrawer'
+
+const TX = '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'
+
+function auction(id: string, ts: bigint) {
+  return create(AuctionSummarySchema, {
+    auctionId: id,
+    pair: 'ETH/USDC',
+    clearingPrice: '3000.12',
+    matchedVolume: '12.5',
+    matchCount: 4,
+    timestampUnix: ts,
+  })
+}
+
+function fakeClient(): DarkPoolClient {
+  const history = create(GetAuctionHistoryResponseSchema, {
+    auctions: [auction('a-2', 1_700_000_005n), auction('a-1', 1_700_000_000n)],
+  })
+  return {
+    placeOrder: vi.fn(),
+    cancelOrder: vi.fn(),
+    getOrder: vi.fn(),
+    getOrderBook: vi.fn(),
+    getAuctionHistory: async () => history,
+    streamAuctions: () =>
+      (async function* () {
+        await new Promise(() => {}) // hold the stream open → status "live"
+      })(),
+  } as unknown as DarkPoolClient
+}
+
+describe('Tape a11y', () => {
+  afterEach(cleanup)
+
+  it('has no axe violations with a populated tape', async () => {
+    render(
+      <DarkPoolClientProvider client={fakeClient()}>
+        <Tape refetchIntervalMs={3_600_000} />
+      </DarkPoolClientProvider>
+    )
+    await waitFor(() => {
+      if (screen.queryAllByText(/3,?000\.12/).length === 0) {
+        throw new Error('tape rows not loaded yet')
+      }
+    })
+    await expectNoAxeViolations()
+  })
+
+  it('has no axe violations with the auction drawer open', async () => {
+    render(
+      <TapeDrawer
+        auction={auction('a-1', 1_700_000_000n)}
+        link={{ txHash: TX, url: `https://arbiscan.io/tx/${TX}` }}
+        onClose={() => {}}
+      />
+    )
+    await expectNoAxeViolations()
+  })
+})

--- a/front/components/ui/dialog.tsx
+++ b/front/components/ui/dialog.tsx
@@ -19,6 +19,7 @@ const DialogOverlay = React.forwardRef<
     className={cn(
       'fixed inset-0 z-50 bg-[rgba(6,6,10,0.85)]',
       'data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out',
+      'motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none',
       className
     )}
     {...props}
@@ -38,6 +39,7 @@ const DialogContent = React.forwardRef<
         'fixed left-1/2 top-1/2 z-50 -translate-x-1/2 -translate-y-1/2',
         'w-full max-w-lg bg-brand-surface text-brand-fg p-8',
         'data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out',
+        'motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none',
         'focus:outline-none',
         className
       )}

--- a/front/components/ui/motion-reduce.test.tsx
+++ b/front/components/ui/motion-reduce.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+
+// Locks the prefers-reduced-motion contract on the shared primitives
+// (#80): every Radix entrance/exit animation carries a motion-reduce
+// variant matching the data-[state] selector's specificity (a bare
+// `motion-reduce:animate-none` loses the cascade against
+// `data-[state=open]:animate-*`). Pattern reference: StatusPill /
+// skeleton use plain `animate-* motion-reduce:animate-none`.
+
+import * as React from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from './dialog'
+import { Sheet, SheetContent, SheetTitle } from './sheet'
+import { Toast, ToastProvider, ToastViewport } from './toast'
+import { PlaceButton } from '@/app/app/trade/_components/entry/ProveSubmitStages'
+
+describe('reduced-motion variants on shared primitives', () => {
+  afterEach(cleanup)
+
+  it('dialog overlay and content freeze under reduced motion', () => {
+    render(
+      <Dialog open>
+        <DialogContent>
+          <DialogTitle>T</DialogTitle>
+          <DialogDescription>D</DialogDescription>
+        </DialogContent>
+      </Dialog>
+    )
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.className).toContain('motion-reduce:data-[state=open]:animate-none')
+    const overlay = document.querySelector('[class*="fixed inset-0"]')
+    expect(overlay?.className).toContain('motion-reduce:data-[state=open]:animate-none')
+  })
+
+  it('sheet content freezes under reduced motion', () => {
+    render(
+      <Sheet open>
+        <SheetContent>
+          <SheetTitle>T</SheetTitle>
+        </SheetContent>
+      </Sheet>
+    )
+    expect(screen.getByRole('dialog').className).toContain(
+      'motion-reduce:data-[state=open]:animate-none'
+    )
+  })
+
+  it('toast freezes under reduced motion', () => {
+    const { container } = render(
+      <ToastProvider>
+        <Toast open>t</Toast>
+        <ToastViewport />
+      </ToastProvider>
+    )
+    // The toast root is the <li data-state="open"> inside the viewport
+    // (role="status" lands on Radix's internal announce region instead).
+    const root = container.querySelector('li[data-state]')
+    expect(root?.className).toContain('motion-reduce:data-[state=open]:animate-none')
+    expect(root?.className).toContain('motion-reduce:data-[swipe=end]:animate-none')
+  })
+
+  it('place-button progress bar freezes under reduced motion', () => {
+    render(
+      <PlaceButton
+        idleLabel="BUY · WETH"
+        phase={{ kind: 'running', stage: 'proving', progress: 0.4 }}
+        onClick={() => {}}
+        accent={false}
+      />
+    )
+    const bar = screen.getByTestId('place-progress')
+    expect(bar.className).toContain('motion-reduce:transition-none')
+    expect(bar.parentElement?.className).toContain('motion-reduce:transition-none')
+  })
+})

--- a/front/components/ui/sheet.tsx
+++ b/front/components/ui/sheet.tsx
@@ -20,6 +20,7 @@ const SheetOverlay = React.forwardRef<
     className={cn(
       'fixed inset-0 z-50 bg-[rgba(6,6,10,0.85)]',
       'data-[state=open]:animate-fade-in data-[state=closed]:animate-fade-out',
+      'motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none',
       className
     )}
     {...props}
@@ -28,7 +29,13 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName
 
 const sheetVariants = cva(
-  cn('fixed z-50 bg-brand-surface text-brand-fg p-8', 'focus:outline-none'),
+  cn(
+    'fixed z-50 bg-brand-surface text-brand-fg p-8',
+    'focus:outline-none',
+    // DESIGN.md motion contract: entrance/exit animations skip to their
+    // final state under prefers-reduced-motion (#80).
+    'motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none'
+  ),
   {
     variants: {
       side: {

--- a/front/components/ui/toast.tsx
+++ b/front/components/ui/toast.tsx
@@ -29,7 +29,11 @@ const toastVariants = cva(
     'bg-brand-surface border border-brand-border text-brand-fg',
     'data-[state=open]:animate-slide-in-right',
     'data-[state=closed]:animate-fade-out',
-    'data-[swipe=end]:animate-fade-out'
+    'data-[swipe=end]:animate-fade-out',
+    // DESIGN.md motion contract: entrance/exit animations skip to their
+    // final state under prefers-reduced-motion (#80).
+    'motion-reduce:data-[state=open]:animate-none motion-reduce:data-[state=closed]:animate-none',
+    'motion-reduce:data-[swipe=end]:animate-none'
   ),
   {
     variants: {

--- a/front/components/ui/tooltip.tsx
+++ b/front/components/ui/tooltip.tsx
@@ -20,6 +20,7 @@ const TooltipContent = React.forwardRef<
       'z-50 overflow-hidden bg-brand-bg border border-brand-border px-2 py-1',
       'font-mono text-[11px] leading-[1.4] tracking-[0.15em] uppercase text-brand-fg',
       'data-[state=delayed-open]:animate-fade-in data-[state=closed]:animate-fade-out',
+      'motion-reduce:data-[state=delayed-open]:animate-none motion-reduce:data-[state=closed]:animate-none',
       className
     )}
     {...props}

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -51,6 +51,7 @@
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "@wagmi/cli": "^2.10.0",
+        "axe-core": "^4.12.0",
         "eslint": "^8",
         "eslint-config-next": "14.2.35",
         "eslint-config-prettier": "^9.1.0",
@@ -10568,9 +10569,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.4",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
-      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.0.tgz",
+      "integrity": "sha512-FTavr/7Ba0IptwGOPxnQvdyW2tAsdLBMTBXz7rKH6xJ2skpyxpBxyHkDdBs4lf69yRqYpkqCdfhnwS8YULGOmg==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {

--- a/front/package.json
+++ b/front/package.json
@@ -61,6 +61,7 @@
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@wagmi/cli": "^2.10.0",
+    "axe-core": "^4.12.0",
     "eslint": "^8",
     "eslint-config-next": "14.2.35",
     "eslint-config-prettier": "^9.1.0",

--- a/front/test/axe.ts
+++ b/front/test/axe.ts
@@ -1,0 +1,43 @@
+import * as axe from 'axe-core'
+
+// WCAG 2.0/2.1 A + AA — the bar issue #80 sets for /trade and /portfolio.
+// Best-practice-only rules (region, landmark-unique, …) are excluded on
+// purpose: panels render as fragments in tests and would false-positive.
+const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa']
+
+/**
+ * Run axe against a node and throw a readable report when violations exist.
+ *
+ * Defaults to the whole `document` so Radix portals (Dialog, Sheet, Toast)
+ * mounted on `document.body` are included in the scan.
+ *
+ * `color-contrast` is disabled because jsdom has no layout engine, so axe
+ * cannot resolve computed colors here. Contrast is covered by the manual
+ * review tracked in issue #80 (DESIGN.md already regulates `brand-muted`).
+ *
+ * Note: axe-core errors if two runs overlap on one document — always
+ * `await` each call before starting the next.
+ */
+export async function expectNoAxeViolations(node: Element | Document = document): Promise<void> {
+  const results = await axe.run(node, {
+    runOnly: { type: 'tag', values: WCAG_TAGS },
+    rules: {
+      'color-contrast': { enabled: false },
+      // jsdom test documents have no <title>/lang — the real app sets both
+      // via the root layout (`<html lang="en">` + Next metadata). Pure
+      // environment artifacts, not app violations.
+      'document-title': { enabled: false },
+      'html-has-lang': { enabled: false },
+    },
+  })
+  if (results.violations.length === 0) return
+  const report = results.violations
+    .map((v) =>
+      [
+        `${v.id} (${v.impact ?? 'unknown'}): ${v.help}`,
+        ...v.nodes.map((n) => `  ${n.html}\n  ${n.failureSummary ?? ''}`),
+      ].join('\n')
+    )
+    .join('\n\n')
+  throw new Error(`axe violations:\n\n${report}`)
+}


### PR DESCRIPTION
Closes #80

QA pass over every shipped trading-app surface. Surgical fixes only — no component refactors. Follow-ups that fell out of the pass are tracked in #205.

## 1. axe-core clean on /trade and /portfolio — now locked in CI

- `front/test/axe.ts`: shared `expectNoAxeViolations()` helper (axe-core, WCAG 2.0/2.1 A+AA tags, scans `document` so Radix portals are included).
- 8 new `*.a11y.test.tsx` suites colocated with the panels: Shell (incl. open mobile sheet), OrderBook, Tape + open drawer, OrderEntry, Balances, Deposit/Withdraw modals (incl. validation-error state), MyOrders (all row states), Portfolio (+ populated fill history). They run as part of `npm test`, so regressions fail CI.
- Disabled rules, each documented in the helper: `color-contrast` (jsdom has no layout engine — covered by manual review below and #205), `document-title`/`html-has-lang` (test-document artifacts; the real root layout sets both).

### Violations found and fixed
| Problem | Fix |
|---|---|
| Place button had `aria-live` while its label re-renders every 100 ms with elapsed seconds — screen readers spammed through the whole 5–30 s proving stage | sr-only `role=status` announces stage **transitions** only (no timer); errors stay with `SubmitError`'s `role=alert`; `aria-busy` kept (`ProveSubmitStages.tsx`) |
| Countdown bar announced its per-second tick (`aria-live` + `aria-atomic` on ticking text) | single sr-only `role=status` announcing waiting→counting and LIVE↔DELAYED only; visible label stays readable on demand; **no nested live region** — `StreamStatus` remains presentational, and `Countdown.test.tsx` asserts exactly one live region (`tape/Countdown.tsx`) |
| Orphan `role=row` (axe critical `aria-required-parent`) in MyOrders, fill history and orderbook column headers | MyOrders got the full ARIA table tree (`table > rowgroup > row > cell/columnheader`); fill-history header demoted to `aria-hidden` visual guide (rows carry complete aria-labels); orderbook guide keeps readable text, just no `role` |
| Deposit/withdraw amount validation errors were silent paragraphs | `role=alert` on both |
| ConnectButton hydration gate: focusable button inside `aria-hidden` wrapper (`aria-hidden-focus`) | `tabIndex=-1` while gated |

## 2. Keyboard navigation

- **Skip link** `[ SKIP TO CONTENT ]` ahead of the banner/rail chrome → `#main` (with `tabIndex=-1`); visible only on focus, brutalist styling (zero radius, 1px border, lime focus outline — same focus pattern the app already uses).
- **BuySellTabs**: ARIA tabs contract — roving tabindex (one Tab stop), ←/→ move selection with focus, Home/End, inert while disabled (`BuySellTabs.test.tsx`).
- **PairSelector**: Escape closes the disclosure and restores focus to the summary.
- **Horizontal scrollers** (fill history, my orders): `tabIndex=0` + `role=region` + label so keyboard users can scroll them when nothing focusable is inside (WCAG 2.1.1 — axe can't check this in jsdom).
- Modals/drawer were already Radix-correct (focus trap + Escape) — covered by the axe suites.

## 3. prefers-reduced-motion

- `dialog` / `sheet` / `toast` / `tooltip`: every `data-[state]` entrance/exit animation now pairs with `motion-reduce:data-[state=*]:animate-none`. The specificity-matched variant is required — a bare `motion-reduce:animate-none` loses the cascade to `data-[state=open]:animate-fade-in` (verified in built CSS during review).
- Place-button progress bar: `motion-reduce:transition-none` on the width/opacity transitions (state-driven movement, not a hover affordance).
- `components/ui/motion-reduce.test.tsx` locks the contract.
- Already compliant, untouched: `StatusPill`, `StreamStatus`, `skeleton`, `panel-state`, `tape.module.css`.

## 4. Manual layout test (Chrome, exact CSS-px viewports; 375 via same-origin iframe — WM clamps window width)

| Width | /app/trade | /app/portfolio |
|---|---|---|
| 375 | mobile stack, NEW ORDER dock, **no horizontal overflow** | no page overflow. **Fixed:** fill-history's fixed columns (10+4+9 rem) crushed the 1fr numeric columns to zero width, overlapping PRICE/SIZE/BATCH — table now scrolls horizontally behind a min-width track; same latent fix applied to MyOrders (~34 rem). Title + CSV button no longer wrap mid-bracket |
| 768 | single-column stack, no overflow | no overflow, headers spread cleanly |
| 1024 (measured 1025) | desktop 3-col grid + rail engages at `lg`, no overflow | no overflow |
| 1440 | desktop grid, no overflow | no overflow |

Skip link verified with a real Tab keypress (first stop, visibly rendered).

### Contrast (manual, since axe's color-contrast can't run in jsdom)
- `text-brand-muted/70` (below 3:1) in PairSelector/CommandPrompt raised to full `text-brand-muted`.
- Known limitation: the `brand-muted` token itself is ~3.0:1 at 10–11px label sizes vs the 4.5:1 AA threshold. DESIGN.md restricts it to ambient labels, but a real-browser axe run still flags it — that's a design-token decision tracked in #205, not silently absorbed here.

## Out of scope, tracked in #205
Unwired Shell panels (orderbook/chart/entry/tape placeholders), `brand-muted` token contrast, landing-page animations without motion-reduce, hardcoded NetworkIndicator label, depth-row label masking size/total, PairSelector listbox depth.

## Verification
`npm run typecheck` · `next lint` 0 issues · `prettier --check .` exit 0 (via `rtk proxy`, exit code checked) · `vitest run` **757 passed, 0 failed** · `next build` exit 0 · lockfile regenerated with npm 10 and validated with `npm@10 ci --dry-run` (CI runs npm 10.8.2).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced keyboard navigation with Escape key support for closing panels and arrow-key controls for tab switching
  * Improved screen reader support with status announcements, alert regions, and proper document structure
  * Added keyboard skip-to-content link for faster navigation

* **Bug Fixes**
  * Fixed text wrapping issues in export button
  * Corrected focus management during component initialization
  * Improved animations to respect user motion preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->