### PR TITLE
Chunk oversized auction rounds so every fill settles

### DIFF
--- a/crates/dp-engine/src/tick.rs
+++ b/crates/dp-engine/src/tick.rs
@@ -417,19 +417,36 @@ impl Engine {
             }
 
             notifications.push(record_to_notification(&record));
-            pending.push(PendingAggregation {
-                batch_id: Uuid::new_v4(),
-                auction_id: result.auction_id,
-                pair: result.pair.clone(),
-                matches: result
-                    .matches
-                    .iter()
-                    .map(|m| order_matched_to_match(m.bid.clone(), m.ask.clone(), m.price, m.size))
-                    .collect(),
-                orders: order_snapshot,
-                admitted_order_ids,
-                auction_at: now,
-            });
+
+            // Settlement is bounded by the IVC circuit width (`batch_size` ==
+            // `IVC_BATCH_SIZE`): one fold step proves at most that many match
+            // rows. Matching itself is uncapped, so a round can cross into more
+            // matches than a single batch can carry. Split the round into
+            // chunks of at most `batch_size` matches and emit one aggregation
+            // per chunk; each folds and settles independently against the same
+            // admitted set and clearing price. The events above already record
+            // the round as one logical auction with every fill — only the proof
+            // batching is chunked. Without this split an oversized witness was
+            // rejected downstream by `from_witness_with_admitted` *after* the
+            // matches were persisted and applied to the book, so the fold was
+            // skipped and the fills sat on the book but never settled on-chain,
+            // diverging book state from chain permanently (#215).
+            let round_matches: Vec<dp_auction::Match> = result
+                .matches
+                .iter()
+                .map(|m| order_matched_to_match(m.bid.clone(), m.ask.clone(), m.price, m.size))
+                .collect();
+            for chunk in round_matches.chunks(self.inner.batch_size) {
+                pending.push(PendingAggregation {
+                    batch_id: Uuid::new_v4(),
+                    auction_id: result.auction_id,
+                    pair: result.pair.clone(),
+                    matches: chunk.to_vec(),
+                    orders: order_snapshot.clone(),
+                    admitted_order_ids: admitted_order_ids.clone(),
+                    auction_at: now,
+                });
+            }
         }
 
         let aggregator = self.inner.aggregator.read().clone();
@@ -893,6 +910,86 @@ mod ivc_tests {
             engine.active_order_count(),
             0,
             "both orders fully filled and removed from the book"
+        );
+    }
+
+    /// A single auction round that crosses into more matches than the circuit
+    /// width (`IVC_BATCH_SIZE` = 8) must still settle every fill. The round is
+    /// split into chunks of at most `batch_size` matches, each folded as its
+    /// own batch. Before the fix the engine pushed one oversized aggregation:
+    /// `from_witness_with_admitted` rejected the >8-match witness *after* the
+    /// `OrderMatched` events were already persisted and applied, the fold was
+    /// skipped with `continue`, and the book diverged permanently from chain —
+    /// recorded fills that could never settle (#215). Here `fold_calls` was 0
+    /// pre-fix; with chunking nine matches fold as 8 + 1.
+    #[tokio::test]
+    async fn oversized_round_chunks_and_folds_every_match() {
+        use dp_event::Store;
+        use dp_types::EventType;
+
+        let (engine, store) = make_engine_with_pair();
+        let agg = MockFoldingAggregator::new();
+        engine.set_aggregator(Arc::clone(&agg) as Arc<dyn ProofAggregator>);
+        // Stay well below the finalize/submit boundary; this test asserts only
+        // that every match folds, not that a batch is submitted.
+        engine.set_finalize_every(1000);
+
+        let ttl = Duration::from_secs(60);
+        // One size-9 bid crossing nine size-1 asks at the same price → nine
+        // matches in a single round, one more than the circuit width of 8.
+        place_plaintext_order(
+            &engine,
+            "ETH/USDC",
+            Side::Buy,
+            Decimal::from(100),
+            Decimal::from(9),
+            "key_bid",
+            ttl,
+        )
+        .await
+        .unwrap();
+        for i in 0..9 {
+            place_plaintext_order(
+                &engine,
+                "ETH/USDC",
+                Side::Sell,
+                Decimal::from(100),
+                Decimal::ONE,
+                &format!("key_ask_{i}"),
+                ttl,
+            )
+            .await
+            .unwrap();
+        }
+
+        engine.run_auction_tick().await;
+
+        let events = store.read_from(0, 10_000).unwrap();
+        let executed = events
+            .iter()
+            .filter(|e| e.event_type == EventType::AuctionExecuted)
+            .count();
+        let matched = events
+            .iter()
+            .filter(|e| e.event_type == EventType::OrderMatched)
+            .count();
+
+        // The event log records one logical auction with all nine fills; only
+        // the proof batching is split.
+        assert_eq!(executed, 1, "exactly one auction round recorded");
+        assert_eq!(matched, 9, "every one of the nine fills recorded");
+        // Nine matches at batch_size 8 → two chunks (8 + 1), each folded once.
+        // Pre-fix the single oversized witness was rejected and fold_calls
+        // stayed 0 while the fills were already on the book.
+        assert_eq!(
+            agg.fold_calls(),
+            2,
+            "oversized round must fold in chunks of at most batch_size"
+        );
+        assert_eq!(
+            engine.active_order_count(),
+            0,
+            "bid and all nine asks fully filled and removed from the book"
         );
     }
 }

