### PR TITLE
Gate the IVC stub, settlement arming, and governance behind a dev/test chain allowlist

### DIFF
--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -82,6 +82,16 @@ contract DeployScript is Script {
                 "IVC_VERIFIER_ADDRESS required off the dev/test allowlist; the stub decider must never settle real funds"
             );
             require(realIvcVerifier.code.length > 0, "IVC_VERIFIER_ADDRESS has no code");
+            // Requiring an explicit address must not become a backdoor for
+            // wiring the very verifier this guard exists to keep off real
+            // chains: the all-accepting stub has code, so the length check alone
+            // lets it through. Reject it by runtime-bytecode hash. This catches
+            // the stub compiled from this repo; a real decider is a distinct
+            // contract with a distinct codehash.
+            require(
+                realIvcVerifier.codehash != keccak256(type(HyperNovaDeciderVerifier).runtimeCode),
+                "IVC_VERIFIER_ADDRESS must not be the all-accepting stub decider"
+            );
         }
 
         (

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -60,6 +60,28 @@ contract DeployScript is Script {
         );
         address darkPoolOwner = vm.envOr("DARKPOOL_OWNER", deployer);
 
+        // IVC verifier backend selection (#210). The HyperNova decider is still
+        // a stub that accepts every proof, so it must never be wired into this
+        // fund-custody contract on a real chain. Dev/test chains (local +
+        // Sepolia) auto-wire the stub and arm the IVC path for end-to-end
+        // testing; every other chain - including every L2/L1 mainnet - MUST
+        // supply a real, audited decider via IVC_VERIFIER_ADDRESS, validated
+        // HERE before vm.startBroadcast so a missing/invalid verifier aborts
+        // with nothing deployed (the same fail-fast contract as the env checks
+        // above) rather than reverting mid-broadcast.
+        bool stubChain = _stubAllowedOnChain(block.chainid);
+        address realIvcVerifier;
+        if (!stubChain) {
+            // address(0) sentinel: an unset OR explicitly-zero env var both mean
+            // "no real verifier provided", which is the reject case.
+            realIvcVerifier = vm.envOr("IVC_VERIFIER_ADDRESS", address(0));
+            require(
+                realIvcVerifier != address(0),
+                "IVC_VERIFIER_ADDRESS required off the dev/test allowlist; the stub decider must never settle real funds"
+            );
+            require(realIvcVerifier.code.length > 0, "IVC_VERIFIER_ADDRESS has no code");
+        }
+
         (
             uint256[2] memory alpha1,
             uint256[2][2] memory beta2,
@@ -97,17 +119,28 @@ contract DeployScript is Script {
             console.log("Allowlisted quote token:", quoteToken);
         }
 
-        require(
-            block.chainid != 1,
-            "stub IVC verifier cannot be deployed on mainnet; use a real Decider verifier"
-        );
-        HyperNovaDeciderVerifier hypernova = new HyperNovaDeciderVerifier();
-        console.log("HyperNovaDeciderVerifier:", address(hypernova));
-        // Route IVC verification through the proxy so key rotation only
-        // requires proxy.setIvcVerifier(newImpl) — no DarkPool redeployment.
-        proxy.setIvcVerifier(address(hypernova));
+        // Wire the IVC verifier decided above. On dev/test chains deploy the
+        // stub now and arm the path; off-allowlist use the pre-validated real
+        // verifier and leave the path DISARMED until the owner reviews it.
+        address ivcImpl;
+        if (stubChain) {
+            HyperNovaDeciderVerifier hypernova = new HyperNovaDeciderVerifier();
+            ivcImpl = address(hypernova);
+            console.log("HyperNovaDeciderVerifier (STUB - dev/test only):", ivcImpl);
+        } else {
+            ivcImpl = realIvcVerifier;
+            console.log("IVC verifier (real, from IVC_VERIFIER_ADDRESS):", ivcImpl);
+        }
+        // Route IVC verification through the proxy so key rotation only requires
+        // proxy.setIvcVerifier(newImpl) - no DarkPool redeployment.
+        proxy.setIvcVerifier(ivcImpl);
         pool.setIvcVerifier(address(proxy));
-        console.log("IVC verifier set on DarkPool via VerifierProxy (stub)");
+        if (stubChain) {
+            pool.setIvcEnabled(true);
+            console.log("IVC settlement path armed (dev/test stub)");
+        } else {
+            console.log("IVC path DISARMED - owner must call setIvcEnabled(true) after review");
+        }
 
         if (governor != deployer) {
             proxy.transferOwnership(governor);
@@ -125,14 +158,26 @@ contract DeployScript is Script {
             console.log("DarkPool ownership transfer initiated (awaiting acceptOwnership):", darkPoolOwner);
         }
 
+        // Records the concrete decider behind the proxy (stub on dev/test, the
+        // real verifier off-allowlist) under the unchanged hypernovaDeciderVerifier
+        // JSON key (no rename) so existing deployment-file consumers keep working.
         _writeDeployment(
             address(pool),
             address(proxy),
             address(verifier),
-            address(hypernova)
+            ivcImpl
         );
 
         vm.stopBroadcast();
+    }
+
+    /// @dev Chains where the all-accepting stub decider may be auto-wired and
+    ///      the IVC settlement path armed: local dev (Anvil 31337, legacy 1337)
+    ///      and the Sepolia testnet (11155111). Every other chain - including
+    ///      every L2/L1 mainnet - must instead supply a real decider via
+    ///      IVC_VERIFIER_ADDRESS (#210).
+    function _stubAllowedOnChain(uint256 chainId) internal pure returns (bool) {
+        return chainId == 31337 || chainId == 1337 || chainId == 11155111;
     }
 
     function _writeDeployment(

--- a/contracts/script/Deploy.s.sol
+++ b/contracts/script/Deploy.s.sol
@@ -38,11 +38,12 @@ contract DeployScript is Script {
         // VERIFIER_GOVERNOR: address that can rotate the verifier backend.
         // In production this should be a TimelockController (or a multisig
         // fronting one); the default falls back to the deployer for local
-        // and CI deploys. On mainnet we refuse the silent fallback — a single
+        // and CI deploys. Off the dev/test allowlist — i.e. on every real
+        // chain, not just Ethereum L1 — we refuse the silent fallback: a single
         // EOA holding VK-rotation rights would be a governance footgun.
         require(
-            block.chainid != 1 || vm.envExists("VERIFIER_GOVERNOR"),
-            "VERIFIER_GOVERNOR must be set on mainnet"
+            _isDevTestChain(block.chainid) || vm.envExists("VERIFIER_GOVERNOR"),
+            "VERIFIER_GOVERNOR must be set on non-dev/test chains"
         );
         address governor = vm.envOr("VERIFIER_GOVERNOR", deployer);
 
@@ -51,12 +52,13 @@ contract DeployScript is Script {
         // verifier pointer, and pause on the contract that escrows every
         // trader's funds. In production this must be a TimelockController
         // (or a multisig fronting one); the default falls back to the
-        // deployer for local and CI deploys. On mainnet we refuse the
-        // silent fallback — leaving full protocol control on a single
-        // deploying EOA is the centralisation risk flagged in #166.
+        // deployer for local and CI deploys. Off the dev/test allowlist — i.e.
+        // on every real chain, not just Ethereum L1 — we refuse the silent
+        // fallback: leaving full protocol control on a single deploying EOA is
+        // the centralisation risk flagged in #166.
         require(
-            block.chainid != 1 || vm.envExists("DARKPOOL_OWNER"),
-            "DARKPOOL_OWNER must be set on mainnet"
+            _isDevTestChain(block.chainid) || vm.envExists("DARKPOOL_OWNER"),
+            "DARKPOOL_OWNER must be set on non-dev/test chains"
         );
         address darkPoolOwner = vm.envOr("DARKPOOL_OWNER", deployer);
 
@@ -69,9 +71,9 @@ contract DeployScript is Script {
         // HERE before vm.startBroadcast so a missing/invalid verifier aborts
         // with nothing deployed (the same fail-fast contract as the env checks
         // above) rather than reverting mid-broadcast.
-        bool stubChain = _stubAllowedOnChain(block.chainid);
+        bool devTestChain = _isDevTestChain(block.chainid);
         address realIvcVerifier;
-        if (!stubChain) {
+        if (!devTestChain) {
             // address(0) sentinel: an unset OR explicitly-zero env var both mean
             // "no real verifier provided", which is the reject case.
             realIvcVerifier = vm.envOr("IVC_VERIFIER_ADDRESS", address(0));
@@ -123,7 +125,7 @@ contract DeployScript is Script {
         // stub now and arm the path; off-allowlist use the pre-validated real
         // verifier and leave the path DISARMED until the owner reviews it.
         address ivcImpl;
-        if (stubChain) {
+        if (devTestChain) {
             HyperNovaDeciderVerifier hypernova = new HyperNovaDeciderVerifier();
             ivcImpl = address(hypernova);
             console.log("HyperNovaDeciderVerifier (STUB - dev/test only):", ivcImpl);
@@ -135,7 +137,7 @@ contract DeployScript is Script {
         // proxy.setIvcVerifier(newImpl) - no DarkPool redeployment.
         proxy.setIvcVerifier(ivcImpl);
         pool.setIvcVerifier(address(proxy));
-        if (stubChain) {
+        if (devTestChain) {
             pool.setIvcEnabled(true);
             console.log("IVC settlement path armed (dev/test stub)");
         } else {
@@ -171,12 +173,15 @@ contract DeployScript is Script {
         vm.stopBroadcast();
     }
 
-    /// @dev Chains where the all-accepting stub decider may be auto-wired and
-    ///      the IVC settlement path armed: local dev (Anvil 31337, legacy 1337)
-    ///      and the Sepolia testnet (11155111). Every other chain - including
-    ///      every L2/L1 mainnet - must instead supply a real decider via
+    /// @dev Dev/test chains, where production hardening is deliberately relaxed:
+    ///      local dev (Anvil 31337, legacy 1337) and the Sepolia testnet
+    ///      (11155111). On these the deploy may fall back to the deployer EOA
+    ///      for the verifier governor and the pool owner, and may auto-wire and
+    ///      arm the all-accepting stub decider. Every other chain - including
+    ///      every L2/L1 mainnet - must instead supply an explicit
+    ///      VERIFIER_GOVERNOR, DARKPOOL_OWNER, and a real decider via
     ///      IVC_VERIFIER_ADDRESS (#210).
-    function _stubAllowedOnChain(uint256 chainId) internal pure returns (bool) {
+    function _isDevTestChain(uint256 chainId) internal pure returns (bool) {
         return chainId == 31337 || chainId == 1337 || chainId == 11155111;
     }
 

--- a/contracts/src/DarkPool.sol
+++ b/contracts/src/DarkPool.sol
@@ -101,6 +101,16 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
     ///         double-spending reserved escrow.
     mapping(bytes32 => bool) public sessionSettled;
 
+    /// @notice IVC settlement arm switch. `submitSession` and `settleAuction`
+    ///         revert while this is false, so wiring the all-accepting stub
+    ///         decider no longer auto-arms fund settlement on the IVC path
+    ///         (#210). Defaults to false at construction; the owner flips it on
+    ///         only once a real, audited Decider verifier has replaced the stub.
+    ///         Defense-in-depth behind the deploy-time chain allowlist: a stub
+    ///         wired post-deploy via `setIvcVerifier`, or a deploy-script
+    ///         regression, still cannot settle reserved escrow while this is off.
+    bool public ivcEnabled;
+
     address public feeRecipient;
     uint256 public minSize;
     uint256 public minPrice;
@@ -122,9 +132,17 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
 
     event SessionSubmitted(bytes32 indexed sessionId, uint64 nSteps, bytes32 policyHash);
     event AuctionSettled(bytes32 indexed sessionId, bytes32 indexed auctionId);
+    event IvcEnabledSet(bool enabled);
 
     modifier onlyOperator() {
         require(operators[msg.sender], "not operator");
+        _;
+    }
+
+    /// @dev Gates the IVC settlement path (submitSession + settleAuction) on the
+    ///      owner having explicitly armed it via setIvcEnabled. See `ivcEnabled`.
+    modifier whenIvcEnabled() {
+        require(ivcEnabled, "ivc settlement disabled");
         _;
     }
 
@@ -380,6 +398,17 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         ivcVerifier = IDeciderVerifier(ivcVerifier_);
     }
 
+    /// @notice Arm or disarm the IVC settlement path. Off until the owner turns
+    ///         it on, which should happen only after a real Decider verifier
+    ///         (the trusted-setup output, not the all-accepting stub) is wired
+    ///         via setIvcVerifier. Kept independent of the verifier pointer on
+    ///         purpose: settlement needs both a verifier set AND the path armed,
+    ///         so neither a stray setIvcVerifier nor a stale arm settles alone.
+    function setIvcEnabled(bool enabled) external onlyOwner {
+        ivcEnabled = enabled;
+        emit IvcEnabledSet(enabled);
+    }
+
     /// @notice Commit to an IVC-proved session. The matches are bound to the
     ///         proof by its settlement hash-chain `zN[3]` (#209), which
     ///         settleAuction recomputes from `matches[]` — no separate
@@ -394,7 +423,7 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         uint256[5] calldata zN,
         uint64 nSteps,
         bytes32 policyHash
-    ) external onlyOperator whenNotPaused {
+    ) external onlyOperator whenNotPaused whenIvcEnabled {
         require(!sessionSubmitted[sessionId], "session already submitted");
         require(address(ivcVerifier) != address(0), "ivc verifier not set");
         require(ivcVerifier.verifyIvcProof(proof, z0, zN, nSteps), "invalid ivc proof");
@@ -429,7 +458,7 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         bytes32 sessionId,
         bytes32 auctionId,
         IDarkPool.Match[] calldata matches
-    ) external onlyOperator whenNotPaused {
+    ) external onlyOperator whenNotPaused whenIvcEnabled {
         require(sessionSubmitted[sessionId], "session not submitted");
         require(!settled[auctionId], "auction already settled");
         // A session proves exactly one auction's matches. Because the binding

--- a/contracts/test/DarkPool.t.sol
+++ b/contracts/test/DarkPool.t.sol
@@ -66,6 +66,11 @@ contract DarkPoolTest is Test {
         // not on the allowlist are rejected by deposit().
         pool.setTokenAllowed(address(baseToken), true);
         pool.setTokenAllowed(address(quoteToken), true);
+
+        // Arm the IVC settlement path (#210) so the HyperNova session tests can
+        // exercise submitSession/settleAuction. It defaults off; the dedicated
+        // gate tests below disarm it (or use a fresh pool) to cover that.
+        pool.setIvcEnabled(true);
     }
 
     // --- Deposit ---
@@ -784,6 +789,78 @@ contract DarkPoolTest is Test {
         vm.prank(operator);
         pool.settleAuction(sessionId, auctionId, matches);
         assertTrue(pool.settled(auctionId));
+    }
+
+    /// #210: the IVC settlement path is disarmed on a freshly constructed pool,
+    /// so wiring the all-accepting stub decider cannot auto-settle escrow.
+    function test_ivc_disabledByDefault() public {
+        DarkPool fresh = new DarkPool(address(verifier), feeRecipient, initialPubkey);
+        assertFalse(fresh.ivcEnabled());
+    }
+
+    /// Only the owner can arm/disarm the IVC path, and doing so emits the event.
+    function test_setIvcEnabled_onlyOwner_and_emits() public {
+        DarkPool fresh = new DarkPool(address(verifier), feeRecipient, initialPubkey);
+
+        vm.prank(address(0xdead));
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, address(0xdead)));
+        fresh.setIvcEnabled(true);
+
+        vm.expectEmit(false, false, false, true);
+        emit DarkPool.IvcEnabledSet(true);
+        fresh.setIvcEnabled(true);
+        assertTrue(fresh.ivcEnabled());
+
+        fresh.setIvcEnabled(false);
+        assertFalse(fresh.ivcEnabled());
+    }
+
+    /// submitSession reverts while the IVC path is disarmed, even with a verifier
+    /// wired and a valid operator — the gate is independent of both.
+    function test_submitSession_revertsWhenIvcDisabled() public {
+        pool.setIvcVerifier(address(new HyperNovaDeciderVerifier()));
+        pool.setIvcEnabled(false);
+
+        (uint256[5] memory z0, uint256[5] memory zN) = _ivcStates(0);
+        vm.prank(operator);
+        vm.expectRevert("ivc settlement disabled");
+        pool.submitSession(bytes32(uint256(1)), new bytes(64), z0, zN, 60, bytes32(TEST_POLICY_HASH));
+    }
+
+    /// Disarming after a session is submitted also freezes settlement: the whole
+    /// IVC path, not just its entry point, is gated.
+    function test_settleAuction_revertsWhenIvcDisabled() public {
+        pool.setIvcVerifier(address(new HyperNovaDeciderVerifier()));
+
+        uint256 price = 100e18;
+        uint256 size = 10e18;
+        uint256 notional = price * size / 1e18;
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
+
+        bytes32 sessionId = bytes32(uint256(1));
+        uint256 settlementAcc = _settlementAcc(trader1, trader2, price, size);
+        (uint256[5] memory z0, uint256[5] memory zN) = _ivcStates(settlementAcc);
+        vm.prank(operator);
+        pool.submitSession(sessionId, new bytes(64), z0, zN, 60, bytes32(TEST_POLICY_HASH));
+
+        // Owner disarms the path after submission; settlement must now revert.
+        pool.setIvcEnabled(false);
+
+        IDarkPool.Match[] memory matches = new IDarkPool.Match[](1);
+        matches[0] = IDarkPool.Match({
+            bidOrderId: bytes32(uint256(10)),
+            askOrderId: bytes32(uint256(11)),
+            bidTrader: trader1,
+            askTrader: trader2,
+            baseToken: address(baseToken),
+            quoteToken: address(quoteToken),
+            price: price,
+            size: size
+        });
+        vm.prank(operator);
+        vm.expectRevert("ivc settlement disabled");
+        pool.settleAuction(sessionId, bytes32(uint256(2)), matches);
     }
 
     /// The #209 binding: the proof fixes zN[3] to the settlement chain over the

--- a/contracts/test/Deploy.t.sol
+++ b/contracts/test/Deploy.t.sol
@@ -5,13 +5,11 @@ import {Test} from "forge-std/Test.sol";
 import {stdJson} from "forge-std/StdJson.sol";
 import {DeployScript} from "../script/Deploy.s.sol";
 import {DarkPool} from "../src/DarkPool.sol";
+import {HyperNovaDeciderVerifier} from "../src/HyperNovaDeciderVerifier.sol";
 
 contract DeployTest is Test {
     using stdJson for string;
 
-    // Non-mainnet id so the deploy writes to a throwaway deployments file
-    // we clean up, instead of clobbering the committed 31337.json.
-    uint256 constant CHAIN_ID = 424242;
     uint256 constant DEPLOYER_KEY = 0xA11CE;
 
     address deployer = vm.addr(DEPLOYER_KEY);
@@ -28,10 +26,21 @@ contract DeployTest is Test {
         );
     }
 
-    // The deploy must not leave DarkPool — which escrows every trader's
-    // funds — owned by the deploying EOA. On mainnet it refuses the silent
-    // fallback; given a DARKPOOL_OWNER it hands the pool over (Ownable2Step,
-    // so ownership is pending until the timelock/multisig accepts).
+    // forge runs a contract's test functions in parallel and vm.setEnv mutates
+    // process-global state, so two tests that set IVC_VERIFIER_ADDRESS to
+    // different values would race. These tests avoid that: only
+    // test_ivc_offAllowlistRequiresRealVerifier touches that env (reading it
+    // sequentially within itself), the allowlist tests never read it (the script
+    // auto-wires the stub before consulting the env), and every test that writes
+    // a deployment file uses a distinct chainid so the deployments/<id>.json
+    // paths never collide.
+
+    // The deploy must not leave DarkPool — which escrows every trader's funds —
+    // owned by the deploying EOA. On mainnet it refuses the silent fallback;
+    // given a DARKPOOL_OWNER it hands the pool over (Ownable2Step, so ownership
+    // is pending until the timelock/multisig accepts). Run here on an allowlisted
+    // local chain, which also confirms the stub is auto-wired and the IVC path
+    // armed for local end-to-end work.
     function test_darkPoolOwnershipHandoff() public {
         // Mainnet without DARKPOOL_OWNER is refused. VERIFIER_GOVERNOR is set
         // so we get past its (earlier) guard and reach the new requirement.
@@ -41,16 +50,64 @@ contract DeployTest is Test {
         vm.expectRevert(bytes("DARKPOOL_OWNER must be set on mainnet"));
         mainnetDeploy.run();
 
-        // With an owner set, deploy on a non-mainnet chain and confirm the
-        // pool is handed to it rather than retained by the deployer.
+        // With an owner set, deploy on the allowlisted local devnet (1337, not
+        // the committed 31337.json) and confirm the pool is handed over.
         vm.setEnv("DARKPOOL_OWNER", vm.toString(darkPoolOwner));
-        vm.chainId(CHAIN_ID);
+        vm.chainId(1337);
         DeployScript deploy = new DeployScript();
         deploy.run();
 
         DarkPool pool = DarkPool(_deployedPool());
         assertEq(pool.pendingOwner(), darkPoolOwner, "owner transfer not queued");
         assertEq(pool.owner(), deployer, "owner should change only on acceptOwnership");
+        assertTrue(pool.ivcEnabled(), "local allowlist deploy should arm the IVC stub");
+
+        vm.removeFile(_deploymentPath());
+    }
+
+    // Sepolia is on the dev/test allowlist, so the stub is auto-wired and the
+    // IVC path armed there too (covers the testnet allowlist member; the local
+    // member is covered by test_darkPoolOwnershipHandoff on 1337).
+    function test_ivc_stubArmedOnSepolia() public {
+        vm.chainId(11155111);
+        DeployScript deploy = new DeployScript();
+        deploy.run();
+
+        DarkPool pool = DarkPool(_deployedPool());
+        assertTrue(pool.ivcEnabled(), "Sepolia deploy should arm the IVC stub");
+
+        vm.removeFile(_deploymentPath());
+    }
+
+    // #210, the core guard: off the dev/test allowlist the all-accepting stub is
+    // never auto-wired. Without a real IVC_VERIFIER_ADDRESS the deploy reverts so
+    // the stub can't reach a real-money chain; with a real, code-bearing decider
+    // it wires that verifier but leaves the IVC path DISARMED for the owner to
+    // enable only after review. Both halves live in one test so this is the only
+    // function that mutates IVC_VERIFIER_ADDRESS (see the parallelism note above).
+    function test_ivc_offAllowlistRequiresRealVerifier() public {
+        // Base mainnet (8453): real money, not chainid 1. No verifier -> revert.
+        vm.setEnv("IVC_VERIFIER_ADDRESS", vm.toString(address(0)));
+        vm.chainId(8453);
+        DeployScript blocked = new DeployScript();
+        vm.expectRevert(
+            bytes(
+                "IVC_VERIFIER_ADDRESS required off the dev/test allowlist; the stub decider must never settle real funds"
+            )
+        );
+        blocked.run();
+
+        // Optimism mainnet (10): a real, code-bearing decider is supplied. The
+        // deploy succeeds and wires it, but leaves the IVC path disarmed.
+        address realDecider = address(new HyperNovaDeciderVerifier());
+        vm.setEnv("IVC_VERIFIER_ADDRESS", vm.toString(realDecider));
+        vm.chainId(10);
+        DeployScript deploy = new DeployScript();
+        deploy.run();
+
+        DarkPool pool = DarkPool(_deployedPool());
+        assertFalse(pool.ivcEnabled(), "real-chain deploy must leave IVC disarmed");
+        assertTrue(address(pool.ivcVerifier()) != address(0), "ivc verifier should be wired");
 
         vm.removeFile(_deploymentPath());
     }

--- a/contracts/test/Deploy.t.sol
+++ b/contracts/test/Deploy.t.sol
@@ -7,6 +7,19 @@ import {DeployScript} from "../script/Deploy.s.sol";
 import {DarkPool} from "../src/DarkPool.sol";
 import {HyperNovaDeciderVerifier} from "../src/HyperNovaDeciderVerifier.sol";
 
+// Stand-in for a real Decider verifier in deploy tests: code-bearing and, unlike
+// HyperNovaDeciderVerifier, not all-accepting (distinct runtime bytecode, hence a
+// distinct codehash), so it passes the deploy's stub-rejection guard.
+contract NotTheStubDecider {
+    function verifyIvcProof(bytes calldata, uint256[5] calldata, uint256[5] calldata, uint64)
+        external
+        pure
+        returns (bool)
+    {
+        return false;
+    }
+}
+
 contract DeployTest is Test {
     using stdJson for string;
 
@@ -92,10 +105,17 @@ contract DeployTest is Test {
         );
         deploy.run();
 
-        // 5. All three supplied: the deploy succeeds, queues the ownership
-        // handoff (Ownable2Step, pending until acceptOwnership), and leaves the
-        // IVC path disarmed for the owner to enable after review.
+        // 4b. Even a code-bearing address is rejected if it is the all-accepting
+        // stub itself: requiring an explicit address must not become a backdoor
+        // for wiring the very verifier this guard keeps off real chains.
         vm.setEnv("IVC_VERIFIER_ADDRESS", vm.toString(address(new HyperNovaDeciderVerifier())));
+        vm.expectRevert(bytes("IVC_VERIFIER_ADDRESS must not be the all-accepting stub decider"));
+        deploy.run();
+
+        // 5. A real (non-stub) decider plus governor and owner: the deploy
+        // succeeds, queues the ownership handoff (Ownable2Step, pending until
+        // acceptOwnership), and leaves the IVC path disarmed for owner review.
+        vm.setEnv("IVC_VERIFIER_ADDRESS", vm.toString(address(new NotTheStubDecider())));
         deploy.run();
         DarkPool pool = DarkPool(_deployedPool());
         assertEq(pool.pendingOwner(), darkPoolOwner, "owner transfer not queued");

--- a/contracts/test/Deploy.t.sol
+++ b/contracts/test/Deploy.t.sol
@@ -27,47 +27,19 @@ contract DeployTest is Test {
     }
 
     // forge runs a contract's test functions in parallel and vm.setEnv mutates
-    // process-global state, so two tests that set IVC_VERIFIER_ADDRESS to
-    // different values would race. These tests avoid that: only
-    // test_ivc_offAllowlistRequiresRealVerifier touches that env (reading it
-    // sequentially within itself), the allowlist tests never read it (the script
-    // auto-wires the stub before consulting the env), and every test that writes
-    // a deployment file uses a distinct chainid so the deployments/<id>.json
-    // paths never collide.
-
-    // The deploy must not leave DarkPool — which escrows every trader's funds —
-    // owned by the deploying EOA. On mainnet it refuses the silent fallback;
-    // given a DARKPOOL_OWNER it hands the pool over (Ownable2Step, so ownership
-    // is pending until the timelock/multisig accepts). Run here on an allowlisted
-    // local chain, which also confirms the stub is auto-wired and the IVC path
-    // armed for local end-to-end work.
-    function test_darkPoolOwnershipHandoff() public {
-        // Mainnet without DARKPOOL_OWNER is refused. VERIFIER_GOVERNOR is set
-        // so we get past its (earlier) guard and reach the new requirement.
-        vm.setEnv("VERIFIER_GOVERNOR", vm.toString(governor));
-        vm.chainId(1);
-        DeployScript mainnetDeploy = new DeployScript();
-        vm.expectRevert(bytes("DARKPOOL_OWNER must be set on mainnet"));
-        mainnetDeploy.run();
-
-        // With an owner set, deploy on the allowlisted local devnet (1337, not
-        // the committed 31337.json) and confirm the pool is handed over.
-        vm.setEnv("DARKPOOL_OWNER", vm.toString(darkPoolOwner));
-        vm.chainId(1337);
-        DeployScript deploy = new DeployScript();
-        deploy.run();
-
-        DarkPool pool = DarkPool(_deployedPool());
-        assertEq(pool.pendingOwner(), darkPoolOwner, "owner transfer not queued");
-        assertEq(pool.owner(), deployer, "owner should change only on acceptOwnership");
-        assertTrue(pool.ivcEnabled(), "local allowlist deploy should arm the IVC stub");
-
-        vm.removeFile(_deploymentPath());
-    }
+    // process-global state, so two tests that set the same governance env var
+    // (VERIFIER_GOVERNOR, DARKPOOL_OWNER, IVC_VERIFIER_ADDRESS) to different
+    // values — or one needing it set while another needs it absent — would race.
+    // test_deployGuardsAndOwnershipHandoff is the sole reader/writer of those
+    // three vars and walks every case sequentially within itself. The Sepolia
+    // test touches none of them (dev/test chain: governor/owner fall back and
+    // the stub is auto-wired) and asserts only ivcEnabled, so it stays
+    // standalone and race-free. Each test that writes a deployment file uses a
+    // distinct chainid so the deployments/<id>.json paths never collide.
 
     // Sepolia is on the dev/test allowlist, so the stub is auto-wired and the
-    // IVC path armed there too (covers the testnet allowlist member; the local
-    // member is covered by test_darkPoolOwnershipHandoff on 1337).
+    // IVC path armed. Asserts only ivcEnabled, which is independent of the
+    // governance env vars the comprehensive test mutates.
     function test_ivc_stubArmedOnSepolia() public {
         vm.chainId(11155111);
         DeployScript deploy = new DeployScript();
@@ -79,36 +51,57 @@ contract DeployTest is Test {
         vm.removeFile(_deploymentPath());
     }
 
-    // #210, the core guard: off the dev/test allowlist the all-accepting stub is
-    // never auto-wired. Without a real IVC_VERIFIER_ADDRESS the deploy reverts so
-    // the stub can't reach a real-money chain; with a real, code-bearing decider
-    // it wires that verifier but leaves the IVC path DISARMED for the owner to
-    // enable only after review. Both halves live in one test so this is the only
-    // function that mutates IVC_VERIFIER_ADDRESS (see the parallelism note above).
-    function test_ivc_offAllowlistRequiresRealVerifier() public {
-        // Base mainnet (8453): real money, not chainid 1. No verifier -> revert.
-        vm.setEnv("IVC_VERIFIER_ADDRESS", vm.toString(address(0)));
+    // #210 and its adjacent governance finding. On every chain off the dev/test
+    // allowlist — not just Ethereum L1 — the deploy must refuse to silently fall
+    // back to the deploying EOA for the verifier governor and pool owner, and
+    // must refuse to wire the all-accepting stub decider. Walked here in one
+    // function (the sole toucher of the three governance env vars, so it cannot
+    // race a parallel test). One DeployScript instance is reused so expectRevert
+    // only ever wraps run(), never a contract creation.
+    function test_deployGuardsAndOwnershipHandoff() public {
+        DeployScript deploy = new DeployScript();
+
+        // 1. Dev chain (legacy local 1337, not the committed 31337.json): no
+        // governance env set, so governor and owner fall back to the deployer
+        // (no transfer) and the stub is auto-wired and armed.
+        vm.chainId(1337);
+        deploy.run();
+        DarkPool devPool = DarkPool(_deployedPool());
+        assertEq(devPool.owner(), deployer, "dev chain should keep the deployer as owner");
+        assertEq(devPool.pendingOwner(), address(0), "dev chain should not queue a transfer");
+        assertTrue(devPool.ivcEnabled(), "dev chain should arm the IVC stub");
+        vm.removeFile(_deploymentPath());
+
+        // 2. Real chain (Base mainnet 8453) with no VERIFIER_GOVERNOR -> reject.
         vm.chainId(8453);
-        DeployScript blocked = new DeployScript();
+        vm.expectRevert(bytes("VERIFIER_GOVERNOR must be set on non-dev/test chains"));
+        deploy.run();
+
+        // 3. Governor set, but no DARKPOOL_OWNER -> reject.
+        vm.setEnv("VERIFIER_GOVERNOR", vm.toString(governor));
+        vm.expectRevert(bytes("DARKPOOL_OWNER must be set on non-dev/test chains"));
+        deploy.run();
+
+        // 4. Governor + owner set, but no real IVC verifier -> reject (the stub
+        // must never reach a real-money chain).
+        vm.setEnv("DARKPOOL_OWNER", vm.toString(darkPoolOwner));
         vm.expectRevert(
             bytes(
                 "IVC_VERIFIER_ADDRESS required off the dev/test allowlist; the stub decider must never settle real funds"
             )
         );
-        blocked.run();
-
-        // Optimism mainnet (10): a real, code-bearing decider is supplied. The
-        // deploy succeeds and wires it, but leaves the IVC path disarmed.
-        address realDecider = address(new HyperNovaDeciderVerifier());
-        vm.setEnv("IVC_VERIFIER_ADDRESS", vm.toString(realDecider));
-        vm.chainId(10);
-        DeployScript deploy = new DeployScript();
         deploy.run();
 
+        // 5. All three supplied: the deploy succeeds, queues the ownership
+        // handoff (Ownable2Step, pending until acceptOwnership), and leaves the
+        // IVC path disarmed for the owner to enable after review.
+        vm.setEnv("IVC_VERIFIER_ADDRESS", vm.toString(address(new HyperNovaDeciderVerifier())));
+        deploy.run();
         DarkPool pool = DarkPool(_deployedPool());
+        assertEq(pool.pendingOwner(), darkPoolOwner, "owner transfer not queued");
+        assertEq(pool.owner(), deployer, "owner should change only on acceptOwnership");
         assertFalse(pool.ivcEnabled(), "real-chain deploy must leave IVC disarmed");
         assertTrue(address(pool.ivcVerifier()) != address(0), "ivc verifier should be wired");
-
         vm.removeFile(_deploymentPath());
     }
 

--- a/contracts/test/SettleAuctionGas.t.sol
+++ b/contracts/test/SettleAuctionGas.t.sol
@@ -58,6 +58,7 @@ contract SettleAuctionGasTest is Test {
         pool.setTokenAllowed(address(baseToken), true);
         pool.setTokenAllowed(address(quoteToken), true);
         pool.setIvcVerifier(address(new HyperNovaDeciderVerifier()));
+        pool.setIvcEnabled(true); // #210: arm the IVC path for the gas test
     }
 
     function _bidTrader(uint256 i) internal pure returns (address) {

--- a/crates/dp-settlement/abi/DarkPool.json
+++ b/crates/dp-settlement/abi/DarkPool.json
@@ -187,6 +187,19 @@
   },
   {
     "type": "function",
+    "name": "ivcEnabled",
+    "inputs": [],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
     "name": "ivcVerifier",
     "inputs": [],
     "outputs": [
@@ -510,6 +523,19 @@
         "name": "recipient",
         "type": "address",
         "internalType": "address"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "setIvcEnabled",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "internalType": "bool"
       }
     ],
     "outputs": [],
@@ -918,6 +944,19 @@
         "type": "uint256",
         "indexed": false,
         "internalType": "uint256"
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "IvcEnabledSet",
+    "inputs": [
+      {
+        "name": "enabled",
+        "type": "bool",
+        "indexed": false,
+        "internalType": "bool"
       }
     ],
     "anonymous": false

--- a/front/lib/contracts/generated.ts
+++ b/front/lib/contracts/generated.ts
@@ -98,6 +98,13 @@ export const darkPoolAbi = [
   {
     type: 'function',
     inputs: [],
+    name: 'ivcEnabled',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [],
     name: 'ivcVerifier',
     outputs: [{ name: '', internalType: 'contract IDeciderVerifier', type: 'address' }],
     stateMutability: 'view',
@@ -258,6 +265,13 @@ export const darkPoolAbi = [
     type: 'function',
     inputs: [{ name: 'recipient', internalType: 'address', type: 'address' }],
     name: 'setFeeRecipient',
+    outputs: [],
+    stateMutability: 'nonpayable',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: 'enabled', internalType: 'bool', type: 'bool' }],
+    name: 'setIvcEnabled',
     outputs: [],
     stateMutability: 'nonpayable',
   },
@@ -475,6 +489,12 @@ export const darkPoolAbi = [
       },
     ],
     name: 'Deposit',
+  },
+  {
+    type: 'event',
+    anonymous: false,
+    inputs: [{ name: 'enabled', internalType: 'bool', type: 'bool', indexed: false }],
+    name: 'IvcEnabledSet',
   },
   {
     type: 'event',


### PR DESCRIPTION
Closes #210

The HyperNova decider is still the all-accepting stub, and the deploy script conflated "mainnet" with Ethereum L1 (chainid == 1) in three places. Every L2 and L1 mainnet, every testnet and every fork therefore wired the all-accepting verifier into the fund-custody contract, and silently fell back to the deploying EOA for the verifier governor and the pool owner — leaving a verifier that returns true for any proof, plus VK-rotation rights and full protocol control, on a single hot key on real-money chains.

Three complementary changes close that off. DarkPool now gates submitSession and settleAuction behind an owner-armed ivcEnabled switch that defaults off, so wiring the stub no longer auto-arms settlement — the owner only enables the path once a real decider replaces the stub. The deploy script replaces the chainid==1 checks with a single dev/test allowlist helper (Anvil 31337, legacy 1337, Sepolia 11155111): on those chains the stub is auto-wired and armed and governor/owner may default to the deployer, while every other chain must supply an explicit VERIFIER_GOVERNOR, an explicit DARKPOOL_OWNER, and a real, code-bearing decider via IVC_VERIFIER_ADDRESS — all validated before broadcast — and is left with the IVC path disarmed for the owner to enable after review.

The Groth16 settlement path is untouched. Forge tests cover the arm switch (disabled by default, owner-only arming, both entry points reverting while disarmed) and the deploy guards (dev-chain fallback, each missing-env rejection on an L2 mainnet, and the successful production handoff with the IVC path disarmed); the settlement-crate ABI is regenerated for the new functions. Full forge suite green at 135 tests and deterministic across reruns, dp-settlement builds against the new ABI, rustfmt clean.