### PR TITLE
[dp-engine] Reject replayed ciphertexts in place_encrypted_order

### DIFF
--- a/crates/dp-api/src/error.rs
+++ b/crates/dp-api/src/error.rs
@@ -19,6 +19,9 @@ pub fn engine_error_to_status(err: EngineError) -> Status {
         EngineError::Validation(e @ DarkPoolError::TraderAddressMismatch { .. }) => {
             Status::permission_denied(e.to_string())
         }
+        EngineError::Validation(e @ DarkPoolError::DuplicateOrder) => {
+            Status::already_exists(e.to_string())
+        }
         EngineError::Validation(
             e @ (DarkPoolError::PairRequired
             | DarkPoolError::PriceMustBePositive
@@ -102,6 +105,12 @@ mod tests {
             },
         ));
         assert_eq!(s.code(), Code::PermissionDenied);
+    }
+
+    #[test]
+    fn duplicate_order_maps_to_already_exists() {
+        let s = engine_error_to_status(EngineError::Validation(DarkPoolError::DuplicateOrder));
+        assert_eq!(s.code(), Code::AlreadyExists);
     }
 
     #[test]

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -758,6 +758,9 @@ impl Engine {
         ciphertext: Vec<u8>,
         salt_nonce: Vec<u8>,
     ) -> Result<u64, EngineError> {
+        // Hash the ciphertext now, before it is moved into the event below;
+        // this is the replay/spent-set key (#233).
+        let digest = ciphertext_digest(&ciphertext);
         let mut events = [Event {
             seq: 0,
             event_type: EventType::OrderPlaced,
@@ -771,7 +774,7 @@ impl Engine {
             },
         }];
 
-        let state = self.inner.state.lock();
+        let mut state = self.inner.state.lock();
         // Re-validate the pair status under the *same* lock that does the
         // append + insert. The status check in `place_encrypted_order` runs
         // in an earlier, separately-acquired lock scope; between dropping
@@ -795,6 +798,11 @@ impl Engine {
                 )));
             }
         }
+        // Reject a replayed ciphertext (#233), under the same lock that appends
+        // and inserts so two concurrent identical submissions can't both pass.
+        if state.seen_ciphertexts.contains(&digest) {
+            return Err(EngineError::Validation(DarkPoolError::DuplicateOrder));
+        }
         self.inner.store.append(&mut events)?;
         let evt = &events[0];
         // The store stamped the monotonic seq onto the event during append;
@@ -808,6 +816,9 @@ impl Engine {
             Side::Sell => "sell",
         };
         state.book.insert_order(order);
+        // Record the digest only after the event is durably appended, so the
+        // live spent-set and a replay rebuilt from the log stay in lockstep.
+        state.seen_ciphertexts.insert(digest);
         metrics::counter!(M_ORDERS_PLACED, "side" => side_label).increment(1);
         Ok(assigned_seq)
     }
