### PR TITLE
[security] Bind the solvency witness to on-chain reserved collateral

### DIFF
--- a/crates/dp-api/src/main.rs
+++ b/crates/dp-api/src/main.rs
@@ -270,6 +270,28 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
                 chain_id = cfg.chain_id,
                 "batch submitter: on-chain (EthSubmitter)"
             );
+
+            // Value-bearing deployment: fail closed on the InsecureDevOracle
+            // default. The matching circuit's solvency witness must come from
+            // real on-chain `reserved` collateral, not a fabricated 1B balance
+            // (#213). A read-only provider (no signer needed for eth_call) backs
+            // the oracle; a bad address/URL aborts boot rather than serving
+            // traffic whose solvency proof attests nothing about real funds.
+            let oracle_contract = contract_addr
+                .parse::<alloy_primitives::Address>()
+                .map_err(|e| format!("bad DARKPOOL_CONTRACT_ADDR: {e}"))?;
+            let oracle_provider = alloy_provider::ProviderBuilder::new().connect_http(
+                rpc.parse()
+                    .map_err(|e| format!("bad DARKPOOL_ETH_RPC URL: {e}"))?,
+            );
+            engine.set_balance_oracle(Arc::new(dp_settlement::ChainBalanceOracle::new(
+                oracle_provider,
+                oracle_contract,
+            )));
+            info!(
+                contract = %contract_addr,
+                "balance oracle: on-chain (reads reserved[trader][asset])"
+            );
         } else {
             warn!(
                 rpc = %rpc,

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -6,7 +6,7 @@ use chrono::Utc;
 use dp_aggregator::{NoopAggregator, ProofAggregator};
 use dp_crypto::{Decrypter, NoopDecrypter, SnapshotCipher};
 use dp_event::{Event, EventData, EventError, SnapshotStore, Store};
-use dp_settlement::{NoopSubmitter, Submitter};
+use dp_settlement::{BalanceOracle, InsecureDevOracle, NoopSubmitter, Submitter};
 use dp_types::metrics::M_ORDERS_PLACED;
 use dp_types::{DarkPoolError, EventType, Order, Side};
 use parking_lot::{Mutex, RwLock};
@@ -47,35 +47,6 @@ impl Drop for OrderSecrets {
         self.salt.zeroize();
         self.trader_id.zeroize();
         self.commitment.zeroize();
-    }
-}
-
-/// Looks up balance/position for a trader. Default impl trusts the caller
-/// — pending escrow oracle integration.
-///
-/// **Per-leg asset semantics (#170).** The solvency constraint checks each
-/// leg's balance in the asset that leg *spends*: a bid (buyer) is checked
-/// against `notional` in the quote asset, an ask (seller) against `size` in
-/// the base asset — mirroring the on-chain `_settleMatch` debits. The real
-/// oracle must therefore return the balance in the right asset for the
-/// order's side: quote for a bid, base for an ask. The lookup is keyed only
-/// by `trader_id` today because the stub is asset-blind; the escrow-backed
-/// oracle wiring (the #165/#153-overlapping follow-up) must thread the side
-/// or per-asset escrow through so the witnessed `balance` matches the leg.
-pub trait BalanceOracle: Send + Sync {
-    fn lookup(&self, trader_id: &[u8; 32]) -> (Decimal, i128);
-}
-
-/// Returns a hard-coded 1B balance / 0 position for any trader. Solvency
-/// constraints (family 7) pass trivially under this oracle. NOT FOR
-/// PRODUCTION — `Engine::new` installs it as a placeholder and emits a
-/// startup warning; wire a real oracle via [`Engine::set_balance_oracle`]
-/// before serving traffic.
-pub struct InsecureDevOracle;
-
-impl BalanceOracle for InsecureDevOracle {
-    fn lookup(&self, _trader_id: &[u8; 32]) -> (Decimal, i128) {
-        (Decimal::from(1_000_000_000u64), 0)
     }
 }
 
@@ -572,8 +543,9 @@ impl Engine {
         // Pair-registry defense-in-depth. The API layer cannot inspect the
         // encrypted PlaceOrder payload, so the engine is the only point at
         // which an unknown/suspended pair, sub-minimum size, or off-tick
-        // price can be rejected.
-        {
+        // price can be rejected. The same lock-scoped lookup resolves the asset
+        // this leg spends for the solvency witness (#170/#213).
+        let (spend_token, spend_decimals) = {
             let state = self.inner.state.lock();
             let cfg = state.pair_config(&pair_key).ok_or_else(|| {
                 EngineError::Validation(DarkPoolError::PairNotRegistered(pair_key.clone()))
@@ -605,7 +577,14 @@ impl Engine {
                     ));
                 }
             }
-        }
+            // A bid (buyer) pays the quote token; an ask (seller) delivers the
+            // base token. The solvency oracle reads `reserved` for exactly this
+            // asset, so the witnessed balance matches the leg (#170).
+            match decrypted.side {
+                Side::Buy => (cfg.quote_token, cfg.quote_decimals),
+                Side::Sell => (cfg.base_token, cfg.base_decimals),
+            }
+        };
 
         let default_ttl = self.inner.state.lock().default_ttl;
         let ttl = if decrypted.ttl > 0 {
@@ -640,6 +619,16 @@ impl Engine {
         // derived from commitment_key. This avoids persisting plaintext
         // and survives the privacy canary test.
         let nonce = &self.inner.salt_nonce;
+        // Read the trader's settlement-locked balance for the asset this leg
+        // spends from the installed BalanceOracle (#213). Clone the Arc out so
+        // the parking_lot read guard is not held across the await; a real
+        // (chain-backed) oracle does an RPC here and fails the placement closed
+        // if the read errors rather than fabricating a balance.
+        let oracle = self.inner.oracle.read().clone();
+        let (balance, position) = oracle
+            .lookup(order.trader, spend_token, spend_decimals)
+            .await
+            .map_err(EngineError::BalanceLookup)?;
         let secrets = derive_order_secrets(
             order.id,
             order.trader.as_slice(),
@@ -647,7 +636,8 @@ impl Engine {
             order.side as u8,
             order.price,
             order.size,
-            self.inner.oracle.read().as_ref(),
+            balance,
+            position,
             nonce,
         )?;
         let commitment = secrets.commitment.to_vec();
@@ -921,8 +911,9 @@ fn leg_witness_from(
         trader_id: hex::encode(secret.trader_id),
         salt: hex::encode(secret.salt),
         // Circuit checks this in the asset the leg spends: quote for a bid,
-        // base for an ask (#170). The stub oracle is asset-blind; see
-        // `BalanceOracle` for the per-asset wiring the real oracle owes.
+        // base for an ask (#170). `place_encrypted_order` already read the
+        // BalanceOracle for that exact asset (#213), so `secret.balance` is
+        // denominated to match the leg.
         balance: secret.balance,
         position: secret.position.to_string(),
         limit_price: order.price,
@@ -953,7 +944,8 @@ fn derive_order_secrets(
     side: u8,
     price: Decimal,
     size: Decimal,
-    oracle: &dyn BalanceOracle,
+    balance: Decimal,
+    position: i128,
     nonce: &[u8; 32],
 ) -> Result<OrderSecrets, EngineError> {
     // Identity is bound to the verified on-chain address, not the client-
@@ -963,7 +955,9 @@ fn derive_order_secrets(
     let salt = derive_salt(commitment_key, order_id, nonce);
     let commitment = compute_poseidon_commitment(&trader_id, side, price, size, &salt)?;
 
-    let (balance, position) = oracle.lookup(&trader_id);
+    // `balance`/`position` are read from the installed BalanceOracle by the
+    // caller (#213) — in the asset this leg spends (#170) — and threaded in
+    // here so this helper stays pure and synchronous.
     Ok(OrderSecrets {
         salt,
         trader_id,

--- a/crates/dp-engine/src/error.rs
+++ b/crates/dp-engine/src/error.rs
@@ -19,6 +19,9 @@ pub enum EngineError {
     #[error("submit batch: {0}")]
     Submit(#[source] SettlementError),
 
+    #[error("balance oracle lookup: {0}")]
+    BalanceLookup(#[source] SettlementError),
+
     #[error(transparent)]
     Event(#[from] EventError),
 

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -5,7 +5,7 @@ use alloy_primitives::Address;
 use dp_aggregator::ProofAggregator;
 use dp_crypto::{DecryptedOrder, SnapshotCipher};
 use dp_event::{EventData, FileStore, MemStore, Store};
-use dp_settlement::Submitter;
+use dp_settlement::{BalanceOracle, SettlementError, Submitter};
 use dp_types::{EventType, Side};
 use rust_decimal::Decimal;
 use uuid::Uuid;
@@ -42,6 +42,41 @@ fn register_btc_usd(engine: &Engine) {
     engine.register_pair_without_event("BTC-USD".into(), crate::state::PairConfig::default());
 }
 
+/// Test oracle whose lookup always errors — exercises the #213 fail-closed
+/// path where a balance read failure must reject the placement.
+struct FailingOracle;
+
+impl BalanceOracle for FailingOracle {
+    fn lookup<'a>(
+        &'a self,
+        _trader: Address,
+        _asset: Address,
+        _decimals: u8,
+    ) -> dp_settlement::BalanceLookupFuture<'a> {
+        Box::pin(async { Err(SettlementError::Rpc("oracle offline".into())) })
+    }
+}
+
+/// Test oracle that records the `(asset, decimals)` of each lookup so a test
+/// can assert the engine reads the asset each leg spends (#170): quote for a
+/// bid, base for an ask.
+#[derive(Default)]
+struct RecordingOracle {
+    seen: std::sync::Mutex<Vec<(Address, u8)>>,
+}
+
+impl BalanceOracle for RecordingOracle {
+    fn lookup<'a>(
+        &'a self,
+        _trader: Address,
+        asset: Address,
+        decimals: u8,
+    ) -> dp_settlement::BalanceLookupFuture<'a> {
+        self.seen.lock().unwrap().push((asset, decimals));
+        Box::pin(async { Ok((Decimal::from(1_000_000u64), 0)) })
+    }
+}
+
 // --- engine_test.go ports ---
 
 #[tokio::test]
@@ -61,6 +96,70 @@ async fn place_order_succeeds() {
     assert_eq!(order.pair, "BTC-USD");
     assert_eq!(order.side, Side::Buy);
     assert_eq!(engine.active_order_count(), 1);
+}
+
+#[tokio::test]
+async fn place_order_fails_closed_when_balance_oracle_errors() {
+    let (engine, _store) = make_engine();
+    engine.set_balance_oracle(Arc::new(FailingOracle));
+    let r = place_plaintext_order(
+        &engine,
+        "BTC-USD",
+        Side::Buy,
+        dec(100),
+        dec(1),
+        "key1",
+        Duration::from_secs(60),
+    )
+    .await;
+    assert!(
+        matches!(r, Err(crate::EngineError::BalanceLookup(_))),
+        "a failing balance oracle must reject placement, got {r:?}"
+    );
+    assert_eq!(engine.active_order_count(), 0, "no order should be booked");
+}
+
+#[tokio::test]
+async fn place_order_reads_spend_asset_per_side() {
+    let base = Address::from([0x11u8; 20]);
+    let quote = Address::from([0x22u8; 20]);
+    let store = Arc::new(MemStore::new());
+    let engine = Engine::new(store, Duration::from_millis(50));
+    let mut pc = crate::state::PairConfig::new(base, quote);
+    pc.base_decimals = 18;
+    pc.quote_decimals = 6;
+    engine.register_pair_without_event("ETH/USDC".into(), pc);
+
+    let oracle = Arc::new(RecordingOracle::default());
+    engine.set_balance_oracle(oracle.clone());
+
+    // A bid (buyer) spends the quote token; an ask (seller) spends the base.
+    place_plaintext_order(
+        &engine,
+        "ETH/USDC",
+        Side::Buy,
+        dec(100),
+        dec(1),
+        "bid",
+        Duration::from_secs(60),
+    )
+    .await
+    .unwrap();
+    place_plaintext_order(
+        &engine,
+        "ETH/USDC",
+        Side::Sell,
+        dec(100),
+        dec(1),
+        "ask",
+        Duration::from_secs(60),
+    )
+    .await
+    .unwrap();
+
+    let seen = oracle.seen.lock().unwrap();
+    assert_eq!(seen[0], (quote, 6), "bid must read the quote asset");
+    assert_eq!(seen[1], (base, 18), "ask must read the base asset");
 }
 
 #[tokio::test]

--- a/crates/dp-settlement/src/balance_oracle.rs
+++ b/crates/dp-settlement/src/balance_oracle.rs
@@ -1,0 +1,159 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::str::FromStr;
+
+use alloy_primitives::{Address, U256};
+use alloy_provider::Provider;
+use rust_decimal::Decimal;
+
+use crate::abi::DarkPool;
+use crate::SettlementError;
+
+/// Boxed future returned by [`BalanceOracle::lookup`]. Aliased to keep the
+/// trait and its impls readable (and to satisfy `clippy::type_complexity`).
+pub type BalanceLookupFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<(Decimal, i128), SettlementError>> + Send + 'a>>;
+
+/// Per-leg solvency/position source for the matching circuit's family-7
+/// (solvency) and family-8 (position) constraints.
+///
+/// **Per-asset semantics (#170).** The two legs of a match settle different
+/// assets, so the balance is denominated in the asset the leg *spends*: a bid
+/// (buyer) pays the quote token, an ask (seller) delivers the base token. The
+/// caller resolves the spend asset from the pair registry and passes its
+/// address and on-chain `decimals`, so the returned `Decimal` is in whole-token
+/// units the circuit can scale into its 1e8 fixed-point domain.
+///
+/// `lookup` is fallible and async: a real oracle reads chain state and must be
+/// able to fail closed (reject the order) rather than fabricate a balance when
+/// the read fails.
+pub trait BalanceOracle: Send + Sync {
+    fn lookup<'a>(
+        &'a self,
+        trader: Address,
+        asset: Address,
+        decimals: u8,
+    ) -> BalanceLookupFuture<'a>;
+}
+
+/// Returns a hard-coded 1B balance / 0 position for any trader, ignoring the
+/// asset. Solvency constraints (family 7) pass trivially under this oracle, so
+/// it proves nothing about real funds. NOT FOR PRODUCTION — it exists only so
+/// dev/test deployments without a chain connection can exercise the matching
+/// path. A value-bearing deployment must install [`ChainBalanceOracle`] and
+/// refuse to boot on this one (the `dp-api` boot path enforces that).
+pub struct InsecureDevOracle;
+
+impl BalanceOracle for InsecureDevOracle {
+    fn lookup<'a>(
+        &'a self,
+        _trader: Address,
+        _asset: Address,
+        _decimals: u8,
+    ) -> BalanceLookupFuture<'a> {
+        Box::pin(async { Ok((Decimal::from(1_000_000_000u64), 0i128)) })
+    }
+}
+
+/// Reads a trader's settlement-locked collateral from the on-chain
+/// `reserved[trader][asset]` mapping of the `DarkPool` contract. Only reserved
+/// funds are eligible for matching and settlement (the contract debits
+/// `reserved` in `_consumeReserved` and reverts the whole batch on underflow),
+/// so binding the circuit's solvency witness to the same mapping is what stops
+/// an honest batch from being matched against funds that aren't there.
+///
+/// **Position (family 8) is not yet sourced.** The contract tracks no net
+/// position, so `lookup` returns `0` for position and the in-circuit position
+/// limit remains effectively unenforced. Wiring a real position source needs
+/// on-chain position accounting and is tracked as a separate follow-up; this
+/// oracle deliberately does not pretend otherwise.
+pub struct ChainBalanceOracle<P> {
+    provider: P,
+    contract: Address,
+}
+
+impl<P: Provider + Send + Sync> ChainBalanceOracle<P> {
+    pub fn new(provider: P, contract: Address) -> Self {
+        Self { provider, contract }
+    }
+}
+
+impl<P: Provider + Send + Sync + 'static> BalanceOracle for ChainBalanceOracle<P> {
+    fn lookup<'a>(
+        &'a self,
+        trader: Address,
+        asset: Address,
+        decimals: u8,
+    ) -> BalanceLookupFuture<'a> {
+        Box::pin(async move {
+            let pool = DarkPool::new(self.contract, &self.provider);
+            let raw = pool
+                .reserved(trader, asset)
+                .call()
+                .await
+                .map_err(|e| SettlementError::Rpc(e.to_string()))?;
+            let balance = raw_to_decimal(raw, decimals)?;
+            Ok((balance, 0i128))
+        })
+    }
+}
+
+/// Convert a raw on-chain token amount (`value * 10^decimals`) into whole-token
+/// `Decimal` units. Fails closed when the amount or `10^decimals` exceeds
+/// `Decimal`'s range rather than silently truncating a balance the solvency
+/// check would then trust.
+fn raw_to_decimal(raw: U256, decimals: u8) -> Result<Decimal, SettlementError> {
+    let int = Decimal::from_str(&raw.to_string()).map_err(|e| {
+        SettlementError::Parse(format!("reserved {raw} exceeds Decimal range: {e}"))
+    })?;
+    let mut divisor = Decimal::ONE;
+    for _ in 0..decimals {
+        divisor = divisor
+            .checked_mul(Decimal::TEN)
+            .ok_or_else(|| SettlementError::Parse(format!("10^{decimals} overflows Decimal")))?;
+    }
+    int.checked_div(divisor).ok_or_else(|| {
+        SettlementError::Parse(format!("reserved {raw} / 10^{decimals} overflows Decimal"))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn insecure_dev_oracle_returns_fixed_billion() {
+        let (bal, pos) = InsecureDevOracle
+            .lookup(Address::ZERO, Address::ZERO, 18)
+            .await
+            .unwrap();
+        assert_eq!(bal, Decimal::from(1_000_000_000u64));
+        assert_eq!(pos, 0);
+    }
+
+    #[test]
+    fn raw_to_decimal_18_decimals() {
+        // 1.5 ETH at 18 decimals.
+        let raw = U256::from(15u64) * U256::from(10u64).pow(U256::from(17u64));
+        assert_eq!(raw_to_decimal(raw, 18).unwrap(), Decimal::new(15, 1));
+    }
+
+    #[test]
+    fn raw_to_decimal_6_decimals() {
+        // 1000.5 USDC at 6 decimals.
+        let raw = U256::from(1_000_500_000u64);
+        assert_eq!(raw_to_decimal(raw, 6).unwrap(), Decimal::new(10005, 1));
+    }
+
+    #[test]
+    fn raw_to_decimal_zero() {
+        assert_eq!(raw_to_decimal(U256::ZERO, 18).unwrap(), Decimal::ZERO);
+    }
+
+    #[test]
+    fn raw_to_decimal_overflows_fail_closed() {
+        // 10^40 raw far exceeds Decimal's 96-bit mantissa: must error, not wrap.
+        let raw = U256::from(10u64).pow(U256::from(40u64));
+        assert!(raw_to_decimal(raw, 18).is_err());
+    }
+}

--- a/crates/dp-settlement/src/balance_oracle.rs
+++ b/crates/dp-settlement/src/balance_oracle.rs
@@ -1,6 +1,7 @@
 use std::future::Future;
 use std::pin::Pin;
 use std::str::FromStr;
+use std::time::Duration;
 
 use alloy_primitives::{Address, U256};
 use alloy_provider::Provider;
@@ -67,6 +68,13 @@ impl BalanceOracle for InsecureDevOracle {
 /// limit remains effectively unenforced. Wiring a real position source needs
 /// on-chain position accounting and is tracked as a separate follow-up; this
 /// oracle deliberately does not pretend otherwise.
+///
+/// **Reports total reserved, not per-order available.** `reserved` is the
+/// trader's whole settlement-locked bucket for the asset, so each of N
+/// concurrent orders witnesses the full balance and the solvency check
+/// over-approximates what is actually free. The on-chain `_consumeReserved`
+/// debit is the real guard against over-spend; trustless per-order accounting
+/// would need a committed reserved-state root (out of scope, see #213).
 pub struct ChainBalanceOracle<P> {
     provider: P,
     contract: Address,
@@ -78,6 +86,12 @@ impl<P: Provider + Send + Sync> ChainBalanceOracle<P> {
     }
 }
 
+/// Wall-clock bound on a single `reserved` read. Order placement awaits this
+/// synchronously and the HTTP transport has no default timeout, so without a
+/// cap a hung RPC would stall placement indefinitely — the opposite of the
+/// fail-closed contract. On elapse the lookup errors and the order is rejected.
+const LOOKUP_TIMEOUT: Duration = Duration::from_secs(5);
+
 impl<P: Provider + Send + Sync + 'static> BalanceOracle for ChainBalanceOracle<P> {
     fn lookup<'a>(
         &'a self,
@@ -87,10 +101,13 @@ impl<P: Provider + Send + Sync + 'static> BalanceOracle for ChainBalanceOracle<P
     ) -> BalanceLookupFuture<'a> {
         Box::pin(async move {
             let pool = DarkPool::new(self.contract, &self.provider);
-            let raw = pool
-                .reserved(trader, asset)
-                .call()
+            let raw = tokio::time::timeout(LOOKUP_TIMEOUT, pool.reserved(trader, asset).call())
                 .await
+                .map_err(|_| {
+                    SettlementError::Rpc(format!(
+                        "balance oracle lookup timed out after {LOOKUP_TIMEOUT:?}"
+                    ))
+                })?
                 .map_err(|e| SettlementError::Rpc(e.to_string()))?;
             let balance = raw_to_decimal(raw, decimals)?;
             Ok((balance, 0i128))

--- a/crates/dp-settlement/src/lib.rs
+++ b/crates/dp-settlement/src/lib.rs
@@ -7,7 +7,9 @@ mod submitter;
 mod watcher;
 
 pub use abi::DarkPool;
-pub use balance_oracle::{BalanceLookupFuture, BalanceOracle, ChainBalanceOracle, InsecureDevOracle};
+pub use balance_oracle::{
+    BalanceLookupFuture, BalanceOracle, ChainBalanceOracle, InsecureDevOracle,
+};
 pub use eth_submitter::{EthSubmitter, EthSubmitterConfig};
 pub use helpers::{bytes32_to_uuid, decimal_to_wei, uuid_to_bytes32};
 pub use signer::{LocalTxSigner, TxSigner};

--- a/crates/dp-settlement/src/lib.rs
+++ b/crates/dp-settlement/src/lib.rs
@@ -1,4 +1,5 @@
 mod abi;
+mod balance_oracle;
 mod eth_submitter;
 mod helpers;
 pub mod signer;
@@ -6,6 +7,7 @@ mod submitter;
 mod watcher;
 
 pub use abi::DarkPool;
+pub use balance_oracle::{BalanceLookupFuture, BalanceOracle, ChainBalanceOracle, InsecureDevOracle};
 pub use eth_submitter::{EthSubmitter, EthSubmitterConfig};
 pub use helpers::{bytes32_to_uuid, decimal_to_wei, uuid_to_bytes32};
 pub use signer::{LocalTxSigner, TxSigner};


### PR DESCRIPTION
Closes #213

The matching circuit's family-7 solvency constraint compared a witnessed balance against each leg's notional, but that balance came from InsecureDevOracle, which the engine installed unconditionally and which returns a flat 1B for every trader. No on-chain-reading oracle existed and set_balance_oracle had no callers, so the solvency proof attested nothing about real funds and the family-8 position check ran against a fabricated zero.

This wires a real source. A BalanceOracle trait now lives in dp-settlement next to Submitter, with ChainBalanceOracle reading reserved[trader][asset] from the DarkPool contract and InsecureDevOracle kept for chainless dev/test. The engine reads the installed oracle when capturing each order's secrets, in the asset the leg spends (#170): a bid is checked in the quote token it pays, an ask in the base token it delivers. The lookup is async and fallible, so a read failure rejects the placement rather than fabricating a balance. When a node is configured to submit batches on-chain — the value-bearing case — dp-api now builds and installs the chain oracle against the same contract, and a bad address or RPC URL aborts boot. That is the fail-closed behaviour the dev oracle's startup warning always promised.

Worth being explicit about what this does not do. The contract already enforces fund safety on both settlement paths: _consumeReserved debits real reserved escrow with checked-underflow and reverts the whole batch if a trader is short, so this change is operator-side correctness — it stops an honest batch from being matched against funds that aren't there and makes the solvency proof mean what it claims, rather than being the thing that prevents theft. Two deliberate scope cuts: the issue suggested binding the balance into a public input the contract checks, but that is redundant with _consumeReserved and does not fit the fixed uint256[6] public-input array (per-trader balances are variable); a trustless in-circuit solvency proof would need a committed reserved-state root and is a larger, separate design. And position has no on-chain source at all, so the chain oracle returns zero and the family-8 limit stays a documented gap pending position accounting.

Verification: dp-engine and dp-settlement suites pass (146 tests, including new coverage for the fail-closed path and per-side asset selection), dp-api builds, cargo fmt --check and clippy are clean.