### PR TITLE
dp-engine: Encrypt state snapshots at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,13 @@ DARKPOOL_RATE_LIMIT=10
 DARKPOOL_RATE_BURST=20
 DARKPOOL_RATE_STALE_AFTER=10m
 DARKPOOL_OPERATOR_KEY=
+# Snapshot-at-rest encryption key URI (#203). Same schemes as the operator key
+# (file:/age:/awskms:), resolving to a dedicated 32-byte symmetric key —
+# separate from the operator ECIES identity. REQUIRED when snapshots use a
+# durable store (file/postgres); the server refuses to boot otherwise rather
+# than write plaintext orders to disk. Empty → in-memory store uses a
+# per-process ephemeral key (non-durable).
+DARKPOOL_SNAPSHOT_KEY_URI=
 # Set to /usr/local/bin/dp-aggregator under --profile zk to enable proof generation.
 DARKPOOL_AGGREGATOR_BIN=
 DARKPOOL_AGGREGATOR_TIMEOUT=30s

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -2396,6 +2397,7 @@ version = "0.1.0"
 dependencies = [
  "age",
  "alloy-primitives",
+ "chacha20poly1305",
  "dp-types",
  "ecies",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ sha2 = "0.10"
 subtle = "2"
 hex = "0.4"
 ecies = { version = "0.2", default-features = false, features = ["pure"] }
+# AEAD for snapshot-at-rest encryption (#203). Default features pull `alloc`
+# (Vec/Payload API) + `getrandom` (OsRng); already in the lock via `age`.
+chacha20poly1305 = "0.10"
 bincode = "1"
 tokio-util = { version = "0.7", features = ["rt"] }
 alloy-primitives = "1"

--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ cargo run   --release --bin darkpool-server
 --operator-key /etc/darkpool/op.key  # ECIES private key (single-key mode)
 --operator-key-uris file:/etc/dp/active.hex@active,age:/etc/dp/old.age@sunset
                                  # multi-key rotation mode (issue #28)
+--snapshot-key-uri file:/etc/dp/snapshot.hex
+                                 # dedicated key encrypting state snapshots at rest (issue #203);
+                                 # required when --snapshot-dir or a postgres store is used
 --signer-key-uri file:/etc/dp/eth.hex   # independent Ethereum signer URI
 --aggregator-bin /usr/local/bin/dp-aggregate  # proof aggregator subprocess (omit → noop)
 --eth-rpc https://...            # settlement RPC (with --signer-key-uri + --contract-addr → on-chain)
@@ -205,6 +208,9 @@ cargo run   --release --bin darkpool-server
 - [Operator key rotation](docs/operations/key-rotation.md) — runbook for
   generating, publishing, registering, draining, and deleting an
   ECIES key without restarting the operator.
+- [Snapshot encryption at rest](docs/adr/0006-snapshot-encryption-at-rest.md)
+  — why state snapshots are AEAD-sealed under a dedicated key, and how to
+  provision `--snapshot-key-uri`.
 
 ## Project structure
 

--- a/crates/dp-api/src/config.rs
+++ b/crates/dp-api/src/config.rs
@@ -162,6 +162,19 @@ pub struct Config {
     #[arg(long, env = "DARKPOOL_SNAPSHOT_RETAIN_COUNT", default_value = "3")]
     pub snapshot_retain_count: usize,
 
+    /// Key URI for snapshot-at-rest encryption (#203). Same schemes as the
+    /// operator key (`file:` / `age:` / `awskms:`), resolving to a 32-byte
+    /// symmetric key. This is a *dedicated* key, separate from the operator
+    /// ECIES identity, so its compromise cannot decrypt live orders and
+    /// rotating the operator key never strands snapshot recovery.
+    ///
+    /// Required when snapshots use a durable store (file / postgres): the boot
+    /// path refuses to start rather than write plaintext order data. The
+    /// non-durable in-memory store uses a per-process ephemeral key when this
+    /// is empty.
+    #[arg(long, env = "DARKPOOL_SNAPSHOT_KEY_URI", default_value = "")]
+    pub snapshot_key_uri: String,
+
     #[arg(long, env = "DARKPOOL_OPERATOR_KEY", default_value = "")]
     pub operator_key: String,
 
@@ -275,6 +288,10 @@ impl Config {
 
     pub fn snapshot_dir_path(&self) -> Option<&str> {
         opt(&self.snapshot_dir)
+    }
+
+    pub fn snapshot_key_uri_str(&self) -> Option<&str> {
+        opt(&self.snapshot_key_uri)
     }
 
     pub fn operator_key_path(&self) -> Option<&str> {

--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -16,6 +16,7 @@ use dp_api::rest::{self, OpsState};
 use dp_api::tls;
 use dp_crypto::{
     decrypter_from_uri, validate_key_id, EciesDecrypter, KeyEntry, KeyStatus, MultiKeyDecrypter,
+    SnapshotCipher,
 };
 use dp_engine::{Engine, PairConfig, PairStatus, SnapshotConfig};
 use dp_event::{
@@ -108,6 +109,34 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
     let engine = Engine::new(store.clone(), cfg.auction_interval);
     engine.set_snapshot_store(snapshot_store.clone());
+
+    // Snapshot-at-rest encryption (#203). A snapshot store without a cipher
+    // would persist cleartext order data (trader / price / size), so fail
+    // closed for durable backends and use a process-lifetime key for the
+    // non-durable in-memory store.
+    if snapshot_store.is_some() {
+        let cipher = if let Some(uri) = cfg.snapshot_key_uri_str() {
+            let c = SnapshotCipher::from_key_uri(uri)?;
+            info!(uri = %sanitize_uri_for_log(uri), "snapshot cipher: key loaded");
+            c
+        } else if cfg.event_db_url().is_some() || cfg.snapshot_dir_path().is_some() {
+            return Err(
+                "snapshots are enabled with a durable store but DARKPOOL_SNAPSHOT_KEY_URI \
+                 is unset — refusing to write plaintext order data at rest. Set a snapshot \
+                 key (e.g. file:/path/to/key.hex) or disable snapshots \
+                 (DARKPOOL_SNAPSHOT_ENABLED=false)."
+                    .into(),
+            );
+        } else {
+            warn!(
+                "snapshot store is in-memory and DARKPOOL_SNAPSHOT_KEY_URI is unset — using \
+                 an ephemeral per-process snapshot key. In-memory snapshots are not durable \
+                 across restarts; configure a durable store + key URI for real recovery."
+            );
+            SnapshotCipher::generate_ephemeral()
+        };
+        engine.set_snapshot_cipher(Some(Arc::new(cipher)));
+    }
 
     // Always construct a MultiKeyDecrypter and wire it to the engine
     // so admin-time rotation does not require restarting the process.

--- a/crates/dp-crypto/Cargo.toml
+++ b/crates/dp-crypto/Cargo.toml
@@ -12,6 +12,7 @@ serde_json   = { workspace = true }
 thiserror    = { workspace = true }
 hex          = { workspace = true }
 ecies        = { workspace = true }
+chacha20poly1305 = { workspace = true }
 tracing      = "0.1"
 metrics      = { workspace = true }
 parking_lot  = { workspace = true }

--- a/crates/dp-crypto/src/key_source.rs
+++ b/crates/dp-crypto/src/key_source.rs
@@ -49,29 +49,7 @@ impl KeySource {
     /// panicking, so a typo in operator config fails fast at boot.
     pub fn from_uri(uri: &str) -> Result<Self, CryptoError> {
         let uri = uri.trim();
-        let secret = if let Some(path) = uri.strip_prefix("file:") {
-            load_operator_key_file(path)?
-        } else if let Some(path) = uri.strip_prefix("age:") {
-            // Both the passphrase and the decrypted hex blob are
-            // wrapped so they are scrubbed on early-return / error
-            // paths as well as on the happy path.
-            let pass = Zeroizing::new(std::env::var("DARKPOOL_KEY_PASSPHRASE").map_err(|_| {
-                CryptoError::KeySource(
-                    "age: key URI requires DARKPOOL_KEY_PASSPHRASE env var".into(),
-                )
-            })?);
-            let mut bytes = decrypt_age_passphrase(Path::new(path), &pass)
-                .map_err(|e| CryptoError::KeySource(format!("age: {e}")))?;
-            let secret = parse_hex_secret(&bytes)?;
-            bytes.zeroize();
-            secret
-        } else if let Some(rest) = uri.strip_prefix("awskms:") {
-            decrypt_via_aws_kms(rest)?
-        } else {
-            return Err(CryptoError::KeySource(format!(
-                "unsupported key URI scheme: {uri}"
-            )));
-        };
+        let secret = resolve_secret_bytes(uri)?;
         if secret.len() != 32 {
             return Err(CryptoError::InvalidKeyFile(format!(
                 "expected 32-byte secp256k1 secret, got {}",
@@ -101,6 +79,38 @@ pub fn decrypter_from_uri(uri: &str) -> Result<Arc<dyn Decrypter>, CryptoError> 
     let source = KeySource::from_uri(uri)?;
     let dec = source.into_decrypter()?;
     Ok(Arc::new(dec))
+}
+
+/// Resolve a key URI into raw secret bytes, without imposing a length or
+/// curve interpretation. Shared by [`KeySource::from_uri`] (which then
+/// enforces the 32-byte secp256k1 contract) and the snapshot-key loader
+/// (which uses the bytes directly as a symmetric AEAD key). Keeping the
+/// `file:` / `age:` / `awskms:` dispatch in one place means a new scheme is
+/// added once and both consumers pick it up.
+pub(crate) fn resolve_secret_bytes(uri: &str) -> Result<Vec<u8>, CryptoError> {
+    let uri = uri.trim();
+    let secret = if let Some(path) = uri.strip_prefix("file:") {
+        load_operator_key_file(path)?
+    } else if let Some(path) = uri.strip_prefix("age:") {
+        // Both the passphrase and the decrypted hex blob are wrapped so
+        // they are scrubbed on early-return / error paths as well as on
+        // the happy path.
+        let pass = Zeroizing::new(std::env::var("DARKPOOL_KEY_PASSPHRASE").map_err(|_| {
+            CryptoError::KeySource("age: key URI requires DARKPOOL_KEY_PASSPHRASE env var".into())
+        })?);
+        let mut bytes = decrypt_age_passphrase(Path::new(path), &pass)
+            .map_err(|e| CryptoError::KeySource(format!("age: {e}")))?;
+        let secret = parse_hex_secret(&bytes)?;
+        bytes.zeroize();
+        secret
+    } else if let Some(rest) = uri.strip_prefix("awskms:") {
+        decrypt_via_aws_kms(rest)?
+    } else {
+        return Err(CryptoError::KeySource(format!(
+            "unsupported key URI scheme: {uri}"
+        )));
+    };
+    Ok(secret)
 }
 
 fn parse_hex_secret(bytes: &[u8]) -> Result<Vec<u8>, CryptoError> {

--- a/crates/dp-crypto/src/lib.rs
+++ b/crates/dp-crypto/src/lib.rs
@@ -9,10 +9,10 @@ pub use decrypted_order::DecryptedOrder;
 pub use decrypter::{Decrypter, NoopDecrypter};
 pub use ecies_decrypter::{load_operator_key_file, EciesDecrypter};
 pub use key_source::{decrypter_from_uri, KeySource};
-pub use snapshot_cipher::{SnapshotCipher, SNAPSHOT_NONCE_LEN};
 pub use multi_key_decrypter::{
     validate_key_id, KeyEntry, KeyStatus, MultiKeyDecrypter, MAX_KEY_ID_LEN,
 };
+pub use snapshot_cipher::{SnapshotCipher, SNAPSHOT_NONCE_LEN};
 
 #[derive(Debug, thiserror::Error)]
 pub enum CryptoError {

--- a/crates/dp-crypto/src/lib.rs
+++ b/crates/dp-crypto/src/lib.rs
@@ -3,11 +3,13 @@ mod decrypter;
 mod ecies_decrypter;
 mod key_source;
 mod multi_key_decrypter;
+mod snapshot_cipher;
 
 pub use decrypted_order::DecryptedOrder;
 pub use decrypter::{Decrypter, NoopDecrypter};
 pub use ecies_decrypter::{load_operator_key_file, EciesDecrypter};
 pub use key_source::{decrypter_from_uri, KeySource};
+pub use snapshot_cipher::{SnapshotCipher, SNAPSHOT_NONCE_LEN};
 pub use multi_key_decrypter::{
     validate_key_id, KeyEntry, KeyStatus, MultiKeyDecrypter, MAX_KEY_ID_LEN,
 };

--- a/crates/dp-crypto/src/lib.rs
+++ b/crates/dp-crypto/src/lib.rs
@@ -19,6 +19,9 @@ pub enum CryptoError {
     #[error("decryption failed: {0}")]
     DecryptionFailed(String),
 
+    #[error("encryption failed: {0}")]
+    EncryptionFailed(String),
+
     #[error("invalid key file: {0}")]
     InvalidKeyFile(String),
 

--- a/crates/dp-crypto/src/snapshot_cipher.rs
+++ b/crates/dp-crypto/src/snapshot_cipher.rs
@@ -89,7 +89,7 @@ impl SnapshotCipher {
                     aad,
                 },
             )
-            .map_err(|e| CryptoError::DecryptionFailed(format!("snapshot seal: {e}")))?;
+            .map_err(|e| CryptoError::EncryptionFailed(format!("snapshot seal: {e}")))?;
         let mut out = Vec::with_capacity(SNAPSHOT_NONCE_LEN + ciphertext.len());
         out.extend_from_slice(&nonce_bytes);
         out.extend_from_slice(&ciphertext);
@@ -243,5 +243,17 @@ mod tests {
         assert_eq!(a.open(&sealed, b"aad").unwrap(), b"payload");
         // An independent ephemeral key cannot open it.
         assert!(b.open(&sealed, b"aad").is_err());
+    }
+
+    #[test]
+    fn seal_failure_reads_as_encryption_not_decryption() {
+        // A real `seal()` failure needs a multi-hundred-GB plaintext (the only
+        // way XChaCha20-Poly1305 encrypt errors), so it can't be triggered in a
+        // unit test. Lock in the variant's operator-facing wording instead: a
+        // seal failure must read as *encryption* failed, not *decryption* —
+        // guarding against a regression that swaps the mapping back.
+        let enc = CryptoError::EncryptionFailed("snapshot seal: boom".into());
+        assert_eq!(enc.to_string(), "encryption failed: snapshot seal: boom");
+        assert!(!enc.to_string().contains("decryption"));
     }
 }

--- a/crates/dp-crypto/src/snapshot_cipher.rs
+++ b/crates/dp-crypto/src/snapshot_cipher.rs
@@ -82,7 +82,13 @@ impl SnapshotCipher {
         let nonce = XNonce::from(nonce_bytes);
         let ciphertext = self
             .cipher
-            .encrypt(&nonce, Payload { msg: plaintext, aad })
+            .encrypt(
+                &nonce,
+                Payload {
+                    msg: plaintext,
+                    aad,
+                },
+            )
             .map_err(|e| CryptoError::DecryptionFailed(format!("snapshot seal: {e}")))?;
         let mut out = Vec::with_capacity(SNAPSHOT_NONCE_LEN + ciphertext.len());
         out.extend_from_slice(&nonce_bytes);
@@ -106,7 +112,13 @@ impl SnapshotCipher {
             .expect("split_at(SNAPSHOT_NONCE_LEN) yields exactly that many bytes");
         let nonce = XNonce::from(nonce_arr);
         self.cipher
-            .decrypt(&nonce, Payload { msg: ciphertext, aad })
+            .decrypt(
+                &nonce,
+                Payload {
+                    msg: ciphertext,
+                    aad,
+                },
+            )
             .map_err(|e| CryptoError::DecryptionFailed(format!("snapshot open: {e}")))
     }
 }

--- a/crates/dp-crypto/src/snapshot_cipher.rs
+++ b/crates/dp-crypto/src/snapshot_cipher.rs
@@ -1,0 +1,235 @@
+//! Authenticated encryption for engine state snapshots at rest.
+//!
+//! Snapshots serialize the live order book and pending settlement matches,
+//! both of which carry cleartext `trader` / `price` / `size`. Writing them as
+//! bare bincode leaks resting-order data to anyone with read access to the
+//! `SnapshotStore` (issue #203). [`SnapshotCipher`] seals the serialized blob
+//! under a dedicated symmetric key with XChaCha20-Poly1305, so the store holds
+//! only ciphertext plus an authentication tag.
+//!
+//! The key is *dedicated* — distinct from the operator ECIES identity — so a
+//! snapshot-key compromise cannot decrypt live order ciphertext, and rotating
+//! the operator key never strands snapshot recovery. It is resolved through the
+//! same [`crate::KeySource`] URI machinery (`file:` / `age:` / `awskms:`).
+//!
+//! XChaCha20-Poly1305 takes a 192-bit nonce, generated randomly per seal. That
+//! width makes accidental nonce reuse statistically impossible without a
+//! counter, which suits independently-encrypted snapshot blobs.
+
+use chacha20poly1305::aead::rand_core::{OsRng, RngCore};
+use chacha20poly1305::aead::{Aead, KeyInit, Payload};
+use chacha20poly1305::{XChaCha20Poly1305, XNonce};
+use zeroize::{Zeroize, Zeroizing};
+
+use crate::key_source::resolve_secret_bytes;
+use crate::CryptoError;
+
+/// XChaCha20-Poly1305 nonce width (bytes). Stored as the prefix of every
+/// sealed blob produced by [`SnapshotCipher::seal`].
+pub const SNAPSHOT_NONCE_LEN: usize = 24;
+
+const SNAPSHOT_KEY_LEN: usize = 32;
+
+/// A symmetric cipher for sealing/opening snapshot blobs. Holds the key inside
+/// an `XChaCha20Poly1305` instance, which zeroizes its key material on drop.
+pub struct SnapshotCipher {
+    cipher: XChaCha20Poly1305,
+}
+
+impl SnapshotCipher {
+    /// Build from raw 32-byte key material. Any 32 bytes are a valid symmetric
+    /// key (no curve constraint, unlike the operator ECIES secret).
+    pub fn from_bytes(key: &[u8]) -> Result<Self, CryptoError> {
+        if key.len() != SNAPSHOT_KEY_LEN {
+            return Err(CryptoError::InvalidKeyFile(format!(
+                "snapshot key must be {SNAPSHOT_KEY_LEN} bytes, got {}",
+                key.len()
+            )));
+        }
+        let cipher = XChaCha20Poly1305::new_from_slice(key)
+            .map_err(|e| CryptoError::InvalidKeyFile(format!("snapshot key: {e}")))?;
+        Ok(Self { cipher })
+    }
+
+    /// Resolve a dedicated snapshot key from a [`crate::KeySource`] URI
+    /// (`file:` / `age:` / `awskms:`) and build a cipher. The resolved bytes
+    /// are zeroized before returning regardless of outcome.
+    pub fn from_key_uri(uri: &str) -> Result<Self, CryptoError> {
+        let mut bytes = resolve_secret_bytes(uri)?;
+        let result = Self::from_bytes(&bytes);
+        bytes.zeroize();
+        result
+    }
+
+    /// Generate a process-lifetime random key. Used only for the in-memory
+    /// (non-durable) snapshot store: those snapshots never survive a restart
+    /// anyway, so an ephemeral key has no recovery downside while still keeping
+    /// at-rest bytes encrypted.
+    pub fn generate_ephemeral() -> Self {
+        let mut key = Zeroizing::new([0u8; SNAPSHOT_KEY_LEN]);
+        OsRng.fill_bytes(key.as_mut_slice());
+        // `from_bytes` only fails on a length mismatch, impossible for a fixed
+        // 32-byte array.
+        Self::from_bytes(key.as_slice()).expect("32-byte key is always valid")
+    }
+
+    /// Seal `plaintext`, binding `aad` (the envelope header identity) into the
+    /// authentication tag. Returns `nonce || ciphertext+tag`. A fresh random
+    /// nonce is drawn per call.
+    pub fn seal(&self, plaintext: &[u8], aad: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        let mut nonce_bytes = [0u8; SNAPSHOT_NONCE_LEN];
+        OsRng.fill_bytes(&mut nonce_bytes);
+        let nonce = XNonce::from(nonce_bytes);
+        let ciphertext = self
+            .cipher
+            .encrypt(&nonce, Payload { msg: plaintext, aad })
+            .map_err(|e| CryptoError::DecryptionFailed(format!("snapshot seal: {e}")))?;
+        let mut out = Vec::with_capacity(SNAPSHOT_NONCE_LEN + ciphertext.len());
+        out.extend_from_slice(&nonce_bytes);
+        out.extend_from_slice(&ciphertext);
+        Ok(out)
+    }
+
+    /// Open a `nonce || ciphertext+tag` blob produced by [`Self::seal`],
+    /// verifying `aad`. Any tampering — ciphertext, tag, nonce, or a mismatched
+    /// `aad` — fails with [`CryptoError::DecryptionFailed`].
+    pub fn open(&self, sealed: &[u8], aad: &[u8]) -> Result<Vec<u8>, CryptoError> {
+        if sealed.len() < SNAPSHOT_NONCE_LEN {
+            return Err(CryptoError::DecryptionFailed(format!(
+                "snapshot blob too short: {} bytes (need at least {SNAPSHOT_NONCE_LEN})",
+                sealed.len()
+            )));
+        }
+        let (nonce_bytes, ciphertext) = sealed.split_at(SNAPSHOT_NONCE_LEN);
+        let nonce_arr: [u8; SNAPSHOT_NONCE_LEN] = nonce_bytes
+            .try_into()
+            .expect("split_at(SNAPSHOT_NONCE_LEN) yields exactly that many bytes");
+        let nonce = XNonce::from(nonce_arr);
+        self.cipher
+            .decrypt(&nonce, Payload { msg: ciphertext, aad })
+            .map_err(|e| CryptoError::DecryptionFailed(format!("snapshot open: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn cipher() -> SnapshotCipher {
+        SnapshotCipher::from_bytes(&[0x42u8; 32]).unwrap()
+    }
+
+    #[test]
+    fn seal_open_round_trip() {
+        let c = cipher();
+        let plaintext = b"resting order: trader=0xabc price=1500 size=3";
+        let aad = b"DPS2\x00\x00\x00\x02seq=7";
+        let sealed = c.seal(plaintext, aad).unwrap();
+        // Ciphertext must not echo the plaintext.
+        assert!(!sealed.windows(plaintext.len()).any(|w| w == plaintext));
+        let opened = c.open(&sealed, aad).unwrap();
+        assert_eq!(opened, plaintext);
+    }
+
+    #[test]
+    fn nonce_is_random_per_seal() {
+        let c = cipher();
+        let a = c.seal(b"same", b"aad").unwrap();
+        let b = c.seal(b"same", b"aad").unwrap();
+        // Different nonces ⇒ different sealed bytes for identical input.
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn open_rejects_tampered_ciphertext() {
+        let c = cipher();
+        let mut sealed = c.seal(b"secret", b"aad").unwrap();
+        let last = sealed.len() - 1;
+        sealed[last] ^= 0xFF;
+        assert!(matches!(
+            c.open(&sealed, b"aad"),
+            Err(CryptoError::DecryptionFailed(_))
+        ));
+    }
+
+    #[test]
+    fn open_rejects_wrong_key() {
+        let sealed = cipher().seal(b"secret", b"aad").unwrap();
+        let other = SnapshotCipher::from_bytes(&[0x99u8; 32]).unwrap();
+        assert!(matches!(
+            other.open(&sealed, b"aad"),
+            Err(CryptoError::DecryptionFailed(_))
+        ));
+    }
+
+    #[test]
+    fn open_rejects_wrong_aad() {
+        let c = cipher();
+        let sealed = c.seal(b"secret", b"aad-one").unwrap();
+        // A mismatched AAD (e.g. a relabeled seq) must fail the tag check.
+        assert!(matches!(
+            c.open(&sealed, b"aad-two"),
+            Err(CryptoError::DecryptionFailed(_))
+        ));
+    }
+
+    #[test]
+    fn open_rejects_truncated_blob() {
+        let c = cipher();
+        assert!(matches!(
+            c.open(&[0u8; 8], b"aad"),
+            Err(CryptoError::DecryptionFailed(_))
+        ));
+    }
+
+    #[test]
+    fn from_bytes_rejects_wrong_length() {
+        assert!(matches!(
+            SnapshotCipher::from_bytes(&[0u8; 16]),
+            Err(CryptoError::InvalidKeyFile(_))
+        ));
+    }
+
+    #[test]
+    fn from_key_uri_file_round_trips() {
+        let key = [0xCDu8; 32];
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(hex::encode(key).as_bytes()).unwrap();
+        f.flush().unwrap();
+
+        let c = SnapshotCipher::from_key_uri(&format!("file:{}", f.path().display())).unwrap();
+        let sealed = c.seal(b"hello", b"aad").unwrap();
+        // A cipher built straight from the same bytes opens it.
+        let direct = SnapshotCipher::from_bytes(&key).unwrap();
+        assert_eq!(direct.open(&sealed, b"aad").unwrap(), b"hello");
+    }
+
+    #[test]
+    fn from_key_uri_rejects_short_file_key() {
+        // `file:` keys must be 32-byte hex; a 16-byte key is rejected upstream.
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(hex::encode([0u8; 16]).as_bytes()).unwrap();
+        f.flush().unwrap();
+        assert!(SnapshotCipher::from_key_uri(&format!("file:{}", f.path().display())).is_err());
+    }
+
+    #[test]
+    fn from_key_uri_rejects_unknown_scheme() {
+        assert!(matches!(
+            SnapshotCipher::from_key_uri("vault://snapshot"),
+            Err(CryptoError::KeySource(_))
+        ));
+    }
+
+    #[test]
+    fn generate_ephemeral_round_trips_but_differs_per_instance() {
+        let a = SnapshotCipher::generate_ephemeral();
+        let b = SnapshotCipher::generate_ephemeral();
+        let sealed = a.seal(b"payload", b"aad").unwrap();
+        assert_eq!(a.open(&sealed, b"aad").unwrap(), b"payload");
+        // An independent ephemeral key cannot open it.
+        assert!(b.open(&sealed, b"aad").is_err());
+    }
+}

--- a/crates/dp-engine/benches/recover.rs
+++ b/crates/dp-engine/benches/recover.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 
 use alloy_primitives::Address;
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use dp_crypto::{CryptoError, DecryptedOrder, Decrypter};
+use dp_crypto::{CryptoError, DecryptedOrder, Decrypter, SnapshotCipher};
 use dp_engine::{Engine, SnapshotConfig};
 use dp_event::{Event, MemSnapshotStore, MemStore, SnapshotStore, Store};
 use dp_types::Side;
@@ -56,6 +56,11 @@ impl Decrypter for JsonDecrypter {
 fn build_engine(store: Arc<dyn Store>) -> Engine {
     let engine = Engine::new(store, Duration::from_secs(60));
     engine.set_decrypter(Arc::new(JsonDecrypter));
+    // Fixed key so the snapshot writer and the `from_snapshot` restorer arm
+    // share it and the sealed envelope round-trips (#203).
+    engine.set_snapshot_cipher(Some(Arc::new(
+        SnapshotCipher::from_bytes(&[7u8; 32]).unwrap(),
+    )));
     engine.register_pair_without_event(
         "BTC-USD".into(),
         dp_engine::PairConfig::new(Address::repeat_byte(1), Address::repeat_byte(2)),

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -217,13 +217,13 @@ impl Engine {
     /// Install the AEAD cipher used to seal/open snapshot envelopes at rest.
     /// Must be set whenever a [`SnapshotStore`] is wired — the snapshotter
     /// fails closed (writes nothing) without it, and recovery cannot decode
-    /// existing envelopes. See [`Inner::snapshot_cipher`].
+    /// existing envelopes. See `Inner::snapshot_cipher`.
     pub fn set_snapshot_cipher(&self, cipher: Option<Arc<SnapshotCipher>>) {
         *self.inner.snapshot_cipher.write() = cipher;
     }
 
     /// Clone of the active snapshot [`SnapshotCipher`], if one is installed.
-    /// Consulted by [`crate::snapshot::take_snapshot`] before writing and by
+    /// Consulted by `crate::snapshot::take_snapshot` before writing and by
     /// the recover path before decoding an envelope.
     pub fn snapshot_cipher_clone(&self) -> Option<Arc<SnapshotCipher>> {
         self.inner.snapshot_cipher.read().clone()

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 
 use chrono::Utc;
 use dp_aggregator::{NoopAggregator, ProofAggregator};
-use dp_crypto::{Decrypter, NoopDecrypter};
+use dp_crypto::{Decrypter, NoopDecrypter, SnapshotCipher};
 use dp_event::{Event, EventData, EventError, SnapshotStore, Store};
 use dp_settlement::{NoopSubmitter, Submitter};
 use dp_types::metrics::M_ORDERS_PLACED;
@@ -103,6 +103,11 @@ pub(crate) struct Inner {
     /// the snapshot pipeline — recover then always falls back to full
     /// event replay. Set at boot via [`Engine::set_snapshot_store`].
     pub(crate) snapshot_store: RwLock<Option<Arc<dyn SnapshotStore>>>,
+    /// AEAD cipher that seals every snapshot envelope at rest (#203). Set at
+    /// boot via [`Engine::set_snapshot_cipher`]. When a `snapshot_store` is
+    /// installed this MUST be `Some`, or the snapshotter refuses to run rather
+    /// than write plaintext; the boot path (`dp-api`) enforces that policy.
+    pub(crate) snapshot_cipher: RwLock<Option<Arc<SnapshotCipher>>>,
     /// Per-pair IVC round counter: how many fold steps have been
     /// executed for each pair since the last `finalize`.
     pub(crate) ivc_round: Mutex<std::collections::HashMap<String, u64>>,
@@ -140,6 +145,7 @@ impl Engine {
                 salt_nonce,
                 batch_size: 8,
                 snapshot_store: RwLock::new(None),
+                snapshot_cipher: RwLock::new(None),
                 ivc_round: Mutex::new(std::collections::HashMap::new()),
                 finalize_every: std::sync::atomic::AtomicU64::new(60),
             }),
@@ -206,6 +212,21 @@ impl Engine {
     /// loading the latest envelope.
     pub fn snapshot_store_clone(&self) -> Option<Arc<dyn SnapshotStore>> {
         self.inner.snapshot_store.read().clone()
+    }
+
+    /// Install the AEAD cipher used to seal/open snapshot envelopes at rest.
+    /// Must be set whenever a [`SnapshotStore`] is wired — the snapshotter
+    /// fails closed (writes nothing) without it, and recovery cannot decode
+    /// existing envelopes. See [`Inner::snapshot_cipher`].
+    pub fn set_snapshot_cipher(&self, cipher: Option<Arc<SnapshotCipher>>) {
+        *self.inner.snapshot_cipher.write() = cipher;
+    }
+
+    /// Clone of the active snapshot [`SnapshotCipher`], if one is installed.
+    /// Consulted by [`crate::snapshot::take_snapshot`] before writing and by
+    /// the recover path before decoding an envelope.
+    pub fn snapshot_cipher_clone(&self) -> Option<Arc<SnapshotCipher>> {
+        self.inner.snapshot_cipher.read().clone()
     }
 
     /// Highest event sequence number observed by the underlying event

--- a/crates/dp-engine/src/recover.rs
+++ b/crates/dp-engine/src/recover.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::engine::Engine;
 use crate::error::EngineError;
-use crate::snapshot::decode_envelope;
+use crate::snapshot::{decode_envelope, SnapshotError};
 use crate::state::{try_build_settlement_row, AuctionExecutedRecord, PairConfig, PendingBatch};
 
 /// Result of the snapshot recovery probe. Drives the recover() control
@@ -34,7 +34,8 @@ enum SnapshotRecoveryOutcome {
 /// Apply a decoded snapshot and populate `placed_orders` from the restored
 /// book. Logs whether this was a first-attempt or fallback recovery, and
 /// warns when the envelope's self-reported seq disagrees with the store key
-/// (the envelope value is authoritative because it is checksum-covered).
+/// (the envelope value is authoritative: the seq is bound into the AEAD
+/// associated data, so a tampered seq fails the tag rather than being trusted).
 fn apply_and_log_snapshot(
     engine: &Engine,
     placed_orders: &mut HashMap<Uuid, Order>,
@@ -61,7 +62,7 @@ fn apply_and_log_snapshot(
             envelope_seq = decoded_seq,
             store_key,
             "snapshot envelope seq disagrees with store key — \
-             trusting envelope (checksum-covered)"
+             trusting envelope (seq is AEAD-tag-authenticated)"
         );
     }
 }
@@ -94,6 +95,7 @@ fn try_restore_from_snapshots(
         return SnapshotRecoveryOutcome::AllCorrupt;
     };
     let mut attempts = 0usize;
+    let mut decrypt_failures = 0usize;
     for &seq in seqs.iter().rev() {
         let bytes = match snap_store.read_at(seq) {
             Ok(Some(b)) => b,
@@ -117,6 +119,14 @@ fn try_restore_from_snapshots(
                 return SnapshotRecoveryOutcome::Restored(decoded_seq);
             }
             Err(e) => {
+                // An AEAD-open failure is indistinguishable from on-disk
+                // corruption at this layer — that's inherent to AEAD. But if
+                // *every* envelope fails this exact way, the likeliest cause is
+                // the wrong snapshot key, not real corruption; count it so the
+                // post-loop summary can surface that hint.
+                if matches!(e, SnapshotError::Decrypt) {
+                    decrypt_failures += 1;
+                }
                 tracing::warn!(error = ?e, seq, "snapshot envelope corrupt; trying older");
                 // `decode_envelope` is pure and runs before
                 // `apply_snapshot_state`, so the engine's state was never
@@ -124,6 +134,20 @@ fn try_restore_from_snapshots(
                 // is also untouched on this branch for the same reason.
             }
         }
+    }
+    // Every envelope failed to decode. When all failures were AEAD-open
+    // failures — no BadMagic / Truncated / version / length mismatch mixed in —
+    // the envelopes are well-formed but unreadable under this key, the classic
+    // signature of a wrong or freshly-rotated snapshot key. Surface a targeted
+    // hint so the operator checks the key before assuming the snapshots are
+    // lost; the caller still applies its usual safety net regardless.
+    if attempts > 0 && decrypt_failures == attempts {
+        tracing::error!(
+            envelopes = attempts,
+            "every snapshot envelope failed AEAD authentication — as consistent \
+             with a WRONG snapshot key (check DARKPOOL_SNAPSHOT_KEY_URI or a recent \
+             key rotation) as with on-disk corruption"
+        );
     }
     SnapshotRecoveryOutcome::AllCorrupt
 }

--- a/crates/dp-engine/src/recover.rs
+++ b/crates/dp-engine/src/recover.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use alloy_primitives::U256;
 use chrono::{DateTime, Utc};
-use dp_crypto::Decrypter;
+use dp_crypto::{Decrypter, SnapshotCipher};
 use dp_event::{Event, EventData, EventError, SnapshotStore, Store};
 use dp_types::{EventType, Order, Pair};
 use rust_decimal::Decimal;
@@ -72,6 +72,7 @@ fn apply_and_log_snapshot(
 fn try_restore_from_snapshots(
     engine: &Engine,
     snap_store: &dyn SnapshotStore,
+    cipher: Option<&SnapshotCipher>,
     placed_orders: &mut HashMap<Uuid, Order>,
 ) -> SnapshotRecoveryOutcome {
     let seqs = match snap_store.list_seqs() {
@@ -81,6 +82,17 @@ fn try_restore_from_snapshots(
     if seqs.is_empty() {
         return SnapshotRecoveryOutcome::NoneAvailable;
     }
+    // Envelopes are AEAD-sealed (#203); without a cipher they cannot be read.
+    // Treat that as "all corrupt" so the caller applies the same safety net it
+    // uses for genuinely unreadable envelopes (full replay only when the event
+    // log still covers seq 1, else refuse to boot).
+    let Some(cipher) = cipher else {
+        tracing::error!(
+            "snapshot envelopes present but no SnapshotCipher configured — cannot \
+             decrypt; set DARKPOOL_SNAPSHOT_KEY_URI. Falling back to event replay."
+        );
+        return SnapshotRecoveryOutcome::AllCorrupt;
+    };
     let mut attempts = 0usize;
     for &seq in seqs.iter().rev() {
         let bytes = match snap_store.read_at(seq) {
@@ -92,7 +104,7 @@ fn try_restore_from_snapshots(
             }
         };
         attempts += 1;
-        match decode_envelope(&bytes) {
+        match decode_envelope(&bytes, cipher) {
             Ok((decoded_seq, snap_state)) => {
                 apply_and_log_snapshot(
                     engine,
@@ -168,6 +180,7 @@ impl Engine {
         }
 
         let decrypter = self.inner.decrypter.read().clone();
+        let snapshot_cipher = self.inner.snapshot_cipher.read().clone();
         let aggregator = self.inner.aggregator.read().clone();
         let store = self.inner.store.clone();
 
@@ -212,8 +225,12 @@ impl Engine {
         //   3. Only when the event log still starts at seq 1 do we fall
         //      back to a full replay.
         if let Some(snap_store) = self.inner.snapshot_store.read().clone() {
-            let restored =
-                try_restore_from_snapshots(self, snap_store.as_ref(), &mut placed_orders);
+            let restored = try_restore_from_snapshots(
+                self,
+                snap_store.as_ref(),
+                snapshot_cipher.as_deref(),
+                &mut placed_orders,
+            );
             match restored {
                 SnapshotRecoveryOutcome::Restored(seq) => {
                     if !event_log_continuous_after(store.as_ref(), seq)? {

--- a/crates/dp-engine/src/snapshot.rs
+++ b/crates/dp-engine/src/snapshot.rs
@@ -1,19 +1,26 @@
 use std::time::{Duration, Instant};
 
+use dp_crypto::SnapshotCipher;
 use dp_event::{EventError, SnapshotStore};
-use sha2::{Digest, Sha256};
 use tokio_util::sync::CancellationToken;
 use tracing::{info, warn};
 
 use crate::engine::Engine;
 use crate::state::SerializableState;
 
-/// Magic bytes that prefix every snapshot envelope. Bumping the suffix
-/// (e.g. `DPS2`) reserves space for a format break later — current
-/// readers reject any non-`DPS1` magic with [`SnapshotError::BadMagic`].
-const MAGIC: &[u8; 4] = b"DPS1";
-const ENVELOPE_VERSION: u32 = 1;
-const HEADER_LEN: usize = 4 /* magic */ + 4 /* version */ + 8 /* seq */ + 4 /* blob_len */ + 32 /* sha256 */;
+/// Magic bytes that prefix every snapshot envelope. `DPS2` marks the
+/// encrypted-at-rest format (#203): the payload is XChaCha20-Poly1305
+/// ciphertext, not plaintext bincode. Readers reject any non-`DPS2` magic
+/// with [`SnapshotError::BadMagic`] — a stray `DPS1` (plaintext) envelope is
+/// treated as corrupt and the recover path falls back to event replay.
+const MAGIC: &[u8; 4] = b"DPS2";
+const ENVELOPE_VERSION: u32 = 2;
+/// Bytes bound into the AEAD tag as associated data: `magic || version || seq`.
+/// Binding the seq stops a sealed blob from being relabeled under another seq.
+const AAD_LEN: usize = 4 /* magic */ + 4 /* version */ + 8 /* seq */;
+/// Fixed envelope prefix: the [`AAD_LEN`] header plus a 4-byte sealed length.
+/// The sealed payload (nonce || ciphertext+tag) follows.
+const HEADER_LEN: usize = AAD_LEN + 4 /* sealed_len */;
 
 /// Errors raised while encoding / decoding a snapshot envelope. The
 /// recover path catches all of these and falls back to a full event
@@ -22,14 +29,25 @@ const HEADER_LEN: usize = 4 /* magic */ + 4 /* version */ + 8 /* seq */ + 4 /* b
 pub enum SnapshotError {
     #[error("snapshot envelope too small: {len} bytes (need at least {HEADER_LEN})")]
     Truncated { len: usize },
-    #[error("bad snapshot magic: expected DPS1")]
+    #[error("bad snapshot magic: expected DPS2")]
     BadMagic,
     #[error("unsupported snapshot envelope version: {0}")]
     UnsupportedVersion(u32),
-    #[error("snapshot blob_len {declared} does not match payload {actual}")]
+    #[error("snapshot sealed_len {declared} does not match payload {actual}")]
     LengthMismatch { declared: usize, actual: usize },
-    #[error("snapshot checksum mismatch — payload corrupt or truncated")]
-    ChecksumMismatch,
+    /// AEAD open failed: the payload is corrupt, truncated, tampered, or was
+    /// sealed under a different key. The recover path treats this exactly like
+    /// any other corrupt envelope (try an older one, else fall back to replay).
+    #[error("snapshot decryption/authentication failed — corrupt, tampered, or wrong key")]
+    Decrypt,
+    /// AEAD seal failed while writing — an internal cipher error, not a
+    /// recoverable condition. Surfaced so the snapshotter logs and retries.
+    #[error("snapshot encryption failed: {0}")]
+    Encrypt(String),
+    /// No [`SnapshotCipher`] was installed. Fail closed rather than write or
+    /// read a plaintext snapshot. The boot path must configure a snapshot key.
+    #[error("no snapshot cipher configured — refusing plaintext snapshots at rest")]
+    CipherMissing,
     #[error(transparent)]
     Bincode(#[from] bincode::Error),
     #[error(transparent)]
@@ -73,33 +91,50 @@ impl Default for SnapshotConfig {
     }
 }
 
-/// Encode a [`SerializableState`] + its watermark `seq` into the
-/// on-disk envelope. The blob carries its own SHA-256 so the recover
-/// path can drop corrupted snapshots and fall back to event replay.
+/// Encode a [`SerializableState`] + its watermark `seq` into the on-disk
+/// envelope. The serialized state is sealed with `cipher` (XChaCha20-Poly1305)
+/// so the store never holds plaintext order data (#203). The Poly1305 tag is
+/// the integrity check — a tampered payload fails [`decode_envelope`] and the
+/// recover path falls back to event replay.
+///
+/// Layout: `magic(4) | version(4) | seq(8) | sealed_len(4) | sealed`, where
+/// `sealed = nonce(24) || ciphertext+tag`. The `magic||version||seq` prefix is
+/// the AEAD associated data, so neither the version nor the seq can be altered
+/// without failing the tag.
 pub(crate) fn encode_envelope(
     state: &SerializableState,
     seq: u64,
+    cipher: &SnapshotCipher,
 ) -> Result<Vec<u8>, SnapshotError> {
     let blob = bincode::serialize(state)?;
-    let blob_len = u32::try_from(blob.len()).map_err(|_| SnapshotError::LengthMismatch {
-        declared: u32::MAX as usize,
-        actual: blob.len(),
-    })?;
-    let digest = Sha256::digest(&blob);
 
-    let mut out = Vec::with_capacity(HEADER_LEN + blob.len());
-    out.extend_from_slice(MAGIC);
-    out.extend_from_slice(&ENVELOPE_VERSION.to_be_bytes());
-    out.extend_from_slice(&seq.to_be_bytes());
-    out.extend_from_slice(&blob_len.to_be_bytes());
-    out.extend_from_slice(&digest);
-    out.extend_from_slice(&blob);
+    let mut header = Vec::with_capacity(AAD_LEN);
+    header.extend_from_slice(MAGIC);
+    header.extend_from_slice(&ENVELOPE_VERSION.to_be_bytes());
+    header.extend_from_slice(&seq.to_be_bytes());
+
+    let sealed = cipher
+        .seal(&blob, &header)
+        .map_err(|e| SnapshotError::Encrypt(e.to_string()))?;
+    let sealed_len = u32::try_from(sealed.len()).map_err(|_| SnapshotError::LengthMismatch {
+        declared: u32::MAX as usize,
+        actual: sealed.len(),
+    })?;
+
+    let mut out = Vec::with_capacity(HEADER_LEN + sealed.len());
+    out.extend_from_slice(&header); // magic || version || seq (== AAD)
+    out.extend_from_slice(&sealed_len.to_be_bytes());
+    out.extend_from_slice(&sealed);
     Ok(out)
 }
 
-/// Decode an envelope produced by [`encode_envelope`], verifying the
-/// magic, version, declared length, and SHA-256 checksum.
-pub(crate) fn decode_envelope(bytes: &[u8]) -> Result<(u64, SerializableState), SnapshotError> {
+/// Decode an envelope produced by [`encode_envelope`], verifying the magic,
+/// version, declared length, then opening the AEAD payload with `cipher`. A
+/// failed open (corruption, tamper, wrong key) maps to [`SnapshotError::Decrypt`].
+pub(crate) fn decode_envelope(
+    bytes: &[u8],
+    cipher: &SnapshotCipher,
+) -> Result<(u64, SerializableState), SnapshotError> {
     if bytes.len() < HEADER_LEN {
         return Err(SnapshotError::Truncated { len: bytes.len() });
     }
@@ -111,20 +146,19 @@ pub(crate) fn decode_envelope(bytes: &[u8]) -> Result<(u64, SerializableState), 
         return Err(SnapshotError::UnsupportedVersion(version));
     }
     let seq = u64::from_be_bytes(bytes[8..16].try_into().unwrap());
-    let blob_len = u32::from_be_bytes(bytes[16..20].try_into().unwrap()) as usize;
-    let checksum = &bytes[20..52];
+    let sealed_len = u32::from_be_bytes(bytes[16..20].try_into().unwrap()) as usize;
     let payload = &bytes[HEADER_LEN..];
-    if payload.len() != blob_len {
+    if payload.len() != sealed_len {
         return Err(SnapshotError::LengthMismatch {
-            declared: blob_len,
+            declared: sealed_len,
             actual: payload.len(),
         });
     }
-    let digest = Sha256::digest(payload);
-    if &digest[..] != checksum {
-        return Err(SnapshotError::ChecksumMismatch);
-    }
-    let state: SerializableState = bincode::deserialize(payload)?;
+    // AAD is the stored magic||version||seq prefix verbatim — any flip there
+    // (e.g. a relabeled seq) fails the tag below rather than being trusted.
+    let aad = &bytes[0..AAD_LEN];
+    let blob = cipher.open(payload, aad).map_err(|_| SnapshotError::Decrypt)?;
+    let state: SerializableState = bincode::deserialize(&blob)?;
     Ok((seq, state))
 }
 
@@ -147,6 +181,16 @@ pub(crate) async fn run_snapshotter(
         info!("snapshotter started without a SnapshotStore — task exiting");
         return;
     };
+    // Fail closed: a store without a cipher would mean plaintext order data at
+    // rest. Refuse to run rather than leak (#203). The boot path guarantees a
+    // cipher whenever a durable store is configured.
+    if engine.snapshot_cipher_clone().is_none() {
+        warn!(
+            "snapshotter started without a SnapshotCipher — refusing to write \
+             plaintext snapshots; task exiting (set DARKPOOL_SNAPSHOT_KEY_URI)"
+        );
+        return;
+    }
 
     // Sub-tick at the smaller of (interval, 1s) so the event-delta
     // trigger can fire promptly for high-throughput deploys without
@@ -218,12 +262,19 @@ pub(crate) fn take_snapshot(
     config: &SnapshotConfig,
     seq_hint: u64,
 ) -> Result<u64, SnapshotError> {
+    // Fail closed: never write a snapshot without a cipher to seal it. The
+    // boot path installs one whenever a store is wired; this guards against a
+    // library misuse writing plaintext order data to disk.
+    let cipher = engine
+        .snapshot_cipher_clone()
+        .ok_or(SnapshotError::CipherMissing)?;
+
     // Capture under lock — clone the persistable subset and pick a seq
     // *while holding the lock* so the snapshot reflects exactly the
     // event the engine had observed at capture time.
     let (state, seq) = engine.capture_snapshot_state(seq_hint);
 
-    let envelope = encode_envelope(&state, seq)?;
+    let envelope = encode_envelope(&state, seq, &cipher)?;
     snapshot_store.write(seq, &envelope)?;
 
     // Compact the event log behind the new watermark. `retain_events`
@@ -259,11 +310,12 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use dp_crypto::SnapshotCipher;
     use dp_event::{MemSnapshotStore, MemStore};
     use tokio_util::sync::CancellationToken;
 
     use super::*;
-    use crate::state::SerializableState;
+    use crate::state::{PairConfig, SerializableState};
     use dp_book::OrderBook;
 
     fn empty_state() -> SerializableState {
@@ -275,24 +327,58 @@ mod tests {
         }
     }
 
+    /// Deterministic cipher for envelope tests. Real deploys load a key via
+    /// `DARKPOOL_SNAPSHOT_KEY_URI`; tests fix the key so failures are stable.
+    fn test_cipher() -> Arc<SnapshotCipher> {
+        Arc::new(SnapshotCipher::from_bytes(&[7u8; 32]).unwrap())
+    }
+
     fn bare_engine() -> crate::engine::Engine {
         let store = Arc::new(MemStore::new());
-        crate::engine::Engine::new(store, Duration::from_millis(50))
+        let engine = crate::engine::Engine::new(store, Duration::from_millis(50));
+        engine.set_snapshot_cipher(Some(test_cipher()));
+        engine
     }
 
     #[test]
     fn envelope_round_trip() {
+        let c = test_cipher();
         let s = empty_state();
-        let env = encode_envelope(&s, 1234).unwrap();
-        let (seq, _back) = decode_envelope(&env).unwrap();
+        let env = encode_envelope(&s, 1234, &c).unwrap();
+        let (seq, _back) = decode_envelope(&env, &c).unwrap();
         assert_eq!(seq, 1234);
     }
 
     #[test]
+    fn envelope_hides_plaintext() {
+        // A pair key is a cleartext string field in the serialized state. The
+        // unencrypted bincode contains it verbatim; the sealed envelope must
+        // not. The first assert keeps the second honest (proves the marker is
+        // really in the plaintext form, so a passing canary means something).
+        const MARKER: &str = "MARKER-SECRET-PAIR";
+        let mut s = empty_state();
+        s.pair_tokens
+            .insert(MARKER.to_string(), PairConfig::default());
+
+        let plain = bincode::serialize(&s).unwrap();
+        assert!(
+            plain.windows(MARKER.len()).any(|w| w == MARKER.as_bytes()),
+            "marker must appear in the unencrypted bincode"
+        );
+
+        let env = encode_envelope(&s, 1, &test_cipher()).unwrap();
+        assert!(
+            !env.windows(MARKER.len()).any(|w| w == MARKER.as_bytes()),
+            "plaintext pair key leaked into the encrypted envelope"
+        );
+    }
+
+    #[test]
     fn detects_truncation() {
-        let env = encode_envelope(&empty_state(), 1).unwrap();
+        let c = test_cipher();
+        let env = encode_envelope(&empty_state(), 1, &c).unwrap();
         let half = &env[..env.len() / 2];
-        let err = decode_envelope(half).unwrap_err();
+        let err = decode_envelope(half, &c).unwrap_err();
         assert!(
             matches!(
                 err,
@@ -304,19 +390,21 @@ mod tests {
 
     #[test]
     fn detects_bad_magic() {
-        let mut env = encode_envelope(&empty_state(), 1).unwrap();
+        let c = test_cipher();
+        let mut env = encode_envelope(&empty_state(), 1, &c).unwrap();
         env[0] = b'X';
-        let err = decode_envelope(&env).unwrap_err();
+        let err = decode_envelope(&env, &c).unwrap_err();
         assert!(matches!(err, SnapshotError::BadMagic), "got {err:?}");
     }
 
     #[test]
     fn detects_unsupported_version() {
-        let mut env = encode_envelope(&empty_state(), 1).unwrap();
+        let c = test_cipher();
+        let mut env = encode_envelope(&empty_state(), 1, &c).unwrap();
         // Version sits at bytes 4..8 in big-endian.
         let bad_ver: u32 = 0xDEAD;
         env[4..8].copy_from_slice(&bad_ver.to_be_bytes());
-        let err = decode_envelope(&env).unwrap_err();
+        let err = decode_envelope(&env, &c).unwrap_err();
         assert!(
             matches!(err, SnapshotError::UnsupportedVersion(v) if v == bad_ver),
             "got {err:?}",
@@ -324,17 +412,15 @@ mod tests {
     }
 
     #[test]
-    fn detects_corruption_in_payload() {
-        let mut env = encode_envelope(&empty_state(), 1).unwrap();
-        // Mid-payload flip — outside the header, so length and magic
-        // still look OK; only the checksum catches it.
+    fn detects_tampered_ciphertext() {
+        let c = test_cipher();
+        let mut env = encode_envelope(&empty_state(), 1, &c).unwrap();
+        // Flip the last byte (inside the Poly1305 tag) — length and magic
+        // still look OK, so only the AEAD open catches it.
         let last = env.len() - 1;
         env[last] ^= 0xFF;
-        let err = decode_envelope(&env).unwrap_err();
-        assert!(
-            matches!(err, SnapshotError::ChecksumMismatch),
-            "got {err:?}"
-        );
+        let err = decode_envelope(&env, &c).unwrap_err();
+        assert!(matches!(err, SnapshotError::Decrypt), "got {err:?}");
     }
 
     #[test]
@@ -359,7 +445,7 @@ mod tests {
         let snap_store = MemSnapshotStore::new();
         // Pre-populate 4 old envelopes at seqs 1..4.
         for s in [1u64, 2, 3, 4] {
-            let env = encode_envelope(&empty_state(), s).unwrap();
+            let env = encode_envelope(&empty_state(), s, &test_cipher()).unwrap();
             snap_store.write(s, &env).unwrap();
         }
         let cfg = SnapshotConfig {
@@ -446,5 +532,44 @@ mod tests {
         )
         .await
         .expect("snapshotter without store must return immediately");
+    }
+
+    #[test]
+    fn take_snapshot_without_cipher_fails_closed() {
+        // An engine with a store but no cipher must refuse to write rather
+        // than emit a plaintext snapshot (#203).
+        let store = Arc::new(MemStore::new());
+        let engine = crate::engine::Engine::new(store, Duration::from_millis(50));
+        let snap_store = MemSnapshotStore::new();
+        let err = take_snapshot(&engine, &snap_store, &SnapshotConfig::default(), 0).unwrap_err();
+        assert!(matches!(err, SnapshotError::CipherMissing), "got {err:?}");
+        assert!(
+            snap_store.list_seqs().unwrap().is_empty(),
+            "fail-closed must not write any envelope"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_snapshotter_exits_without_cipher() {
+        let store = Arc::new(MemStore::new());
+        let engine = crate::engine::Engine::new(store, Duration::from_millis(50));
+        let snap_store = Arc::new(MemSnapshotStore::new());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+        // Store wired but no cipher → fail closed, write nothing, exit.
+        let cfg = SnapshotConfig {
+            every_events: 0,
+            ..SnapshotConfig::default()
+        };
+        let cancel = CancellationToken::new();
+        tokio::time::timeout(
+            Duration::from_millis(200),
+            run_snapshotter(engine, cfg, cancel),
+        )
+        .await
+        .expect("snapshotter without cipher must return immediately");
+        assert!(
+            snap_store.list_seqs().unwrap().is_empty(),
+            "fail-closed must not write plaintext"
+        );
     }
 }

--- a/crates/dp-engine/src/snapshot.rs
+++ b/crates/dp-engine/src/snapshot.rs
@@ -157,7 +157,9 @@ pub(crate) fn decode_envelope(
     // AAD is the stored magic||version||seq prefix verbatim — any flip there
     // (e.g. a relabeled seq) fails the tag below rather than being trusted.
     let aad = &bytes[0..AAD_LEN];
-    let blob = cipher.open(payload, aad).map_err(|_| SnapshotError::Decrypt)?;
+    let blob = cipher
+        .open(payload, aad)
+        .map_err(|_| SnapshotError::Decrypt)?;
     let state: SerializableState = bincode::deserialize(&blob)?;
     Ok((seq, state))
 }

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -1400,6 +1400,7 @@ mod snapshot_recover {
     use std::time::Duration;
 
     use alloy_primitives::Address;
+    use dp_crypto::SnapshotCipher;
     use dp_event::{MemSnapshotStore, MemStore, SnapshotStore};
     use dp_types::Side;
     use rust_decimal::Decimal;
@@ -1913,6 +1914,119 @@ mod snapshot_recover {
             .recover()
             .await
             .expect_err("must refuse boot on corrupt-snap + empty-log");
+        assert!(
+            matches!(err, crate::EngineError::SnapshotsCorruptAndLogTruncated),
+            "expected SnapshotsCorruptAndLogTruncated, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_snapshot_key_with_compacted_log_refuses_boot() {
+        // The headline operational failure: a valid snapshot sealed under
+        // key A, recovered under key B (a wrong DARKPOOL_SNAPSHOT_KEY_URI, or
+        // a key rotated without re-sealing). Unlike the other corrupt_* tests
+        // — which plant BadMagic / Truncated garbage — the envelope here is
+        // structurally perfect (right magic, version, length) but fails the
+        // AEAD tag, so `decode_envelope` returns `SnapshotError::Decrypt`.
+        // This is the only test that drives the all-Decrypt path through
+        // `try_restore_from_snapshots`, exercising the `decrypt_failures`
+        // counter and the wrong-key hint. With the event log compacted past
+        // seq 1, full replay can't reproduce history, so recover() must
+        // refuse to boot rather than silently come up with partial state.
+        let store = Arc::new(MemStore::new());
+        let snap_store: Arc<dyn SnapshotStore> = Arc::new(MemSnapshotStore::new());
+        let engine = wire_engine(store.clone());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+        drive_scenario(&engine).await;
+
+        // Valid envelope, sealed under the key-7 cipher wire_engine installs.
+        let seq = engine.store_last_seq();
+        take_snapshot(&engine, snap_store.as_ref(), &SnapshotConfig::default(), seq)
+            .expect("take snapshot");
+
+        // Compact the event log past seq 1 so a full replay is impossible.
+        engine.compact_events_before(seq).expect("compact");
+
+        // Restore under a DIFFERENT key: the envelope decodes structurally
+        // but fails the AEAD open → Decrypt → AllCorrupt → refuse boot.
+        let restored = wire_engine(store.clone());
+        restored.set_snapshot_store(Some(snap_store.clone()));
+        restored.set_snapshot_cipher(Some(Arc::new(
+            SnapshotCipher::from_bytes(&[0x99u8; 32]).unwrap(),
+        )));
+        let err = restored
+            .recover()
+            .await
+            .expect_err("wrong snapshot key + compacted log must refuse boot");
+        assert!(
+            matches!(err, crate::EngineError::SnapshotsCorruptAndLogTruncated),
+            "expected SnapshotsCorruptAndLogTruncated, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn wrong_snapshot_key_with_intact_log_falls_back_to_full_replay() {
+        // The graceful half of the wrong-key safety net: same seal/open key
+        // mismatch, but the event log is intact from seq 1. The unreadable
+        // snapshot must be discarded and a full replay must reproduce the
+        // live engine's observable state.
+        let store = Arc::new(MemStore::new());
+        let snap_store: Arc<dyn SnapshotStore> = Arc::new(MemSnapshotStore::new());
+        let engine = wire_engine(store.clone());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+        drive_scenario(&engine).await;
+        let truth = public_state_fingerprint(&engine);
+
+        let seq = engine.store_last_seq();
+        take_snapshot(&engine, snap_store.as_ref(), &SnapshotConfig::default(), seq)
+            .expect("take snapshot");
+
+        let restored = wire_engine(store.clone());
+        restored.set_snapshot_store(Some(snap_store.clone()));
+        restored.set_snapshot_cipher(Some(Arc::new(
+            SnapshotCipher::from_bytes(&[0x99u8; 32]).unwrap(),
+        )));
+        restored
+            .recover()
+            .await
+            .expect("wrong key + intact log must fall back to full replay");
+        assert_eq!(
+            public_state_fingerprint(&restored),
+            truth,
+            "full replay under the wrong snapshot key must reproduce live state",
+        );
+    }
+
+    #[tokio::test]
+    async fn snapshot_present_but_no_cipher_refuses_boot_on_compacted_log() {
+        // Defensive fail-safe (the `None`-cipher branch in
+        // `try_restore_from_snapshots`): envelopes are present on the store
+        // but no SnapshotCipher is configured, so they cannot be read.
+        // recover() must treat that as AllCorrupt — *not* NoneAvailable — so
+        // the compacted-log safety net still fires and the engine refuses to
+        // boot instead of full-replaying partial state. dp-api boots
+        // fail-closed before reaching this, but it's a fail-safe worth pinning.
+        let store = Arc::new(MemStore::new());
+        let snap_store: Arc<dyn SnapshotStore> = Arc::new(MemSnapshotStore::new());
+        let engine = wire_engine(store.clone());
+        engine.set_snapshot_store(Some(snap_store.clone()));
+        drive_scenario(&engine).await;
+
+        let seq = engine.store_last_seq();
+        take_snapshot(&engine, snap_store.as_ref(), &SnapshotConfig::default(), seq)
+            .expect("take snapshot");
+        engine.compact_events_before(seq).expect("compact");
+
+        // Restore with the snapshot store wired but NO cipher installed.
+        let restored = Engine::new(store.clone(), Duration::from_millis(50));
+        restored.set_aggregator(Arc::new(StubAggregator::new(vec![0u8; 32])));
+        restored.set_submitter(Arc::new(StubSubmitter::new()));
+        restored.set_finalize_every(1);
+        restored.set_snapshot_store(Some(snap_store.clone()));
+        let err = restored
+            .recover()
+            .await
+            .expect_err("envelopes present + no cipher + compacted log must refuse boot");
         assert!(
             matches!(err, crate::EngineError::SnapshotsCorruptAndLogTruncated),
             "expected SnapshotsCorruptAndLogTruncated, got {err:?}",

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 
 use alloy_primitives::Address;
 use dp_aggregator::ProofAggregator;
-use dp_crypto::DecryptedOrder;
+use dp_crypto::{DecryptedOrder, SnapshotCipher};
 use dp_event::{EventData, FileStore, MemStore, Store};
 use dp_settlement::Submitter;
 use dp_types::{EventType, Side};
@@ -16,10 +16,18 @@ use crate::test_helpers::{
 };
 use crate::Engine;
 
+/// Fixed snapshot cipher for tests that exercise the snapshot store. Writer
+/// and restorer engines must share this key so a sealed envelope round-trips
+/// on recover. Production loads a key via `DARKPOOL_SNAPSHOT_KEY_URI`.
+fn test_snapshot_cipher() -> Arc<SnapshotCipher> {
+    Arc::new(SnapshotCipher::from_bytes(&[7u8; 32]).unwrap())
+}
+
 fn make_engine() -> (Engine, Arc<MemStore>) {
     let store = Arc::new(MemStore::new());
     let engine = Engine::new(store.clone(), Duration::from_millis(50));
     engine.register_pair_without_event("BTC-USD".into(), crate::state::PairConfig::default());
+    engine.set_snapshot_cipher(Some(test_snapshot_cipher()));
     // IVC path: finalize after every fold step so tests with a single
     // matching tick produce a submitted batch immediately.
     engine.set_finalize_every(1);
@@ -1396,12 +1404,19 @@ mod snapshot_recover {
     use dp_types::Side;
     use rust_decimal::Decimal;
 
+    use super::test_snapshot_cipher;
     use crate::snapshot::{take_snapshot, SnapshotConfig};
-    use crate::test_helpers::{place_plaintext_order, StubAggregator, StubSubmitter};
+    use crate::test_helpers::{
+        place_plaintext_order, place_plaintext_order_as, StubAggregator, StubSubmitter,
+    };
     use crate::Engine;
 
     fn dec(n: i64) -> Decimal {
         Decimal::new(n, 0)
+    }
+
+    fn contains(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack.windows(needle.len()).any(|w| w == needle)
     }
 
     fn wire_engine(store: Arc<MemStore>) -> Engine {
@@ -1411,9 +1426,74 @@ mod snapshot_recover {
         let engine = Engine::new(store, Duration::from_millis(50));
         engine.set_aggregator(Arc::new(StubAggregator::new(vec![0u8; 32])));
         engine.set_submitter(Arc::new(StubSubmitter::new()));
+        engine.set_snapshot_cipher(Some(test_snapshot_cipher()));
         // IVC path: finalize after every fold so each tick produces a batch.
         engine.set_finalize_every(1);
         engine
+    }
+
+    /// Privacy-at-rest canary (#203): a snapshot envelope must not contain the
+    /// cleartext order fields that live in the serialized book. Mirrors
+    /// `event_store_contains_no_plaintext`, but inspects the snapshot path —
+    /// which had zero plaintext coverage before this fix.
+    #[tokio::test]
+    async fn snapshot_contains_no_plaintext() {
+        const COMMIT_MARKER: &str = "SUPER-SECRET-COMMITMENT-KEY";
+        // Distinctive trader bytes — long enough that a coincidental match in
+        // ciphertext is astronomically unlikely.
+        let trader = Address::repeat_byte(0xAB);
+
+        let engine = wire_engine(Arc::new(MemStore::new()));
+        engine
+            .register_pair_with_event(
+                "BTC-USD",
+                crate::state::PairConfig::new(Address::repeat_byte(1), Address::repeat_byte(2)),
+            )
+            .expect("register pair");
+        place_plaintext_order_as(
+            &engine,
+            trader,
+            "BTC-USD",
+            Side::Buy,
+            dec(1234),
+            dec(7),
+            COMMIT_MARKER,
+            Duration::from_secs(60),
+        )
+        .await
+        .expect("place order");
+
+        let snap_store = MemSnapshotStore::new();
+        let seq = take_snapshot(&engine, &snap_store, &SnapshotConfig::default(), 0)
+            .expect("snapshot must be written");
+        let envelope = snap_store
+            .read_at(seq)
+            .expect("read_at")
+            .expect("envelope present");
+
+        // Sanity: the markers really are in the *unencrypted* serialized state,
+        // so a passing canary below means the encryption is what hides them —
+        // not a mistyped marker that would never have matched anyway.
+        let (state, _) = engine.capture_snapshot_state(0);
+        let plain = bincode::serialize(&state).expect("serialize state");
+        assert!(
+            contains(&plain, COMMIT_MARKER.as_bytes()),
+            "marker must appear in the unencrypted serialized state"
+        );
+        assert!(
+            contains(&plain, &[0xABu8; 20]),
+            "trader bytes must appear in the unencrypted serialized state"
+        );
+
+        // The sealed envelope must reveal neither.
+        assert!(
+            !contains(&envelope, COMMIT_MARKER.as_bytes()),
+            "commitment_key leaked into the snapshot envelope"
+        );
+        assert!(
+            !contains(&envelope, &[0xABu8; 20]),
+            "trader address bytes leaked into the snapshot envelope"
+        );
     }
 
     async fn drive_scenario(engine: &Engine) {
@@ -1863,6 +1943,7 @@ mod snapshot_recover_prop {
     use proptest::prelude::*;
     use rust_decimal::Decimal;
 
+    use super::test_snapshot_cipher;
     use crate::snapshot::{take_snapshot, SnapshotConfig};
     use crate::test_helpers::{place_plaintext_order, StubAggregator, StubSubmitter};
     use crate::Engine;
@@ -1881,6 +1962,7 @@ mod snapshot_recover_prop {
         let engine = Engine::new(store, Duration::from_millis(50));
         engine.set_aggregator(Arc::new(StubAggregator::new(vec![0u8; 32])));
         engine.set_submitter(Arc::new(StubSubmitter::new()));
+        engine.set_snapshot_cipher(Some(test_snapshot_cipher()));
         // IVC path: finalize after every fold so each tick produces a batch.
         engine.set_finalize_every(1);
         engine

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -1941,8 +1941,13 @@ mod snapshot_recover {
 
         // Valid envelope, sealed under the key-7 cipher wire_engine installs.
         let seq = engine.store_last_seq();
-        take_snapshot(&engine, snap_store.as_ref(), &SnapshotConfig::default(), seq)
-            .expect("take snapshot");
+        take_snapshot(
+            &engine,
+            snap_store.as_ref(),
+            &SnapshotConfig::default(),
+            seq,
+        )
+        .expect("take snapshot");
 
         // Compact the event log past seq 1 so a full replay is impossible.
         engine.compact_events_before(seq).expect("compact");
@@ -1978,8 +1983,13 @@ mod snapshot_recover {
         let truth = public_state_fingerprint(&engine);
 
         let seq = engine.store_last_seq();
-        take_snapshot(&engine, snap_store.as_ref(), &SnapshotConfig::default(), seq)
-            .expect("take snapshot");
+        take_snapshot(
+            &engine,
+            snap_store.as_ref(),
+            &SnapshotConfig::default(),
+            seq,
+        )
+        .expect("take snapshot");
 
         let restored = wire_engine(store.clone());
         restored.set_snapshot_store(Some(snap_store.clone()));
@@ -2013,8 +2023,13 @@ mod snapshot_recover {
         drive_scenario(&engine).await;
 
         let seq = engine.store_last_seq();
-        take_snapshot(&engine, snap_store.as_ref(), &SnapshotConfig::default(), seq)
-            .expect("take snapshot");
+        take_snapshot(
+            &engine,
+            snap_store.as_ref(),
+            &SnapshotConfig::default(),
+            seq,
+        )
+        .expect("take snapshot");
         engine.compact_events_before(seq).expect("compact");
 
         // Restore with the snapshot store wired but NO cipher installed.

--- a/docs/adr/0006-snapshot-encryption-at-rest.md
+++ b/docs/adr/0006-snapshot-encryption-at-rest.md
@@ -1,0 +1,86 @@
+# ADR 0006 — Snapshot encryption at rest
+
+- **Status:** Accepted
+- **Date:** 2026-06-08
+- **Issue:** [#203](https://github.com/Dnreikronos/DarkPool-Exchange/issues/203)
+
+## Context
+
+The engine periodically writes state snapshots to the `SnapshotStore` so
+recovery can skip a full event replay. Snapshots were serialized as **bare
+bincode**: the blob carried the live order book — every `Order` with cleartext
+`trader`, `price`, `size`, `commitment_key` — plus `pending_batches[]
+.settlement_matches[]` with cleartext `bid_trader` / `ask_trader` / `price` /
+`size`. The envelope's SHA-256 was integrity only. Anyone with read access to
+the snapshot store read resting-order and settled-match data directly — a
+larger privacy-at-rest leak than the salt_nonce concern in #177, and one the
+`event_store_contains_no_plaintext` canary never covered (it walks only the
+event log).
+
+## Decision
+
+Seal the entire serialized snapshot with an AEAD before it touches the store.
+
+- **Cipher:** XChaCha20-Poly1305. The 192-bit random nonce per snapshot rules
+  out nonce reuse without counter state, which suits independently-encrypted
+  blobs. The Poly1305 tag replaces the SHA-256 (authenticity *and* integrity).
+- **Dedicated key, not derived from the operator ECIES key.** Resolved via the
+  existing `KeySource` URI machinery (`file:` / `age:` / `awskms:`) from
+  `--snapshot-key-uri` / `DARKPOOL_SNAPSHOT_KEY_URI`.
+
+### Why a dedicated key over deriving one from the operator key
+
+Both options protect against the core threat (store-read access alone reveals
+nothing). The dedicated key wins on trade-offs:
+
+1. **Key separation.** A leaked snapshot key cannot decrypt live order
+   ciphertext, and a leaked operator ECIES key cannot read snapshots. Distinct
+   blast radii.
+2. **Rotation safety — decisive.** The protocol supports operator pubkey
+   rotation (`setOperatorPubkey`, `MultiKeyDecrypter`). A snapshot key derived
+   from the active ECIES key would make pre-rotation snapshots undecryptable;
+   combined with event compaction behind them, recovery would hit
+   `SnapshotsCorruptAndLogTruncated` and **refuse to boot**. A dedicated key
+   rotates on its own schedule and never entangles the two lifecycles.
+3. **Minimal surface.** Reuses `KeySource` verbatim — one boot-time knob, no new
+   key infrastructure, and no need to re-expose the operator secret that
+   `dp-crypto` deliberately keeps zeroized and private.
+
+The only cost — one extra secret to provision — is outweighed by avoiding a
+boot-availability footgun on a first-class protocol flow.
+
+### Envelope format (magic `DPS1` → `DPS2`)
+
+```
+magic "DPS2" (4) | version=2 (4 BE) | seq (8 BE) | sealed_len (4 BE) | sealed
+sealed = nonce(24) || ciphertext+tag
+```
+
+`magic || version || seq` is the AEAD associated data, so neither the version
+nor the seq can be altered without failing the tag. A stray `DPS1` (plaintext)
+envelope fails `BadMagic` → treated as corrupt → recovery falls back to event
+replay. Greenfield: no back-compat shim.
+
+### Fail-closed boot policy
+
+- **Durable store (file / postgres) without a key URI →** the server refuses to
+  start. It will not write plaintext order data at rest.
+- **Durable store with a key URI →** load the key, seal every snapshot.
+- **In-memory store (non-durable) without a key URI →** generate a per-process
+  ephemeral key. Those snapshots never survive a restart anyway, so an ephemeral
+  key has no recovery downside while still keeping at-rest bytes encrypted.
+
+The engine mirrors this: the snapshotter refuses to run, and `take_snapshot`
+returns `CipherMissing`, when a store is wired without a cipher.
+
+## Consequences
+
+- Operators running a durable snapshot store must provision and protect a
+  second secret (`DARKPOOL_SNAPSHOT_KEY_URI`). Losing it makes existing
+  snapshots unrecoverable — recovery then needs an intact event log from seq 1.
+- Rotating the snapshot key makes envelopes sealed under the old key
+  undecodable; treat a rotation like a compaction boundary (keep an event tail,
+  or accept a full replay on the next boot).
+- The `snapshot_contains_no_plaintext` canary now reads raw envelope bytes and
+  asserts secret markers are absent, with a sanity check that the *unencrypted*
+  form would contain them — so this path can no longer regress silently.


### PR DESCRIPTION
Closes #203

Periodic snapshots were written to the SnapshotStore as plain bincode. The blob held the whole order book (trader, price, size, commitment_key) plus pending settlement matches, all in cleartext, behind nothing but a SHA-256 that only checks integrity. Anyone who could read the snapshot store could read resting orders straight off disk. The existing no-plaintext canary only walked the event log, so this path was never covered.

Now the envelope gets sealed with XChaCha20-Poly1305 before it's written. Random 24-byte nonce per snapshot so there's no counter to keep, and the Poly1305 tag does the integrity job the SHA-256 used to. Magic goes DPS1 to DPS2, and magic||version||seq is bound in as AAD so a blob can't be relabeled to another seq. A stray DPS1 (plaintext) envelope fails the magic check and recovery falls back to event replay.

The snapshot key is its own secret, not derived from the operator ECIES key. That keeps the blast radius separate (losing one doesn't expose the other), and it sidesteps a rotation trap: operator pubkey rotation is a supported flow, and a derived key would make every pre-rotation snapshot undecryptable, at which point a compacted log refuses to boot. The key resolves through the same KeySource URIs as everything else, via DARKPOOL_SNAPSHOT_KEY_URI.

Boot fails closed. A durable store (file or postgres) with no key won't start instead of quietly writing plaintext. The in-memory store falls back to an ephemeral per-process key since those snapshots don't survive a restart anyway. take_snapshot and the snapshotter both bail rather than write when no cipher is set.

For coverage there's a new snapshot_contains_no_plaintext canary: it reads the raw envelope bytes and checks the markers aren't there, with a sanity assert that the unencrypted form does contain them so it can't pass for the wrong reason. Plus SnapshotCipher unit tests and the engine fail-closed cases. clippy --all-targets and the full workspace suite pass. ADR 0006 writes up the key-choice reasoning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snapshot encryption at rest using authenticated encryption; snapshots are now sealed with an encryption key.
  * New `--snapshot-key-uri` CLI option and `DARKPOOL_SNAPSHOT_KEY_URI` environment variable to configure the encryption key source.
  * Durable snapshot stores now require an encryption key to prevent accidental plaintext persistence; in-memory snapshots auto-generate ephemeral keys.

* **Documentation**
  * Added ADR documenting snapshot encryption design, envelope format, and operational policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->