@@ -982,6 +993,16 @@ pub(crate) fn recompute_persisted_commitment(
     let trader_id = dp_zk::pedersen::derive_trader_id_bytes(trader_addr);
     let salt = derive_salt(commitment_key, order_id, nonce);
     compute_poseidon_commitment(&trader_id, side, price, size, &salt)
+}
+
+/// SHA-256 of an order's ciphertext — the key for the replay spent-set (#233).
+/// ECIES is randomized, so a byte-identical ciphertext is a replay of a captured
+/// submission, not a fresh order. The live `persist_order_placed` path and the
+/// recovery replay path MUST hash identically, so both call this one helper.
+pub(crate) fn ciphertext_digest(ciphertext: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(ciphertext);
+    h.finalize().into()
 }
 
 fn derive_salt(commitment_key: &str, order_id: Uuid, nonce: &[u8; 32]) -> [u8; 32] {

--- a/crates/dp-engine/src/engine.rs
+++ b/crates/dp-engine/src/engine.rs
@@ -498,6 +498,22 @@ impl Engine {
         ciphertext: Vec<u8>,
         caller: Option<alloy_primitives::Address>,
     ) -> Result<Order, EngineError> {
+        // Cheap replay shed (#233): a byte-identical ciphertext is a replay of a
+        // captured submission (ECIES is randomized), so reject it before the
+        // ECIES decrypt + commitment derivation every admitted order pays. This
+        // is advisory — the race-free, durable check is the same-lock test in
+        // `persist_order_placed`; this only avoids spending crypto on a
+        // ciphertext already known to be spent.
+        if self
+            .inner
+            .state
+            .lock()
+            .seen_ciphertexts
+            .contains(&ciphertext_digest(&ciphertext))
+        {
+            return Err(EngineError::Validation(DarkPoolError::DuplicateOrder));
+        }
+
         let decrypter = self.inner.decrypter.read().clone();
         let decrypted = decrypter
             .decrypt(&ciphertext)

--- a/crates/dp-engine/src/recover.rs
+++ b/crates/dp-engine/src/recover.rs
@@ -488,6 +488,12 @@ impl Engine {
                 // logs always emit `PairRegistered` first.
                 state.pair_tokens.entry(pair_key).or_default();
                 state.book.insert_order(order);
+                // Rebuild the replay spent-set from the log so a recovered
+                // engine rejects the same ciphertext replays a live one would
+                // (#233). Same hash helper as the live path keeps them aligned.
+                state
+                    .seen_ciphertexts
+                    .insert(crate::engine::ciphertext_digest(ciphertext));
             }
             EventData::OrderCancelled { .. } | EventData::OrderExpired { .. } => {
                 self.inner.state.lock().book.apply(ev);

--- a/crates/dp-engine/src/snapshot.rs
+++ b/crates/dp-engine/src/snapshot.rs
@@ -326,6 +326,7 @@ mod tests {
             pair_tokens: HashMap::new(),
             auction_log: Vec::new(),
             pending_batches: HashMap::new(),
+            seen_ciphertexts: Default::default(),
         }
     }
 

--- a/crates/dp-engine/src/state.rs
+++ b/crates/dp-engine/src/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::time::{Duration, Instant};
 
 use alloy_primitives::{Address, U256};
@@ -186,6 +186,12 @@ pub(crate) struct SerializableState {
     pub pair_tokens: HashMap<String, PairConfig>,
     pub auction_log: Vec<AuctionExecutedRecord>,
     pub pending_batches: HashMap<Uuid, PendingBatch>,
+    /// SHA-256 digests of every ciphertext ever admitted, for replay
+    /// rejection (#233). `serde(default)` so snapshots taken before this
+    /// field existed still decode; the post-snapshot event tail repopulates
+    /// any digests minted after that older snapshot.
+    #[serde(default)]
+    pub seen_ciphertexts: HashSet<[u8; 32]>,
 }
 
 pub(crate) struct EngineState {
@@ -197,6 +203,13 @@ pub(crate) struct EngineState {
     pub pair_tokens: HashMap<String, PairConfig>,
     pub auction_log: Vec<AuctionExecutedRecord>,
     pub pending_batches: HashMap<Uuid, PendingBatch>,
+    /// SHA-256 digests of every ciphertext admitted by `place_encrypted_order`,
+    /// keyed for replay rejection (#233). A projection rebuilt from the
+    /// `OrderPlaced` event stream (so it survives `reset_projection` clearing
+    /// and is captured in snapshots). Grows monotonically — replay protection
+    /// is permanent; expiry-based pruning waits on the per-order freshness
+    /// token (nonce + expiry) tracked in the rest of #233.
+    pub seen_ciphertexts: HashSet<[u8; 32]>,
     pub submit_timeout: Duration,
     pub min_backoff: Duration,
     pub max_backoff: Duration,
@@ -211,6 +224,7 @@ impl EngineState {
             pair_tokens: HashMap::new(),
             auction_log: Vec::new(),
             pending_batches: HashMap::new(),
+            seen_ciphertexts: HashSet::new(),
             submit_timeout: DEFAULT_SUBMIT_TIMEOUT,
             min_backoff: DEFAULT_MIN_BACKOFF,
             max_backoff: DEFAULT_MAX_BACKOFF,
@@ -224,6 +238,10 @@ impl EngineState {
         self.pair_tokens.clear();
         self.auction_log.clear();
         self.pending_batches.clear();
+        // `seen_ciphertexts` is a projection rebuilt from `OrderPlaced` events,
+        // so a projection reset must clear it too — recovery repopulates it as
+        // it replays the log (or restores it from a snapshot).
+        self.seen_ciphertexts.clear();
     }
 
     pub fn pair_config(&self, pair: &str) -> Option<&PairConfig> {
@@ -240,6 +258,7 @@ impl EngineState {
             pair_tokens: self.pair_tokens.clone(),
             auction_log: self.auction_log.clone(),
             pending_batches: self.pending_batches.clone(),
+            seen_ciphertexts: self.seen_ciphertexts.clone(),
         }
     }
 
@@ -251,6 +270,7 @@ impl EngineState {
         self.pair_tokens = snap.pair_tokens;
         self.auction_log = snap.auction_log;
         self.pending_batches = snap.pending_batches;
+        self.seen_ciphertexts = snap.seen_ciphertexts;
     }
 }
 

--- a/crates/dp-engine/src/test_helpers.rs
+++ b/crates/dp-engine/src/test_helpers.rs
@@ -266,6 +266,27 @@ impl Decrypter for XorDecrypter {
     }
 }
 
+/// Counts `decrypt` calls so a test can prove a path short-circuits *before*
+/// decryption (e.g. the #233 replay early-out). Parses JSON straight from the
+/// ciphertext like `NoopDecrypter`, so plaintext-JSON fixtures work unchanged.
+#[derive(Default)]
+pub struct CountingDecrypter {
+    pub calls: AtomicU32,
+}
+
+impl Decrypter for CountingDecrypter {
+    fn decrypt<'a>(
+        &'a self,
+        ciphertext: &'a [u8],
+    ) -> Pin<Box<dyn Future<Output = Result<DecryptedOrder, CryptoError>> + Send + 'a>> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Box::pin(async move {
+            let order: DecryptedOrder = serde_json::from_slice(ciphertext)?;
+            Ok(order)
+        })
+    }
+}
+
 // --- Helpers ---
 
 pub fn count_events(store: &dyn Store, ty: EventType) -> usize {

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -489,19 +489,55 @@ async fn place_encrypted_order_bad_ciphertext() {
     assert!(r.is_err());
 }
 
-#[tokio::test]
-async fn place_encrypted_order_rejects_caller_address_mismatch() {
-    let (engine, _) = make_engine();
-    let d = DecryptedOrder {
+/// The canonical encrypted order on `pair`, shared by the `place_encrypted_order`
+/// tests. `NoopDecrypter`/`CountingDecrypter` parse the order straight from this
+/// JSON, so the plaintext round-trips.
+fn sample_order_ciphertext_for(pair: &str) -> Vec<u8> {
+    serde_json::to_vec(&DecryptedOrder {
         trader: Address::ZERO,
-        pair: "BTC-USD".into(),
+        pair: pair.into(),
         side: Side::Buy,
         price: dec(100),
         size: dec(1),
         commitment_key: "k".into(),
         ttl: 60_000_000_000,
-    };
-    let ct = serde_json::to_vec(&d).unwrap();
+    })
+    .unwrap()
+}
+
+/// The canonical order on the default `BTC-USD` pair. Real ECIES is randomized,
+/// so the replay tests resubmit these exact bytes to stand in for a replay.
+fn sample_order_ciphertext() -> Vec<u8> {
+    sample_order_ciphertext_for("BTC-USD")
+}
+
+/// Submit the canonical order, expecting admission.
+async fn admit_sample_order(engine: &Engine, ct: Vec<u8>) {
+    engine
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
+        .await
+        .expect("first submission is admitted");
+}
+
+/// Resubmit `ct` and assert it is rejected as a #233 replay.
+async fn expect_replay_rejected(engine: &Engine, ct: Vec<u8>) {
+    let err = engine
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::EngineError::Validation(dp_types::DarkPoolError::DuplicateOrder)
+        ),
+        "replay must be rejected as DuplicateOrder, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn place_encrypted_order_rejects_caller_address_mismatch() {
+    let (engine, _) = make_engine();
+    let ct = sample_order_ciphertext();
     let wrong_caller: Address = "0x0000000000000000000000000000000000000001"
         .parse()
         .unwrap();
@@ -516,16 +552,7 @@ async fn place_encrypted_order_rejects_caller_address_mismatch() {
 #[tokio::test]
 async fn place_encrypted_order_accepts_matching_caller() {
     let (engine, _) = make_engine();
-    let d = DecryptedOrder {
-        trader: Address::ZERO,
-        pair: "BTC-USD".into(),
-        side: Side::Buy,
-        price: dec(100),
-        size: dec(1),
-        commitment_key: "k".into(),
-        ttl: 60_000_000_000,
-    };
-    let ct = serde_json::to_vec(&d).unwrap();
+    let ct = sample_order_ciphertext();
     let order = engine
         .place_encrypted_order(vec![0u8; 32], vec![], ct, Some(Address::ZERO))
         .await
@@ -533,57 +560,11 @@ async fn place_encrypted_order_accepts_matching_caller() {
     assert_eq!(order.trader, Address::ZERO);
 }
 
-/// The canonical encrypted order the #233 replay tests submit then resubmit.
-/// Real ECIES is randomized; these tests reuse identical bytes on purpose so a
-/// resubmission is a replay. `NoopDecrypter`/`CountingDecrypter` parse the JSON
-/// straight from the ciphertext, so the plaintext order round-trips.
-fn replay_ciphertext() -> Vec<u8> {
-    serde_json::to_vec(&DecryptedOrder {
-        trader: Address::ZERO,
-        pair: "BTC-USD".into(),
-        side: Side::Buy,
-        price: dec(100),
-        size: dec(1),
-        commitment_key: "k".into(),
-        ttl: 60_000_000_000,
-    })
-    .unwrap()
-}
-
-/// Assert an engine error is the #233 replay rejection.
-fn assert_duplicate_order(err: crate::EngineError) {
-    assert!(
-        matches!(
-            err,
-            crate::EngineError::Validation(dp_types::DarkPoolError::DuplicateOrder)
-        ),
-        "replay must be rejected as DuplicateOrder, got: {err}"
-    );
-}
-
-/// #233: a byte-identical ciphertext resubmitted is a replay (real ECIES is
-/// randomized), so the second submission is rejected with `DuplicateOrder`.
-#[tokio::test]
-async fn place_encrypted_order_rejects_replayed_ciphertext() {
-    let (engine, _) = make_engine();
-    let ct = replay_ciphertext();
-
-    engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct.clone(), None)
-        .await
-        .expect("first submission is admitted");
-
-    let err = engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
-        .await
-        .unwrap_err();
-    assert_duplicate_order(err);
-}
-
-/// #233: a replay is shed by the cheap pre-decrypt early-out, not just the
-/// under-lock check — so a captured ciphertext can't burn ECIES decrypt +
-/// commitment derivation on every resubmission. The spy decrypter must see
-/// exactly one call across two identical submissions.
+/// #233: a replayed ciphertext is rejected on a live engine, and the cheap
+/// pre-decrypt early-out — not just the under-lock check — sheds it, so a
+/// captured ciphertext can't burn ECIES decrypt + commitment derivation on
+/// every resubmission. The spy decrypter must see exactly one call across the
+/// two identical submissions.
 #[tokio::test]
 async fn replayed_ciphertext_rejected_before_decrypt() {
     use std::sync::atomic::Ordering;
@@ -592,17 +573,9 @@ async fn replayed_ciphertext_rejected_before_decrypt() {
     let spy = Arc::new(crate::test_helpers::CountingDecrypter::default());
     engine.set_decrypter(spy.clone());
 
-    let ct = replay_ciphertext();
-    engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct.clone(), None)
-        .await
-        .expect("first submission is admitted");
-
-    let err = engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
-        .await
-        .unwrap_err();
-    assert_duplicate_order(err);
+    let ct = sample_order_ciphertext();
+    admit_sample_order(&engine, ct.clone()).await;
+    expect_replay_rejected(&engine, ct).await;
     assert_eq!(
         spy.calls.load(Ordering::SeqCst),
         1,
@@ -622,22 +595,15 @@ async fn replayed_ciphertext_rejected_after_recovery() {
         .register_pair_with_event("BTC-USD", crate::state::PairConfig::default())
         .expect("register pair");
 
-    let ct = replay_ciphertext();
-    engine
-        .place_encrypted_order(vec![0u8; 32], vec![], ct.clone(), None)
-        .await
-        .expect("first submission is admitted");
+    let ct = sample_order_ciphertext();
+    admit_sample_order(&engine, ct.clone()).await;
 
     // A fresh engine replays the same event log (no snapshot store → full replay).
     let recovered = Engine::new(store.clone(), Duration::from_millis(50));
     recovered.set_snapshot_cipher(Some(test_snapshot_cipher()));
     recovered.recover().await.expect("recover from log");
 
-    let err = recovered
-        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
-        .await
-        .unwrap_err();
-    assert_duplicate_order(err);
+    expect_replay_rejected(&recovered, ct).await;
 }
 
 /// Regression: admin registers via `Pair::parse` (canonical upper-case),
@@ -652,16 +618,7 @@ async fn place_encrypted_order_canonicalises_lowercase_pair() {
         .register_pair_with_event("ETH/USDC", crate::state::PairConfig::default())
         .unwrap();
 
-    let d = DecryptedOrder {
-        trader: Address::ZERO,
-        pair: "eth/usdc".into(),
-        side: Side::Buy,
-        price: dec(100),
-        size: dec(1),
-        commitment_key: "k".into(),
-        ttl: 60_000_000_000,
-    };
-    let ct = serde_json::to_vec(&d).unwrap();
+    let ct = sample_order_ciphertext_for("eth/usdc");
     let order = engine
         .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -533,12 +533,12 @@ async fn place_encrypted_order_accepts_matching_caller() {
     assert_eq!(order.trader, Address::ZERO);
 }
 
-/// #233: a byte-identical ciphertext resubmitted is a replay (real ECIES is
-/// randomized), so the second submission is rejected with `DuplicateOrder`.
-#[tokio::test]
-async fn place_encrypted_order_rejects_replayed_ciphertext() {
-    let (engine, _) = make_engine();
-    let d = DecryptedOrder {
+/// The canonical encrypted order the #233 replay tests submit then resubmit.
+/// Real ECIES is randomized; these tests reuse identical bytes on purpose so a
+/// resubmission is a replay. `NoopDecrypter`/`CountingDecrypter` parse the JSON
+/// straight from the ciphertext, so the plaintext order round-trips.
+fn replay_ciphertext() -> Vec<u8> {
+    serde_json::to_vec(&DecryptedOrder {
         trader: Address::ZERO,
         pair: "BTC-USD".into(),
         side: Side::Buy,
@@ -546,8 +546,27 @@ async fn place_encrypted_order_rejects_replayed_ciphertext() {
         size: dec(1),
         commitment_key: "k".into(),
         ttl: 60_000_000_000,
-    };
-    let ct = serde_json::to_vec(&d).unwrap();
+    })
+    .unwrap()
+}
+
+/// Assert an engine error is the #233 replay rejection.
+fn assert_duplicate_order(err: crate::EngineError) {
+    assert!(
+        matches!(
+            err,
+            crate::EngineError::Validation(dp_types::DarkPoolError::DuplicateOrder)
+        ),
+        "replay must be rejected as DuplicateOrder, got: {err}"
+    );
+}
+
+/// #233: a byte-identical ciphertext resubmitted is a replay (real ECIES is
+/// randomized), so the second submission is rejected with `DuplicateOrder`.
+#[tokio::test]
+async fn place_encrypted_order_rejects_replayed_ciphertext() {
+    let (engine, _) = make_engine();
+    let ct = replay_ciphertext();
 
     engine
         .place_encrypted_order(vec![0u8; 32], vec![], ct.clone(), None)
@@ -558,13 +577,7 @@ async fn place_encrypted_order_rejects_replayed_ciphertext() {
         .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
         .unwrap_err();
-    assert!(
-        matches!(
-            err,
-            crate::EngineError::Validation(dp_types::DarkPoolError::DuplicateOrder)
-        ),
-        "replay must be rejected as DuplicateOrder, got: {err}"
-    );
+    assert_duplicate_order(err);
 }
 
 /// #233: a replay is shed by the cheap pre-decrypt early-out, not just the
@@ -579,17 +592,7 @@ async fn replayed_ciphertext_rejected_before_decrypt() {
     let spy = Arc::new(crate::test_helpers::CountingDecrypter::default());
     engine.set_decrypter(spy.clone());
 
-    let d = DecryptedOrder {
-        trader: Address::ZERO,
-        pair: "BTC-USD".into(),
-        side: Side::Buy,
-        price: dec(100),
-        size: dec(1),
-        commitment_key: "k".into(),
-        ttl: 60_000_000_000,
-    };
-    let ct = serde_json::to_vec(&d).unwrap();
-
+    let ct = replay_ciphertext();
     engine
         .place_encrypted_order(vec![0u8; 32], vec![], ct.clone(), None)
         .await
@@ -599,13 +602,7 @@ async fn replayed_ciphertext_rejected_before_decrypt() {
         .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
         .unwrap_err();
-    assert!(
-        matches!(
-            err,
-            crate::EngineError::Validation(dp_types::DarkPoolError::DuplicateOrder)
-        ),
-        "replay must be rejected as DuplicateOrder, got: {err}"
-    );
+    assert_duplicate_order(err);
     assert_eq!(
         spy.calls.load(Ordering::SeqCst),
         1,
@@ -625,16 +622,7 @@ async fn replayed_ciphertext_rejected_after_recovery() {
         .register_pair_with_event("BTC-USD", crate::state::PairConfig::default())
         .expect("register pair");
 
-    let d = DecryptedOrder {
-        trader: Address::ZERO,
-        pair: "BTC-USD".into(),
-        side: Side::Buy,
-        price: dec(100),
-        size: dec(1),
-        commitment_key: "k".into(),
-        ttl: 60_000_000_000,
-    };
-    let ct = serde_json::to_vec(&d).unwrap();
+    let ct = replay_ciphertext();
     engine
         .place_encrypted_order(vec![0u8; 32], vec![], ct.clone(), None)
         .await
@@ -649,13 +637,7 @@ async fn replayed_ciphertext_rejected_after_recovery() {
         .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
         .await
         .unwrap_err();
-    assert!(
-        matches!(
-            err,
-            crate::EngineError::Validation(dp_types::DarkPoolError::DuplicateOrder)
-        ),
-        "recovered engine must reject the replay, got: {err}"
-    );
+    assert_duplicate_order(err);
 }
 
 /// Regression: admin registers via `Pair::parse` (canonical upper-case),

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -533,6 +533,85 @@ async fn place_encrypted_order_accepts_matching_caller() {
     assert_eq!(order.trader, Address::ZERO);
 }
 
+/// #233: a byte-identical ciphertext resubmitted is a replay (real ECIES is
+/// randomized), so the second submission is rejected with `DuplicateOrder`.
+#[tokio::test]
+async fn place_encrypted_order_rejects_replayed_ciphertext() {
+    let (engine, _) = make_engine();
+    let d = DecryptedOrder {
+        trader: Address::ZERO,
+        pair: "BTC-USD".into(),
+        side: Side::Buy,
+        price: dec(100),
+        size: dec(1),
+        commitment_key: "k".into(),
+        ttl: 60_000_000_000,
+    };
+    let ct = serde_json::to_vec(&d).unwrap();
+
+    engine
+        .place_encrypted_order(vec![0u8; 32], vec![], ct.clone(), None)
+        .await
+        .expect("first submission is admitted");
+
+    let err = engine
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::EngineError::Validation(dp_types::DarkPoolError::DuplicateOrder)
+        ),
+        "replay must be rejected as DuplicateOrder, got: {err}"
+    );
+}
+
+/// #233: the replay spent-set is a projection — a fresh engine that recovers
+/// from the event log rebuilds it, so the same ciphertext is rejected after a
+/// restart even though the in-memory order secrets are gone.
+#[tokio::test]
+async fn replayed_ciphertext_rejected_after_recovery() {
+    let store = Arc::new(MemStore::new());
+    let engine = Engine::new(store.clone(), Duration::from_millis(50));
+    engine.set_snapshot_cipher(Some(test_snapshot_cipher()));
+    engine
+        .register_pair_with_event("BTC-USD", crate::state::PairConfig::default())
+        .expect("register pair");
+
+    let d = DecryptedOrder {
+        trader: Address::ZERO,
+        pair: "BTC-USD".into(),
+        side: Side::Buy,
+        price: dec(100),
+        size: dec(1),
+        commitment_key: "k".into(),
+        ttl: 60_000_000_000,
+    };
+    let ct = serde_json::to_vec(&d).unwrap();
+    engine
+        .place_encrypted_order(vec![0u8; 32], vec![], ct.clone(), None)
+        .await
+        .expect("first submission is admitted");
+
+    // A fresh engine replays the same event log (no snapshot store → full replay).
+    let recovered = Engine::new(store.clone(), Duration::from_millis(50));
+    recovered.set_snapshot_cipher(Some(test_snapshot_cipher()));
+    recovered.recover().await.expect("recover from log");
+
+    let err = recovered
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::EngineError::Validation(dp_types::DarkPoolError::DuplicateOrder)
+        ),
+        "recovered engine must reject the replay, got: {err}"
+    );
+}
+
 /// Regression: admin registers via `Pair::parse` (canonical upper-case),
 /// but traders may send any casing. The trader path must canonicalise
 /// before the registry lookup — otherwise `eth/usdc` 404s against an

--- a/crates/dp-engine/src/tests.rs
+++ b/crates/dp-engine/src/tests.rs
@@ -567,6 +567,52 @@ async fn place_encrypted_order_rejects_replayed_ciphertext() {
     );
 }
 
+/// #233: a replay is shed by the cheap pre-decrypt early-out, not just the
+/// under-lock check — so a captured ciphertext can't burn ECIES decrypt +
+/// commitment derivation on every resubmission. The spy decrypter must see
+/// exactly one call across two identical submissions.
+#[tokio::test]
+async fn replayed_ciphertext_rejected_before_decrypt() {
+    use std::sync::atomic::Ordering;
+
+    let (engine, _) = make_engine();
+    let spy = Arc::new(crate::test_helpers::CountingDecrypter::default());
+    engine.set_decrypter(spy.clone());
+
+    let d = DecryptedOrder {
+        trader: Address::ZERO,
+        pair: "BTC-USD".into(),
+        side: Side::Buy,
+        price: dec(100),
+        size: dec(1),
+        commitment_key: "k".into(),
+        ttl: 60_000_000_000,
+    };
+    let ct = serde_json::to_vec(&d).unwrap();
+
+    engine
+        .place_encrypted_order(vec![0u8; 32], vec![], ct.clone(), None)
+        .await
+        .expect("first submission is admitted");
+
+    let err = engine
+        .place_encrypted_order(vec![0u8; 32], vec![], ct, None)
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            crate::EngineError::Validation(dp_types::DarkPoolError::DuplicateOrder)
+        ),
+        "replay must be rejected as DuplicateOrder, got: {err}"
+    );
+    assert_eq!(
+        spy.calls.load(Ordering::SeqCst),
+        1,
+        "replay must short-circuit before decrypt — decrypt ran more than once"
+    );
+}
+
 /// #233: the replay spent-set is a projection — a fresh engine that recovers
 /// from the event log rebuilds it, so the same ciphertext is rejected after a
 /// restart even though the in-memory order secrets are gone.

--- a/crates/dp-types/src/error.rs
+++ b/crates/dp-types/src/error.rs
@@ -35,6 +35,11 @@ pub enum DarkPoolError {
     CannotSuspendDelistedPair(String),
     #[error("trader address mismatch: expected {expected}, found {found}")]
     TraderAddressMismatch { expected: String, found: String },
+    /// The same encrypted order payload was submitted more than once. ECIES is
+    /// randomized, so a byte-identical ciphertext is a replay of a captured
+    /// submission, not a fresh order (#233).
+    #[error("duplicate order: this encrypted payload was already submitted")]
+    DuplicateOrder,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
`place_encrypted_order` minted a fresh order id per call and never checked whether it had already seen the ciphertext, so a captured encrypted payload could be resubmitted into every auction until its TTL expired — and because the trader-binding check is skipped when the caller is unauthenticated (API-key auth yields no caller), any holder of the shared key could replay another trader's captured ciphertext.

The engine now keys a spent-set on the SHA-256 of each admitted ciphertext. ECIES is randomized, so a byte-identical ciphertext is a replay of a captured submission rather than a fresh order; the second submission is rejected with the new `DarkPoolError::DuplicateOrder`, which the API surfaces as gRPC `AlreadyExists`. The set is a projection — it lives in `EngineState`, is captured in the snapshot, cleared on projection reset, and rebuilt from the `OrderPlaced` event stream on recovery — so a restarted engine rejects the same replays a live one would. The dedup check and the insert run under the same lock that appends the event and inserts into the book, so two concurrent identical submissions cannot both pass.

The spent-set grows monotonically: replay protection is permanent. Expiry-based pruning depends on the per-order freshness token (nonce + expiry inside the authenticated plaintext) that #233 also calls for, and binding the decrypted trader to an authenticated identity needs per-user auth the server does not have yet. Both are left as follow-ups, so this addresses the ciphertext-dedup part of #233 without fully closing it.

It also serves as the engine-side Layer-A spent-set in the #217 replay-binding plan.

Tests: new live-dedup and recover-rebuild cases, plus the full dp-engine suite (including the snapshot/replay equivalence proptests) and the dp-api error-mapping test; rustfmt and clippy clean.

Part of #233.