### PR TITLE
[security] Domain-separate batch and auction settlement guards

### DIFF
--- a/contracts/src/DarkPool.sol
+++ b/contracts/src/DarkPool.sol
@@ -44,7 +44,27 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
     IVerifier public immutable verifier;
 
     mapping(address => bool) public operators;
-    mapping(bytes32 => bool) public settled;
+
+    /// @notice Replay guard for the Groth16 path, keyed by `batchId`. Kept in a
+    ///         namespace distinct from `settledAuction` so a `batchId` can never
+    ///         alias an `auctionId` of the same 32-byte value (#214). A single
+    ///         shared map would either let one economic round settle twice
+    ///         (different keys, no overlap) or falsely block an unrelated round
+    ///         (coincidental key collision).
+    mapping(bytes32 => bool) public settledBatch;
+
+    /// @notice Replay guard for the economic auction round, keyed by `auctionId`
+    ///         and SHARED across both settlement arms. `submitBatch` (Groth16)
+    ///         and `settleAuction` (HyperNova IVC) each set and check it, so a
+    ///         round settled through one arm cannot be re-settled through the
+    ///         other (#214). The off-chain operator runs one auction → one batch
+    ///         → one `submitBatch`, so a one-settlement-per-`auctionId` rule does
+    ///         not constrain any legitimate flow. Without this, the same proved
+    ///         matches could run `_settleMatch` twice — once via `submitBatch`,
+    ///         once via `submitSession` + `settleAuction` — double-charging
+    ///         traders.
+    mapping(bytes32 => bool) public settledAuction;
+
     mapping(address => mapping(address => uint256)) public balances;
 
     /// @notice Tokens approved for deposit. Only vetted, standard ERC20s
@@ -269,7 +289,10 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         uint256[6] calldata publicInputs,
         Match[] calldata matches
     ) external onlyOperator whenNotPaused {
-        require(!settled[batchId], "already settled");
+        require(!settledBatch[batchId], "batch already settled");
+        // Shared with the IVC arm: if this round already settled via
+        // submitSession + settleAuction, reject the Groth16 replay (#214).
+        require(!settledAuction[auctionId], "auction already settled");
         require(matches.length > 0 && matches.length <= MAX_BATCH_SIZE, "invalid batch size");
         require(proof.length == 256, "invalid proof length");
 
@@ -285,7 +308,10 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
             _settleMatch(matches[i]);
         }
 
-        settled[batchId] = true;
+        settledBatch[batchId] = true;
+        // Mark the economic round settled in the shared namespace so the IVC arm
+        // cannot later re-settle the same auctionId (#214).
+        settledAuction[auctionId] = true;
         emit BatchSettled(batchId, block.timestamp);
     }
 