--- a/crates/dp-engine/src/tick.rs
+++ b/crates/dp-engine/src/tick.rs
@@ -431,6 +431,15 @@ impl Engine {
             // matches were persisted and applied to the book, so the fold was
             // skipped and the fills sat on the book but never settled on-chain,
             // diverging book state from chain permanently (#215).
+            //
+            // The per-pair IVC round counter (advanced in the fold loop) ticks
+            // once per chunk, so an oversized round can straddle a
+            // `finalize_every` boundary: an earlier chunk finalizes and settles
+            // in this window while a later one folds into the next. This
+            // double-increments a single pair's counter within one tick —
+            // distinct from separate pairs, which carry independent counters.
+            // Every chunk stays settleable, so this is bounded extra settlement
+            // latency, not the unsettleable-forever divergence above.
             let round_matches: Vec<dp_auction::Match> = result
                 .matches
                 .iter()
@@ -665,7 +674,7 @@ mod ivc_tests {
     use std::future::Future;
     use std::pin::Pin;
     use std::sync::atomic::{AtomicU32, Ordering};
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use alloy_primitives::Address;
@@ -686,6 +695,10 @@ mod ivc_tests {
     struct MockFoldingAggregator {
         fold_calls: AtomicU32,
         finalize_calls: AtomicU32,
+        /// Count of active (non-padding) match rows seen by each `fold_step`,
+        /// in call order. Lets a test assert the chunk boundary (e.g. 8 then 1)
+        /// rather than only the number of folds.
+        fold_active_counts: Mutex<Vec<usize>>,
     }
 
     impl MockFoldingAggregator {
@@ -693,6 +706,7 @@ mod ivc_tests {
             Arc::new(Self {
                 fold_calls: AtomicU32::new(0),
                 finalize_calls: AtomicU32::new(0),
+                fold_active_counts: Mutex::new(Vec::new()),
             })
         }
 
@@ -702,6 +716,10 @@ mod ivc_tests {
 
         fn finalize_calls(&self) -> u32 {
             self.finalize_calls.load(Ordering::SeqCst)
+        }
+
+        fn fold_active_counts(&self) -> Vec<usize> {
+            self.fold_active_counts.lock().unwrap().clone()
         }
     }
 
@@ -719,9 +737,17 @@ mod ivc_tests {
         fn fold_step<'a>(
             &'a self,
             _pair: String,
-            _ext: dp_zk::step_circuit::AuctionExternalInputs,
+            ext: dp_zk::step_circuit::AuctionExternalInputs,
         ) -> Pin<Box<dyn Future<Output = Result<(), AggregatorError>> + Send + 'a>> {
             self.fold_calls.fetch_add(1, Ordering::SeqCst);
+            // Padding rows carry `is_active = 0`; the active rows are the real
+            // matches this chunk folds, so their count is the chunk size.
+            let active = ext
+                .matches
+                .iter()
+                .filter(|m| m.is_active == ark_bn254::Fr::from(1u64))
+                .count();
+            self.fold_active_counts.lock().unwrap().push(active);
             Box::pin(async { Ok(()) })
         }
 
@@ -985,6 +1011,13 @@ mod ivc_tests {
             agg.fold_calls(),
             2,
             "oversized round must fold in chunks of at most batch_size"
+        );
+        // Prove the boundary, not just the fold count: nine matches split into
+        // a full 8-row chunk and a 1-row remainder, each folded as one batch.
+        assert_eq!(
+            agg.fold_active_counts(),
+            vec![8, 1],
+            "oversized round must fold as chunks of 8 then 1"
         );
         assert_eq!(
             engine.active_order_count(),


### PR DESCRIPTION
Closes #215

A round whose matching crossed into more than eight matches recorded fills that never settled, diverging book state from chain permanently. Matching is uncapped, but settlement is bounded by the IVC circuit width (`batch_size == IVC_BATCH_SIZE == 8`): a single fold step proves at most that many match rows. `tick_under_lock` persisted the round's `AuctionExecuted` and `OrderMatched` events and applied the fills to the book, gated only by the clearing-price encodability check. The oversized witness was then rejected downstream by `from_witness_with_admitted`, and the tick swallowed that error with `continue`, skipping the fold, finalize and submit. The fills stayed on the book while the batch never reached the chain. A size-9 bid against nine size-1 asks is enough to trigger it.

The fix splits each round into chunks of at most `batch_size` matches and emits one aggregation per chunk. Each chunk folds and settles independently against the same admitted set and clearing price, so nine matches settle as eight plus one. The event log is untouched — one `AuctionExecuted` with every `OrderMatched`, persisted and applied once — so the round stays one logical auction and only the proof batching splits. The fold loop already handles several pending aggregations per tick (separate trading pairs do exactly this), so nothing downstream changed.

Recovery's orphan re-aggregation path is intentionally left alone: it calls `aggregator.aggregate`, which the production `InlineFoldingAggregator` rejects outright, so it is already a no-op for the IVC pipeline and unrelated to this live-path bug.

Verified with a regression test driving a nine-match round: pre-fix `fold_calls` stayed 0 while all nine `OrderMatched` events were already recorded; post-fix the round folds as two chunks and every order fills. `cargo test -p dp-engine` is green and `cargo fmt --all -- --check` is clean.