@@ -476,7 +502,9 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         IDarkPool.Match[] calldata matches
     ) external onlyOperator whenNotPaused whenIvcEnabled {
         require(sessionSubmitted[sessionId], "session not submitted");
-        require(!settled[auctionId], "auction already settled");
+        // Shared with the Groth16 arm (#214): blocks re-settling this round
+        // whether it first settled via this path or via submitBatch.
+        require(!settledAuction[auctionId], "auction already settled");
         // A session proves exactly one auction's matches. Because the binding
         // below is over `matches[]` only (auctionId is absent from the proof's
         // hash-chain), the same proved session would otherwise settle multiple
@@ -485,7 +513,7 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         // settlement.
         require(!sessionSettled[sessionId], "session already settled");
         // Defense in depth: once an auction is bound to a session, only that
-        // session can settle it. `settled[auctionId]` already blocks
+        // session can settle it. `settledAuction[auctionId]` already blocks
         // re-settlement; this guards a cross-session race where two distinct
         // submitSession calls both try to settle the same auctionId.
         bytes32 bound = auctionToSession[auctionId];
@@ -499,7 +527,7 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         // over `matches[]` and require it equals the proved `zN[3]`.
         require(_settlementChain(matches) == sessionSettlementAcc[sessionId], "settlement binding");
         auctionToSession[auctionId] = sessionId;
-        settled[auctionId] = true;
+        settledAuction[auctionId] = true;
         sessionSettled[sessionId] = true;
         for (uint256 i = 0; i < matches.length; i++) {
             _settleMatch(matches[i]);

--- a/contracts/src/DarkPool.sol
+++ b/contracts/src/DarkPool.sol
@@ -304,14 +304,19 @@ contract DarkPool is IDarkPool, Ownable2Step, ReentrancyGuard, Pausable {
         (uint256[2] memory a, uint256[2][2] memory b, uint256[2] memory c) = _decodeProof(proof);
         require(verifier.verifyProof(a, b, c, publicInputs), "invalid proof");
 
-        for (uint256 i = 0; i < matches.length; i++) {
-            _settleMatch(matches[i]);
-        }
-
+        // Effects before interactions: set the replay guards before the
+        // _settleMatch loop, which makes external decimals() staticcalls. This
+        // matches settleAuction's ordering; on the success path it changes
+        // nothing (an atomic revert rolls the writes back either way).
         settledBatch[batchId] = true;
         // Mark the economic round settled in the shared namespace so the IVC arm
         // cannot later re-settle the same auctionId (#214).
         settledAuction[auctionId] = true;
+
+        for (uint256 i = 0; i < matches.length; i++) {
+            _settleMatch(matches[i]);
+        }
+
         emit BatchSettled(batchId, block.timestamp);
     }
 

--- a/contracts/test/DarkPool.t.sol
+++ b/contracts/test/DarkPool.t.sol
@@ -296,7 +296,7 @@ contract DarkPoolTest is Test {
         _fundAndSubmitBatch(batchId);
 
         vm.prank(operator);
-        vm.expectRevert("already settled");
+        vm.expectRevert("batch already settled");
         pool.submitBatch(batchId, bytes32(0), new bytes(256), _zeroInputs(), _singleMatch());
     }
 
@@ -367,7 +367,7 @@ contract DarkPoolTest is Test {
         vm.prank(operator);
         pool.submitBatch(batchId, bytes32(0), new bytes(256), inputs, matches);
 
-        assertTrue(pool.settled(batchId));
+        assertTrue(pool.settledBatch(batchId));
         assertEq(pool.balances(trader1, address(quoteToken)), 0);
         assertEq(pool.balances(trader1, address(baseToken)), size);
         assertEq(pool.balances(trader2, address(baseToken)), 0);
@@ -412,7 +412,7 @@ contract DarkPoolTest is Test {
         vm.prank(operator);
         pool.submitBatch(bytes32(uint256(0x6d)), bytes32(0), new bytes(256), inputs, matches);
 
-        assertTrue(pool.settled(bytes32(uint256(0x6d))));
+        assertTrue(pool.settledBatch(bytes32(uint256(0x6d))));
         assertEq(pool.balances(trader1, address(usdc)), 0);
         assertEq(pool.balances(trader1, address(baseToken)), baseAmount);
         assertEq(pool.balances(trader2, address(baseToken)), 0);
@@ -833,7 +833,7 @@ contract DarkPoolTest is Test {
         // settleAuction with the proved match
         vm.prank(operator);
         pool.settleAuction(sessionId, auctionId, matches);
-        assertTrue(pool.settled(auctionId));
+        assertTrue(pool.settledAuction(auctionId));
     }
 
     /// #210: the IVC settlement path is disarmed on a freshly constructed pool,
@@ -1032,7 +1032,7 @@ contract DarkPoolTest is Test {
         // First settlement succeeds and marks the session settled.
         vm.prank(operator);
         pool.settleAuction(sessionId, bytes32(uint256(2)), matches);
-        assertTrue(pool.settled(bytes32(uint256(2))));
+        assertTrue(pool.settledAuction(bytes32(uint256(2))));
         assertTrue(pool.sessionSettled(sessionId));
 
         // Replaying the same proved matches under a fresh auctionId clears the
@@ -1088,6 +1088,103 @@ contract DarkPoolTest is Test {
         vm.prank(operator);
         vm.expectRevert("policy hash mismatch");
         pool.submitSession(bytes32(uint256(1)), new bytes(64), z0, zN, 60, bytes32(uint256(999)));
+    }
+
+    // --- Cross-path double-settlement (#214) ---
+
+    /// The Groth16 and IVC arms share `settledAuction`, so a round settled via
+    /// submitBatch cannot be re-settled via settleAuction. The guard fires
+    /// before the binding or any _settleMatch, so the same proved matches
+    /// (which would otherwise pass the #209 binding) are still rejected.
+    function test_groth16ThenIvc_sameAuction_reverts() public {
+        bytes32 auctionId = bytes32(uint256(0xA));
+        bytes32 batchId = bytes32(uint256(0xB));
+
+        uint256 price = 100e18;
+        uint256 size = 10e18;
+        uint256 notional = price * size / 1e18;
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
+
+        // Groth16 settles the economic round.
+        vm.prank(operator);
+        pool.submitBatch(batchId, auctionId, new bytes(256), _zeroInputs(), _fundedMatch());
+        assertTrue(pool.settledAuction(auctionId));
+
+        // IVC submits the SAME matches (binding would pass) and tries to settle
+        // the same auctionId — the shared guard, not the binding, must stop it.
+        pool.setIvcVerifier(address(new HyperNovaDeciderVerifier()));
+        bytes32 sessionId = bytes32(uint256(0xC));
+        uint256 settlementAcc = _settlementAcc(trader1, trader2, price, size);
+        (uint256[5] memory z0, uint256[5] memory zN) = _ivcStates(settlementAcc);
+        vm.prank(operator);
+        pool.submitSession(sessionId, new bytes(64), z0, zN, 60, bytes32(TEST_POLICY_HASH));
+
+        vm.prank(operator);
+        vm.expectRevert("auction already settled");
+        pool.settleAuction(sessionId, auctionId, _fundedMatch());
+    }
+
+    /// Mirror of the above: a round settled via the IVC arm cannot be
+    /// re-settled via submitBatch. settleAuction marks `settledAuction`, which
+    /// submitBatch checks before touching escrow.
+    function test_ivcThenGroth16_sameAuction_reverts() public {
+        bytes32 auctionId = bytes32(uint256(0xA));
+
+        uint256 price = 100e18;
+        uint256 size = 10e18;
+        uint256 notional = price * size / 1e18;
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
+
+        pool.setIvcVerifier(address(new HyperNovaDeciderVerifier()));
+        bytes32 sessionId = bytes32(uint256(0xC));
+        uint256 settlementAcc = _settlementAcc(trader1, trader2, price, size);
+        (uint256[5] memory z0, uint256[5] memory zN) = _ivcStates(settlementAcc);
+        vm.prank(operator);
+        pool.submitSession(sessionId, new bytes(64), z0, zN, 60, bytes32(TEST_POLICY_HASH));
+        vm.prank(operator);
+        pool.settleAuction(sessionId, auctionId, _fundedMatch());
+        assertTrue(pool.settledAuction(auctionId));
+
+        vm.prank(operator);
+        vm.expectRevert("auction already settled");
+        pool.submitBatch(bytes32(uint256(0xB)), auctionId, new bytes(256), _zeroInputs(), _fundedMatch());
+    }
+
+    /// `batchId` and `auctionId` live in separate namespaces, so a Groth16 batch
+    /// settled under id K never blocks an unrelated IVC auction whose auctionId
+    /// equals K. Under the old shared `settled` map this coincidental collision
+    /// would have falsely reverted the second, legitimate settlement.
+    function test_namespaceSeparation_batchIdDoesNotBlockEqualAuctionId() public {
+        bytes32 sharedId = bytes32(uint256(0x7777));
+
+        uint256 price = 100e18;
+        uint256 size = 10e18;
+        uint256 notional = price * size / 1e18;
+
+        // Groth16 batch settled under batchId == sharedId, with a distinct
+        // auctionId so the round guards don't interfere.
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
+        vm.prank(operator);
+        pool.submitBatch(sharedId, bytes32(uint256(0x1111)), new bytes(256), _zeroInputs(), _fundedMatch());
+        assertTrue(pool.settledBatch(sharedId));
+        assertFalse(pool.settledAuction(sharedId));
+
+        // A separate IVC auction whose auctionId == sharedId must still settle.
+        _depositAndReserve(trader1, address(quoteToken), notional);
+        _depositAndReserve(trader2, address(baseToken), size);
+        pool.setIvcVerifier(address(new HyperNovaDeciderVerifier()));
+        bytes32 sessionId = bytes32(uint256(0xC));
+        uint256 settlementAcc = _settlementAcc(trader1, trader2, price, size);
+        (uint256[5] memory z0, uint256[5] memory zN) = _ivcStates(settlementAcc);
+        vm.prank(operator);
+        pool.submitSession(sessionId, new bytes(64), z0, zN, 60, bytes32(TEST_POLICY_HASH));
+        vm.prank(operator);
+        pool.settleAuction(sessionId, sharedId, _fundedMatch());
+
+        assertTrue(pool.settledAuction(sharedId));
     }
 
     // --- Escrow reserve / unbonding (#165) ---
@@ -1230,7 +1327,7 @@ contract DarkPoolTest is Test {
         vm.prank(operator);
         pool.submitBatch(batchId, bytes32(0), new bytes(256), inputs, matches);
 
-        assertTrue(pool.settled(batchId));
+        assertTrue(pool.settledBatch(batchId));
         assertEq(pool.reserved(trader1, address(quoteToken)), 0);
         assertEq(pool.balances(trader1, address(baseToken)), size);
         assertEq(pool.reserved(trader2, address(baseToken)), 0);
@@ -1328,7 +1425,7 @@ contract DarkPoolTest is Test {
         pool.submitBatch(batchId, bytes32(0), new bytes(256), inputs, matches);
 
         // Atomicity: the valid first match did NOT partially settle.
-        assertFalse(pool.settled(batchId));
+        assertFalse(pool.settledBatch(batchId));
         assertEq(pool.reserved(trader1, address(quoteToken)), notional);
         assertEq(pool.balances(trader1, address(baseToken)), 0);
         assertEq(pool.reserved(trader2, address(baseToken)), size);

--- a/contracts/test/DarkPool.t.sol
+++ b/contracts/test/DarkPool.t.sol
@@ -365,7 +365,7 @@ contract DarkPoolTest is Test {
         });
 
         vm.prank(operator);
-        pool.submitBatch(batchId, bytes32(0), new bytes(256), inputs, matches);
+        pool.submitBatch(batchId, _auctionFor(batchId), new bytes(256), inputs, matches);
 
         assertTrue(pool.settledBatch(batchId));
         assertEq(pool.balances(trader1, address(quoteToken)), 0);
@@ -410,7 +410,7 @@ contract DarkPoolTest is Test {
         });
 
         vm.prank(operator);
-        pool.submitBatch(bytes32(uint256(0x6d)), bytes32(0), new bytes(256), inputs, matches);
+        pool.submitBatch(bytes32(uint256(0x6d)), _auctionFor(bytes32(uint256(0x6d))), new bytes(256), inputs, matches);
 
         assertTrue(pool.settledBatch(bytes32(uint256(0x6d))));
         assertEq(pool.balances(trader1, address(usdc)), 0);
@@ -430,7 +430,7 @@ contract DarkPoolTest is Test {
         vm.prank(operator);
         vm.expectEmit(true, false, false, true);
         emit IDarkPool.BatchSettled(batchId, block.timestamp);
-        pool.submitBatch(batchId, bytes32(0), new bytes(256), inputs, _fundedMatch());
+        pool.submitBatch(batchId, _auctionFor(batchId), new bytes(256), inputs, _fundedMatch());
     }
 
     // --- Fee math ---
@@ -460,7 +460,7 @@ contract DarkPoolTest is Test {
         });
 
         vm.prank(operator);
-        pool.submitBatch(bytes32(uint256(99)), bytes32(0), new bytes(256), inputs, matches);
+        pool.submitBatch(bytes32(uint256(99)), _auctionFor(bytes32(uint256(99))), new bytes(256), inputs, matches);
 
         assertEq(pool.balances(feeRecipient, address(quoteToken)), expectedFee);
         assertEq(expectedFee, 5e17);
@@ -1325,7 +1325,7 @@ contract DarkPoolTest is Test {
 
         // Settlement succeeds despite the pending unbonds.
         vm.prank(operator);
-        pool.submitBatch(batchId, bytes32(0), new bytes(256), inputs, matches);
+        pool.submitBatch(batchId, _auctionFor(batchId), new bytes(256), inputs, matches);
 
         assertTrue(pool.settledBatch(batchId));
         assertEq(pool.reserved(trader1, address(quoteToken)), 0);
@@ -1465,7 +1465,7 @@ contract DarkPoolTest is Test {
         // Settlement consumes trader1's reserved quote; the pending request and
         // its timer must be cleared, not left dangling.
         vm.prank(operator);
-        pool.submitBatch(bytes32(uint256(11)), bytes32(0), new bytes(256), inputs, matches);
+        pool.submitBatch(bytes32(uint256(11)), _auctionFor(bytes32(uint256(11))), new bytes(256), inputs, matches);
         assertEq(pool.reserved(trader1, address(quoteToken)), 0);
         assertEq(pool.pendingUnreserve(trader1, address(quoteToken)), 0);
         assertEq(pool.unreserveReadyAt(trader1, address(quoteToken)), 0);
@@ -1564,6 +1564,15 @@ contract DarkPoolTest is Test {
         return matches;
     }
 
+    /// A batch-distinct throwaway auction id for submitBatch settling tests.
+    /// submitBatch records settledAuction[auctionId] (#214), so a settling batch
+    /// needs a real auction id; bytes32(0) reused across two settling batches in
+    /// one test would falsely collide. (Tests asserting a pre-settlement revert
+    /// still pass bytes32(0): they never reach the settledAuction write.)
+    function _auctionFor(bytes32 batchId) internal pure returns (bytes32) {
+        return bytes32(~uint256(batchId));
+    }
+
     function _setupBatchBalances() internal {
         uint256 notional = 100e18 * 10e18 / 1e18;
         _depositAndReserve(trader1, address(quoteToken), notional);
@@ -1577,6 +1586,6 @@ contract DarkPoolTest is Test {
         inputs[0] = 1;
 
         vm.prank(operator);
-        pool.submitBatch(batchId, bytes32(0), new bytes(256), inputs, _fundedMatch());
+        pool.submitBatch(batchId, _auctionFor(batchId), new bytes(256), inputs, _fundedMatch());
     }
 }

--- a/crates/dp-settlement/abi/DarkPool.json
+++ b/crates/dp-settlement/abi/DarkPool.json
@@ -680,7 +680,26 @@
   },
   {
     "type": "function",
-    "name": "settled",
+    "name": "settledAuction",
+    "inputs": [
+      {
+        "name": "",
+        "type": "bytes32",
+        "internalType": "bytes32"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool",
+        "internalType": "bool"
+      }
+    ],
+    "stateMutability": "view"
+  },
+  {
+    "type": "function",
+    "name": "settledBatch",
     "inputs": [
       {
         "name": "",

--- a/front/lib/contracts/generated.ts
+++ b/front/lib/contracts/generated.ts
@@ -341,7 +341,14 @@ export const darkPoolAbi = [
   {
     type: 'function',
     inputs: [{ name: '', internalType: 'bytes32', type: 'bytes32' }],
-    name: 'settled',
+    name: 'settledAuction',
+    outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
+    stateMutability: 'view',
+  },
+  {
+    type: 'function',
+    inputs: [{ name: '', internalType: 'bytes32', type: 'bytes32' }],
+    name: 'settledBatch',
     outputs: [{ name: '', internalType: 'bool', type: 'bool' }],
     stateMutability: 'view',
   },


### PR DESCRIPTION
Closes #214

A single `settled` map guarded both settlement arms, but each keyed it differently: submitBatch on batchId, settleAuction on auctionId. So one auction round could settle twice, once through the Groth16 path and once through the HyperNova IVC path, running _settleMatch both times and double-charging traders. submitBatch took an auctionId but never read it, and the auctionToSession guard only stopped two sessions sharing an auctionId, not a prior Groth16 settlement.

Split the map into settledBatch (the Groth16 batchId replay guard) and settledAuction (the economic round). Both arms now set and check settledAuction, so a round settled through either path blocks the other, and submitBatch finally enforces its auctionId. Keeping the namespaces apart also stops a batchId from aliasing an auctionId that happens to share its value. The off-chain operator already runs one auction to one batch to one submitBatch, so the one-settlement-per-round rule costs no legitimate flow.

Also regenerated the committed Rust ABI snapshot and the wagmi frontend bindings for the getter split. forge test (139 passing), the abi_drift test, and the generated.ts drift test all pass.